### PR TITLE
FIX: Require T2w for brain extraction

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -39,6 +39,11 @@ NiBabies: Preprocessing workflows for infants v{config.environment.version}"""
         "--segmentation-atlases-dir",
         help="Directory containing precalculated segmentations to use for JointLabelFusion."
     )
+    g_baby.add_argument(
+        "--ants-affine-init",
+        choices=("random", "search"),
+        help="TESTING: Customize parameters for ants AI initialization."
+    )
     return parser
 
 

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -491,6 +491,8 @@ class workflow(_Config):
     """Execute the anatomical preprocessing only."""
     anat_modality = "t1w"
     """Structural MRI modality"""
+    ants_affine_init = None
+    """Customize ants affine initialization"""
     aroma_err_on_warn = None
     """Cast AROMA warnings to errors."""
     aroma_melodic_dim = None

--- a/nibabies/data/within_subject.json
+++ b/nibabies/data/within_subject.json
@@ -1,0 +1,23 @@
+{
+    "collapse_output_transforms": true,
+    "convergence_threshold": [ 1e-07, 1e-08 ],
+    "convergence_window_size": [ 200, 100 ],
+    "dimension": 3,
+    "float": true,
+    "interpolation": "LanczosWindowedSinc",
+    "metric": [ "Mattes", "Mattes" ],
+    "metric_weight": [ 1.0, 1.0 ],
+    "number_of_iterations": [ [ 500 ], [ 200 ] ],
+    "radius_or_number_of_bins": [ 64, 64 ],
+    "sampling_percentage": [ 0.5, 0.5 ],
+    "sampling_strategy": [ "Random", "Random" ],
+    "shrink_factors": [ [ 2 ], [ 1 ] ],
+    "sigma_units": [ "mm", "mm" ],
+    "smoothing_sigmas": [ [ 8.0 ], [ 2.0 ] ],
+    "transform_parameters": [ [ 0.05 ], [ 0.01 ] ],
+    "transforms": [ "Translation", "Rigid" ],
+    "use_estimate_learning_rate_once": [ true, true ],
+    "use_histogram_matching": [ true, true ],
+    "winsorize_lower_quantile": 0.005,
+    "winsorize_upper_quantile": 0.998
+}

--- a/nibabies/utils/misc.py
+++ b/nibabies/utils/misc.py
@@ -38,3 +38,20 @@ def check_deps(workflow):
         for node in workflow._get_all_nodes()
         if (hasattr(node.interface, '_cmd')
             and which(node.interface._cmd.split()[0]) is None))
+
+
+
+def cohort_by_months(template, months):
+    cohort_key = {
+        'MNIInfant': (2, 5, 8, 11, 14, 17, 21, 27, 33, 44, 60),
+        'UNCInfant': (8, 12, 24),
+    }
+    ages = cohort_key.get(template)
+    if ages is None:
+        raise KeyError("Template cohort information does not exist.")
+
+    for cohort, age in enumerate(ages, 1):
+        if months <= age:
+            return cohort
+
+    raise KeyError("Age exceeds all cohorts!")

--- a/nibabies/utils/misc.py
+++ b/nibabies/utils/misc.py
@@ -23,8 +23,8 @@ def fix_multi_source_name(in_files):
     p = Path(filename_to_list(in_files)[0])
     # subject_label = p.name.split("_", 1)[0].split("-")[1]
     try:
-        subj = re.search('(?<=^sub-)[a-zA-Z0-9]*', p.name).group()
-        suffix = re.search('(?<=_)\w+(?=\.)', p.name).group()
+        subj = re.search(r'(?<=^sub-)[a-zA-Z0-9]*', p.name).group()
+        suffix = re.search(r'(?<=_)\w+(?=\.)', p.name).group()
     except AttributeError:
         raise AttributeError("Could not extract BIDS information")
     return str(p.parent / f"sub-{subj}_{suffix}.nii.gz")
@@ -38,7 +38,6 @@ def check_deps(workflow):
         for node in workflow._get_all_nodes()
         if (hasattr(node.interface, '_cmd')
             and which(node.interface._cmd.split()[0]) is None))
-
 
 
 def cohort_by_months(template, months):

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -7,11 +7,13 @@ from nipype.interfaces import utility as niu, fsl
 def init_infant_anat_wf(
     *,
     age_months,
-    anatomicals,
+    t1w,
+    t2w,
     anat_modality,
     bids_root,
     existing_derivatives,
     freesurfer,
+    longitudinal,
     omp_nthreads,
     output_dir,
     segmentation_atlases,
@@ -86,13 +88,15 @@ def init_infant_anat_wf(
     from .surfaces import init_infant_surface_recon_wf
 
     # for now, T1w only
-    num_anats = len(anatomicals)
+    num_t1w = len(t1w) if t1w else 0
+    num_t2w = len(t2w) if t2w else 0
+
     wf = pe.Workflow(name=name)
     desc = """Anatomical data preprocessing
 
 : """
     desc += f"""\
-A total of {num_anats} anatomical images were found within the input
+A total of {num_t1w} T1w and {num_t2w} T2w images were found within the input
 BIDS dataset."""
 
     inputnode = pe.Node(
@@ -138,14 +142,14 @@ BIDS dataset."""
         raise NotImplementedError("Reusing derivatives is not yet supported.")
 
     desc += """
-All of them were corrected for intensity non-uniformity (INU)
-""" if num_anats > 1 else """\
+All of the T1-weighted images were corrected for intensity non-uniformity (INU)
+""" if num_t1w > 1 else """\
 The T1-weighted (T1w) image was corrected for intensity non-uniformity (INU)
 """
     desc += """\
 with `N4BiasFieldCorrection` [@n4], distributed with ANTs {ants_ver} \
 [@ants, RRID:SCR_004757]"""
-    desc += '.\n' if num_anats > 1 else ", and used as T1w-reference throughout the workflow.\n"
+    desc += '.\n' if num_t1w > 1 else ", and used as T1w-reference throughout the workflow.\n"
 
     desc += """\
 The T1w-reference was then skull-stripped with a modified implementation of
@@ -168,7 +172,7 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
     anat_derivatives_wf = init_anat_derivatives_wf(
         bids_root=bids_root,
         freesurfer=freesurfer,
-        num_t1w=num_anats,
+        num_t1w=num_t1w,
         output_dir=output_dir,
         spaces=spaces,
     )
@@ -176,12 +180,22 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
     anat_derivatives_wf.get_node('select_tpl').inputs.resolution = Undefined
 
     # Multiple T1w files -> generate average reference
-    # TODO: Add path for T2w
-    anat_template_wf = init_anat_template_wf(
+    t1w_template_wf = init_anat_template_wf(
         longitudinal=False,
         omp_nthreads=omp_nthreads,
-        num_t1w=num_anats,
+        num_t1w=num_t1w,
     )
+
+    use_t2w = False
+    if num_t2w:
+        t2w_template_wf = init_t2w_template_wf(
+            longitudinal=longitudinal,
+            omp_nthreads=omp_nthreads,
+            num_t2w=num_t2w,
+        )
+        # TODO: determine cutoff (< 8 months)
+        use_t2w = True
+
 
     anat_validate = pe.Node(
         ValidateImage(),
@@ -202,6 +216,7 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
         omp_nthreads=omp_nthreads,
         output_dir=Path(output_dir),
         sloppy=sloppy,
+        use_t2w=use_t2w,
     )
     # Ensure single outputs
     be_buffer = pe.Node(
@@ -369,3 +384,40 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
     ])
     # fmt: on
     return wf
+
+
+def init_t2w_template_wf(longitudinal, omp_nthreads, num_t2w, name="anat_t2w_template_wf"):
+    wf = Workflow(name=name)
+
+    inputnode = pe.Node(niu.IdentityInterface(fields=["t2w"]), name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=["t2w_ref", "t2w_valid_list", "t2_realign_xfm", "out_report"]),
+        name="outputnode",
+    )
+
+    # 0. Reorient T1w image(s) to RAS and resample to common voxel space
+    t2w_ref_dimensions = pe.Node(TemplateDimensions(), name='t2w_ref_dimensions')
+    t2w_conform = pe.MapNode(Conform(), iterfield='in_file', name='t2w_conform')
+
+    wf.connect([
+        (inputnode, t2_ref_dimensions, [('t2w', 't1w_list')]),
+        (t2w_ref_dimensions, t2w_conform, [
+            ('t1w_valid_list', 'in_file'),
+            ('target_zooms', 'target_zooms'),
+            ('target_shape', 'target_shape')]),
+        (t2w_ref_dimensions, outputnode, [('out_report', 'out_report'),
+                                          ('t1w_valid_list', 't2w_valid_list')]),
+    ])
+
+    # for now always take the first image
+    # TODO: Average when multiple T2w images
+    get1st = pe.Node(niu.Select(index=[0]), name='get1st')
+    outputnode.inputs.t2w_realign_xfm = [pkgr('smriprep', 'data/itkIdentityTransform.txt')]
+
+    workflow.connect([
+        (t2w_conform, get1st, [('out_file', 'inlist')]),
+        (get1st, outputnode, [('out', 't2w_ref')]),
+    ])
+
+        return workflow

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -7,6 +7,7 @@ from nipype.interfaces import utility as niu, fsl
 def init_infant_anat_wf(
     *,
     age_months,
+    ants_affine_init,
     t1w,
     t2w,
     anat_modality,
@@ -210,7 +211,7 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
     brain_extraction_wf = init_infant_brain_extraction_wf(
         age_months=age_months,
         mri_scheme=anat_modality.capitalize(),
-        ants_affine_init=True,
+        ants_affine_init=ants_affine_init,
         skull_strip_template=skull_strip_template.space,
         template_specs=skull_strip_template.spec,
         omp_nthreads=omp_nthreads,

--- a/nibabies/workflows/anatomical/brain_extraction.py
+++ b/nibabies/workflows/anatomical/brain_extraction.py
@@ -1,7 +1,7 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Nipype translation of ANTs' workflows."""
-import numpy as np
+# import numpy as np
 # general purpose
 from pkg_resources import resource_filename as pkgr_fn
 
@@ -9,7 +9,7 @@ from pkg_resources import resource_filename as pkgr_fn
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from nipype.interfaces.ants import N4BiasFieldCorrection, ImageMath
-from nipype.interfaces.ants.utils import AI
+# from nipype.interfaces.ants.utils import AI
 
 # niworkflows
 from niworkflows.anat.ants import init_atropos_wf, ATROPOS_MODELS
@@ -54,6 +54,18 @@ def init_infant_brain_extraction_wf(
     """
     Build an atlas-based brain extraction pipeline for infant T1w/T2w MRI data.
 
+    Pros/Cons of available templates
+    --------------------------------
+    * MNIInfant
+     + More cohorts available for finer-grain control
+     + T1w/T2w images available
+     - Template masks are poor
+
+    * UNCInfant
+     + Accurate masks
+     - No T2w image available
+
+
     Parameters
     ----------
     ants_affine_init : :obj:`bool`, optional
@@ -74,40 +86,32 @@ def init_infant_brain_extraction_wf(
         niu.IdentityInterface(fields=["t1w", "t2w", "in_mask"]), name="inputnode"
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["out_corrected", "out_brain", "out_mask"]),
+        niu.IdentityInterface(fields=["t1w_corrected", "t1w_corrected_brain", "t1w_mask"]),
         name="outputnode"
     )
 
-    if use_t2w and mri_scheme == 'T1w':
-        tpl_target_path = get(
-            skull_strip_template,
-            suffix='T2w',
-            desc=None,
-            **template_specs,
-        )
-    else:
-        # Find a suitable target template in TemplateFlow
-        tpl_target_path = get_template(
-            skull_strip_template,
-            suffix=mri_scheme,
-            desc=None,
-            **template_specs
+    if not use_t2w:
+        raise RuntimeError("A T2w image is currently required.")
+
+    tpl_target_path = get_template(
+        skull_strip_template,
+        suffix='T1w',  # no T2w template
+        desc=None,
+        **template_specs,
     )
     if not tpl_target_path:
         raise RuntimeError(
-            f"An instance of template <tpl-{skull_strip_template}> with MR scheme '{mri_scheme}'"
-            " could not be found."
+            f"An instance of template <tpl-{skull_strip_template}> with MR scheme "
+            f"'{'T1w' or mri_scheme}' could not be found."
         )
 
-    # tpl_brainmask_path = get_template(
-    #     in_template, desc="brain", suffix="probseg", **template_specs
-    # )
-    # if not tpl_brainmask_path:
-
-    # ignore probseg for the time being
     tpl_brainmask_path = get_template(
-        skull_strip_template, desc="brain", suffix="mask", **template_specs
+        skull_strip_template, desc="brain", suffix="probseg", **template_specs
     )
+    if not tpl_brainmask_path:
+        tpl_brainmask_path = get_template(
+            skull_strip_template, desc="brain", suffix="mask", **template_specs
+        )
 
     tpl_regmask_path = get_template(
         skull_strip_template, desc="BrainCerebellumExtraction", suffix="mask", **template_specs
@@ -116,21 +120,27 @@ def init_infant_brain_extraction_wf(
     # validate images
     val_tmpl = pe.Node(ValidateImage(), name='val_tmpl')
     val_tmpl.inputs.in_file = _pop(tpl_target_path)
-
-    # val_target = pe.Node(ValidateImage(), name='val_target')
+    # val_t1w = val_tmpl.clone("val_t1w")
+    # val_t2w = val_tmpl.clone("val_t2w")
 
     # Resample both target and template to a controlled, isotropic resolution
-    res_tmpl = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_tmpl")  # testing
-    res_target = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_target")  # testing
+    res_tmpl = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_tmpl")
+    res_t1w = res_tmpl.clone("res_t1w")
+    res_t2w = res_tmpl.clone("res_t2w")
+
     gauss_tmpl = pe.Node(niu.Function(function=_gauss_filter), name="gauss_tmpl")
+    gauss_t1w = gauss_tmpl.clone("gauss_t1w")
+    gauss_t2w = gauss_tmpl.clone("gauss_t2w")
 
     # Spatial normalization step
     lap_tmpl = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1"), name="lap_tmpl")
-    lap_target = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1"), name="lap_target")
+    lap_t1w = lap_tmpl.clone("lap_t1w")
+    lap_t2w = lap_tmpl.clone("lap_t2w")
 
     # Merge image nodes
-    mrg_target = pe.Node(niu.Merge(2), name="mrg_target")
     mrg_tmpl = pe.Node(niu.Merge(2), name="mrg_tmpl")
+    mrg_t2w = mrg_tmpl.clone("mrg_t2w")
+    mrg_t1w = mrg_tmpl.clone("mrg_t1w")
 
     norm_lap_tmpl = pe.Node(niu.Function(function=_trunc), name="norm_lap_tmpl")
     norm_lap_tmpl.inputs.dtype = "float32"
@@ -138,11 +148,8 @@ def init_infant_brain_extraction_wf(
     norm_lap_tmpl.inputs.percentile = (0.01, 99.99)
     norm_lap_tmpl.inputs.clip_max = None
 
-    norm_lap_target = pe.Node(niu.Function(function=_trunc), name="norm_lap_target")
-    norm_lap_target.inputs.dtype = "float32"
-    norm_lap_target.inputs.out_max = 1.0
-    norm_lap_target.inputs.percentile = (0.01, 99.99)
-    norm_lap_target.inputs.clip_max = None
+    norm_lap_t1w = norm_lap_tmpl.clone('norm_lap_t1w')
+    norm_lap_t2w = norm_lap_t1w.clone('norm_lap_t2w')
 
     # Set up initial spatial normalization
     ants_params = "testing" if sloppy else "precise"
@@ -157,6 +164,15 @@ def init_infant_brain_extraction_wf(
     )
     norm.inputs.float = use_float
 
+    # Set up T2w -> T1w within-subject registration
+    norm_subj = pe.Node(
+        Registration(from_file=pkgr_fn("nibabies.data", "within_subject.json")),
+        name="norm_subj",
+        n_procs=omp_nthreads,
+        mem_gb=mem_gb,
+    )
+    norm_subj.inputs.float = use_float
+
     # main workflow
     wf = pe.Workflow(name)
     # Create a buffer interface as a cache for the actual inputs to registration
@@ -164,17 +180,14 @@ def init_infant_brain_extraction_wf(
         fields=["hires_target", "smooth_target"]), name="buffernode")
 
     # truncate target intensity for N4 correction
-    clip_target = pe.Node(
-        niu.Function(function=_trunc),
-        name="clip_target",
-    )
     clip_tmpl = pe.Node(
         niu.Function(function=_trunc),
         name="clip_tmpl",
     )
-    #clip_tmpl.inputs.in_file = _pop(tpl_target_path)
+    clip_t2w = clip_tmpl.clone('clip_t2w')
+    clip_t1w = clip_tmpl.clone('clip_t1w')
 
-    # INU correction of the target image
+    # INU correction of the t1w
     init_n4 = pe.Node(
         N4BiasFieldCorrection(
             dimension=3,
@@ -192,23 +205,6 @@ def init_infant_brain_extraction_wf(
         niu.Function(function=_trunc),
         name="clip_inu",
     )
-    gauss_target = pe.Node(niu.Function(function=_gauss_filter), name="gauss_target")
-    wf.connect([
-        # truncation, resampling, and initial N4
-        # (inputnode, val_target, [(("in_files", _pop), "in_file")]),
-        # (inputnode, res_target, [(("in_files", _pop), "in_file")]),
-        (inputnode, res_target, [("in_file", "in_file")]),
-        (res_target, clip_target, [("out_file", "in_file")]),
-        (val_tmpl, clip_tmpl, [("out_file", "in_file")]),
-        (clip_tmpl, res_tmpl, [("out", "in_file")]),
-        (clip_target, init_n4, [("out", "input_image")]),
-        (init_n4, clip_inu, [("output_image", "in_file")]),
-        (clip_inu, gauss_target, [("out", "in_file")]),
-        (clip_inu, buffernode, [("out", "hires_target")]),
-        (gauss_target, buffernode, [("out", "smooth_target")]),
-        (res_tmpl, gauss_tmpl, [("out_file", "in_file")]),
-        # (clip_tmpl, gauss_tmpl, [("out", "in_file")]),
-    ])
 
     # Graft a template registration-mask if present
     if tpl_regmask_path:
@@ -225,15 +221,19 @@ def init_infant_brain_extraction_wf(
             (res_tmpl, hires_mask, [("out_file", "reference_image")]),
         ])
 
-    map_brainmask = pe.Node(
+    map_mask_t2w = pe.Node(
         ApplyTransforms(interpolation="Gaussian", float=True),
-        name="map_brainmask",
+        name="map_mask_t2w",
         mem_gb=1
     )
-    map_brainmask.inputs.input_image = str(tpl_brainmask_path)
+    map_mask_t1w = map_mask_t2w.clone("map_mask_t1w")
 
-    thr_brainmask = pe.Node(Binarize(thresh_low=0.80),
-                            name="thr_brainmask")
+    # map template brainmask to t2w space
+    map_mask_t2w.inputs.input_image = str(tpl_brainmask_path)
+
+    thr_t2w_mask = pe.Node(Binarize(thresh_low=0.80), name="thr_t2w_mask")
+    thr_t1w_mask = thr_t2w_mask.clone('thr_t1w_mask')
+
     bspline_grid = pe.Node(niu.Function(function=_bspline_distance),
                            name="bspline_grid")
 
@@ -268,182 +268,191 @@ def init_infant_brain_extraction_wf(
     sel_wm = pe.Node(niu.Select(index=atropos_model[-1] - 1), name='sel_wm',
                      run_without_submitting=True)
 
-
     wf.connect([
-        (inputnode, map_brainmask, [("in_file", "reference_image")]),
-        (inputnode, final_n4, [("in_file", "input_image")]),
-        (inputnode, bspline_grid, [("in_file", "in_file")]),
-        # (bspline_grid, final_n4, [("out", "bspline_fitting_distance")]),
-        (bspline_grid, final_n4, [("out", "args")]),
-        # merge laplacian and original images
-        (buffernode, lap_target, [("smooth_target", "op1")]),
-        (buffernode, mrg_target, [("hires_target", "in1")]),
-        (lap_target, norm_lap_target, [("output_image", "in_file")]),
-        (norm_lap_target, mrg_target, [("out", "in2")]),
-        # Template massaging
+        # 1. massage template
+        (val_tmpl, clip_tmpl, [("out_file", "in_file")]),
+        (clip_tmpl, res_tmpl, [("out", "in_file")]),
+        (res_tmpl, gauss_tmpl, [("out_file", "in_file")]),
         (res_tmpl, lap_tmpl, [("out_file", "op1")]),
         (res_tmpl, mrg_tmpl, [("out_file", "in1")]),
         (lap_tmpl, norm_lap_tmpl, [("output_image", "in_file")]),
         (norm_lap_tmpl, mrg_tmpl, [("out", "in2")]),
-        # spatial normalization
-        (mrg_target, norm, [("out", "moving_image")]),
+        # 2. massage T2w
+        (inputnode, val_t2w, [('t2w', 'in_file')]),
+        (val_t2w, res_t2w, [('out_file', 'in_file')]),
+        (res_t2w, clip_t2w, [('out_file', 'in_file')]),
+        # no need for init_n4 + clip_inu of T2w
+        (clip_t2w, gauss_t2w, [('out', 'in_file')]),
+        (clip_t2w, buffernode, [('out', 'hires_target')]),
+        (gauss_t2w, buffernode, [('out', 'smooth_target')]),
+        (buffernode, lap_t2w, [("smooth_target", "op1")]),
+        (lap_t2w, norm_lap_t2w, [("output_image", "in_file")]),
+        (norm_lap_t2w, mrg_t2w, [("out", "in2")]),
+        # 3. normalize T2w to target template (UNC)
+        (mrg_t2w, norm, [("out", "moving_image")]),
         (mrg_tmpl, norm, [("out", "fixed_image")]),
-        (norm, map_brainmask, [
+        # 4. map template brainmask to T2w space
+        (inputnode, map_mask_t2w, [('t2w', 'reference_image')]),
+        (norm, map_mask_t2w, [
             ("reverse_transforms", "transforms"),
-            ("reverse_invert_flags", "invert_transform_flags")]),
-        (map_brainmask, thr_brainmask, [("output_image", "in_file")]),
-        # take a second pass of N4
-        (map_brainmask, final_n4, [("output_image", "weight_image")]),
+            ("reverse_invert_flags", "invert_transform_flags")
+        ]),
+        (map_mask_t2w, thr_t2w_mask, [("output_image", "in_file")]),
+        # 5. massage T1w
+        (inputnode, res_t1w, [('t1w', 'in_file')]),
+        (res_t1w, clip_t1w, [('out_file', 'in_file')]),
+        (clip_t1w, init_n4, [("out", "input_image")]),
+        (init_n4, clip_inu, [("output_image", "in_file")]),
+        (clip_inu, gauss_t1w, [("out", "in_file")]),
+        (clip_inu, mrg_t1w, [("out", "in1")]),
+        (gauss_t1w, lap_t1w, [("out", "op1")]),
+        (lap_t1w, norm_lap_t1w, [("output_image", "in_file")]),
+        (norm_lap_t1w, mrg_t1w, [("out", "in2")]),
+        # 6. normalize within subject T2w to T1w
+        (mrg_t2w, norm_subj, [("out", "moving_image")]),
+        (mrg_t1w, norm_subj, [("out", "fixed_image")]),
+        # 7. map mask to T1w space
+        (thr_t2w_mask, map_mask_t1w, [("out_mask", "input_image")]),
+        (inputnode, map_mask_t1w, [("t1w", "reference_image")]),
+        (norm_subj, map_mask_t1w, [
+            ("reverse_transforms", "transforms"),
+            ("reverse_invert_flags", "invert_transform_flags"),
+        ]),
+        (map_mask_t1w, thr_t1w_mask, [("output_image", "in_file")]),
+        # 8. T1w INU
+        (inputnode, final_n4, [("t1w", "input_image")]),
+        (inputnode, bspline_grid, [("t1w", "in_file")]),
+        (bspline_grid, final_n4, [("out", "args")]),
+        (map_mask_t1w, final_n4, [("output_image", "weight_image")]),
         (final_n4, final_mask, [("output_image", "in_file")]),
-        (thr_brainmask, final_mask, [("out_mask", "in_mask")]),
-        (final_n4, outputnode, [("output_image", "out_corrected")]),
-        (thr_brainmask, outputnode, [("out_mask", "out_mask")]),
-        (final_mask, outputnode, [("out_file", "out_brain")]),
+        (thr_t1w_mask, final_mask, [("out_mask", "in_mask")]),
+        # 9. Outputs
+        (final_n4, outputnode, [("output_image", "t1w_corrected")]),
+        (thr_t1w_mask, outputnode, [("out_mask", "t1w_mask")]),
+        (final_mask, outputnode, [("out_file", "t1w_corrected_brain")]),
     ])
-
-    # wf.disconnect([
-    #     (get_brainmask, apply_mask, [('output_image', 'mask_file')]),
-    #     (copy_xform, outputnode, [('out_mask', 'out_mask')]),
-    # ])
-
-    # wf.connect([
-    #     (init_n4, atropos_wf, [
-    #         ('output_image', 'inputnode.in_files')]),  # intensity image
-    #     (thr_brainmask, atropos_wf, [
-    #         ('out_mask', 'inputnode.in_mask')]),
-    #     (atropos_wf, sel_wm, [('outputnode.out_tpms', 'inlist')]),
-    #     (sel_wm, final_n4, [('out', 'weight_image')]),
-    # ])
-    # wf.connect([
-        # (atropos_wf, outputnode, [
-        #     ('outputnode.out_mask', 'out_mask'),
-        #     ('outputnode.out_segm', 'out_segm'),
-        #     ('outputnode.out_tpms', 'out_tpms')]),
-    # ])
 
     if tpl_regmask_path:
         wf.connect([
             (hires_mask, norm, [
                 ("output_image", "fixed_image_masks")]),
-            # (hires_mask, atropos_wf, [
-            #     ("output_image", "inputnode.in_mask_dilated")]),
         ])
 
-    if interim_checkpoints:
-        final_apply = pe.Node(
-            ApplyTransforms(
-                interpolation="BSpline",
-                float=True),
-            name="final_apply",
-            mem_gb=1
-        )
-        final_report = pe.Node(SimpleBeforeAfter(
-            before_label=f"tpl-{skull_strip_template}",
-            after_label="target",
-            out_report="final_report.svg"),
-            name="final_report"
-        )
-        wf.connect([
-            (inputnode, final_apply, [("in_file", "reference_image")]),
-            (res_tmpl, final_apply, [("out_file", "input_image")]),
-            (norm, final_apply, [
-                ("reverse_transforms", "transforms"),
-                ("reverse_invert_flags", "invert_transform_flags")]),
-            (final_apply, final_report, [("output_image", "before")]),
-            (outputnode, final_report, [("out_corrected", "after"),
-                                        ("out_mask", "wm_seg")]),
-        ])
+    # if interim_checkpoints:
+    #     final_apply = pe.Node(
+    #         ApplyTransforms(
+    #             interpolation="BSpline",
+    #             float=True),
+    #         name="final_apply",
+    #         mem_gb=1
+    #     )
+    #     final_report = pe.Node(SimpleBeforeAfter(
+    #         before_label=f"tpl-{skull_strip_template}",
+    #         after_label="target",
+    #         out_report="final_report.svg"),
+    #         name="final_report"
+    #     )
+    #     wf.connect([
+    #         (inputnode, final_apply, [("in_file", "reference_image")]),
+    #         (res_tmpl, final_apply, [("out_file", "input_image")]),
+    #         (norm, final_apply, [
+    #             ("reverse_transforms", "transforms"),
+    #             ("reverse_invert_flags", "invert_transform_flags")]),
+    #         (final_apply, final_report, [("output_image", "before")]),
+    #         (outputnode, final_report, [("out_corrected", "after"),
+    #                                     ("out_mask", "wm_seg")]),
+    #     ])
 
-    if output_dir:
-        from nipype.interfaces.io import DataSink
-        ds_final_inu = pe.Node(DataSink(base_directory=str(output_dir.parent)),
-                               name="ds_final_inu")
-        ds_final_msk = pe.Node(DataSink(base_directory=str(output_dir.parent)),
-                               name="ds_final_msk")
-        ds_report = pe.Node(DataSink(base_directory=str(output_dir.parent)),
-                            name="ds_report")
+    # if output_dir:
+    #     from nipype.interfaces.io import DataSink
+    #     ds_final_inu = pe.Node(DataSink(base_directory=str(output_dir.parent)),
+    #                            name="ds_final_inu")
+    #     ds_final_msk = pe.Node(DataSink(base_directory=str(output_dir.parent)),
+    #                            name="ds_final_msk")
+    #     ds_report = pe.Node(DataSink(base_directory=str(output_dir.parent)),
+    #                         name="ds_report")
 
-        wf.connect([
-            (outputnode, ds_final_inu, [
-                ("out_corrected", f"{output_dir.name}.@inu_corrected")]),
-            (outputnode, ds_final_msk, [
-                ("out_mask", f"{output_dir.name}.@brainmask")]),
-            (final_report, ds_report, [
-                ("out_report", f"{output_dir.name}.@report")]),
-        ])
+    #     wf.connect([
+    #         (outputnode, ds_final_inu, [
+    #             ("out_corrected", f"{output_dir.name}.@inu_corrected")]),
+    #         (outputnode, ds_final_msk, [
+    #             ("out_mask", f"{output_dir.name}.@brainmask")]),
+    #         (final_report, ds_report, [
+    #             ("out_report", f"{output_dir.name}.@report")]),
+    #     ])
 
-    if not ants_affine_init:
-        return wf
+    # if not ants_affine_init:
+    #     return wf
 
-    # Initialize transforms with antsAI
-    lowres_tmpl = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_tmpl")
-    lowres_target = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_target")
+    # # Initialize transforms with antsAI
+    # lowres_tmpl = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_tmpl")
+    # lowres_target = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_target")
 
-    init_aff = pe.Node(
-        AI(
-            metric=("Mattes", 32, "Regular", 0.25),
-            transform=("Affine", 0.1),
-            search_factor=(15, 0.1),
-            principal_axes=False,
-            convergence=(10, 1e-6, 10),
-            search_grid=(40, (0, 40, 40)),
-            verbose=True,
-        ),
-        name="init_aff",
-        n_procs=omp_nthreads,
-    )
-    wf.connect([
-        (gauss_tmpl, lowres_tmpl, [("out", "in_file")]),
-        (lowres_tmpl, init_aff, [("out_file", "fixed_image")]),
-        (gauss_target, lowres_target, [("out", "in_file")]),
-        (lowres_target, init_aff, [("out_file", "moving_image")]),
-        (init_aff, norm, [("output_transform", "initial_moving_transform")]),
-    ])
+    # init_aff = pe.Node(
+    #     AI(
+    #         metric=("Mattes", 32, "Regular", 0.25),
+    #         transform=("Affine", 0.1),
+    #         search_factor=(15, 0.1),
+    #         principal_axes=False,
+    #         convergence=(10, 1e-6, 10),
+    #         search_grid=(40, (0, 40, 40)),
+    #         verbose=True,
+    #     ),
+    #     name="init_aff",
+    #     n_procs=omp_nthreads,
+    # )
+    # wf.connect([
+    #     (gauss_tmpl, lowres_tmpl, [("out", "in_file")]),
+    #     (lowres_tmpl, init_aff, [("out_file", "fixed_image")]),
+    #     (gauss_target, lowres_target, [("out", "in_file")]),
+    #     (lowres_target, init_aff, [("out_file", "moving_image")]),
+    #     (init_aff, norm, [("output_transform", "initial_moving_transform")]),
+    # ])
 
-    if tpl_regmask_path:
-        lowres_mask = pe.Node(
-            ApplyTransforms(
-                input_image=_pop(tpl_regmask_path),
-                transforms="identity",
-                interpolation="MultiLabel",
-                float=True),
-            name="lowres_mask",
-            mem_gb=1
-        )
-        wf.connect([
-            (lowres_tmpl, lowres_mask, [("out_file", "reference_image")]),
-            (lowres_mask, init_aff, [("output_image", "fixed_image_mask")]),
-        ])
+    # if tpl_regmask_path:
+    #     lowres_mask = pe.Node(
+    #         ApplyTransforms(
+    #             input_image=_pop(tpl_regmask_path),
+    #             transforms="identity",
+    #             interpolation="MultiLabel",
+    #             float=True),
+    #         name="lowres_mask",
+    #         mem_gb=1
+    #     )
+    #     wf.connect([
+    #         (lowres_tmpl, lowres_mask, [("out_file", "reference_image")]),
+    #         (lowres_mask, init_aff, [("output_image", "fixed_image_mask")]),
+    #     ])
 
-    if interim_checkpoints:
-        init_apply = pe.Node(
-            ApplyTransforms(
-                interpolation="BSpline",
-                float=True),
-            name="init_apply",
-            mem_gb=1
-        )
-        init_report = pe.Node(SimpleBeforeAfter(
-            before_label=f"tpl-{skull_strip_template}",
-            after_label="target",
-            out_report="init_report.svg"),
-            name="init_report"
-        )
-        wf.connect([
-            (lowres_target, init_apply, [("out_file", "input_image")]),
-            (res_tmpl, init_apply, [("out_file", "reference_image")]),
-            (init_aff, init_apply, [("output_transform", "transforms")]),
-            (init_apply, init_report, [("output_image", "after")]),
-            (res_tmpl, init_report, [("out_file", "before")]),
-        ])
+    # if interim_checkpoints:
+    #     init_apply = pe.Node(
+    #         ApplyTransforms(
+    #             interpolation="BSpline",
+    #             float=True),
+    #         name="init_apply",
+    #         mem_gb=1
+    #     )
+    #     init_report = pe.Node(SimpleBeforeAfter(
+    #         before_label=f"tpl-{skull_strip_template}",
+    #         after_label="target",
+    #         out_report="init_report.svg"),
+    #         name="init_report"
+    #     )
+    #     wf.connect([
+    #         (lowres_target, init_apply, [("out_file", "input_image")]),
+    #         (res_tmpl, init_apply, [("out_file", "reference_image")]),
+    #         (init_aff, init_apply, [("output_transform", "transforms")]),
+    #         (init_apply, init_report, [("output_image", "after")]),
+    #         (res_tmpl, init_report, [("out_file", "before")]),
+    #     ])
 
-        if output_dir:
-            ds_init_report = pe.Node(DataSink(base_directory=str(output_dir.parent)),
-                    name="ds_init_report")
-            wf.connect(
-                init_report, "out_report",
-                ds_init_report, f"{output_dir.name}.@init_report"
-            )
+    #     if output_dir:
+    #         ds_init_report = pe.Node(DataSink(base_directory=str(output_dir.parent)),
+    #                 name="ds_init_report")
+    #         wf.connect(
+    #             init_report, "out_report",
+    #             ds_init_report, f"{output_dir.name}.@init_report"
+    #         )
     return wf
 
 

--- a/nibabies/workflows/anatomical/brain_extraction.py
+++ b/nibabies/workflows/anatomical/brain_extraction.py
@@ -24,7 +24,6 @@ from niworkflows.interfaces.registration import (
 )
 
 from templateflow.api import get as get_template
-from ... import config
 from ...utils.filtering import (
     gaussian_filter as _gauss_filter,
     truncation as _trunc
@@ -62,9 +61,8 @@ def init_infant_brain_extraction_wf(
     # handle template specifics
     if template_specs is None:
         template_specs = {}
-
     if skull_strip_template == 'MNIInfant':
-        template_specs['resolution'] = 2 if config.execution.sloppy else 1
+        template_specs['resolution'] = 2 if sloppy else 1
 
     if not template_specs.get('cohort') and age_months is not None:
         if age_months <= 2:

--- a/nibabies/workflows/anatomical/brain_extraction.py
+++ b/nibabies/workflows/anatomical/brain_extraction.py
@@ -120,8 +120,8 @@ def init_infant_brain_extraction_wf(
     # validate images
     val_tmpl = pe.Node(ValidateImage(), name='val_tmpl')
     val_tmpl.inputs.in_file = _pop(tpl_target_path)
-    # val_t1w = val_tmpl.clone("val_t1w")
-    # val_t2w = val_tmpl.clone("val_t2w")
+    val_t1w = val_tmpl.clone("val_t1w")
+    val_t2w = val_tmpl.clone("val_t2w")
 
     # Resample both target and template to a controlled, isotropic resolution
     res_tmpl = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_tmpl")

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -286,10 +286,12 @@ It is released under the [CC0]\
     anat_preproc_wf = init_infant_anat_wf(
         age_months=config.workflow.age_months,
         anat_modality=anat_modality,
-        anatomicals=subject_data[anat_modality],
+        t1w=subject_data['t1w'],
+        t2w=subject_data['t2w'],
         bids_root=config.execution.bids_dir,
         existing_derivatives=anat_derivatives,
         freesurfer=config.workflow.run_reconall,
+        longitudinal=config.workflow.longitudinal,
         omp_nthreads=config.nipype.omp_nthreads,
         output_dir=fmriprep_dir,
         segmentation_atlases=config.execution.segmentation_atlases_dir,

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -284,6 +284,7 @@ It is released under the [CC0]\
 
     # Preprocessing of anatomical (includes registration to UNCInfant)
     anat_preproc_wf = init_infant_anat_wf(
+        ants_affine_init=config.workflow.ants_affine_init or True,
         age_months=config.workflow.age_months,
         anat_modality=anat_modality,
         t1w=subject_data['t1w'],


### PR DESCRIPTION
Slightly more complicated than #18 due to the fact that the UNCInfant0-1-2 templates are not packaged with a T2w template.

This implementation uses a cross-modal registration between the participant's `T2w` image and the template (`T1w`). Then, within subject registration of the `T2w` to the `T1w` gets us the much improved mask in `T1w` space.