### PR TITLE
ENH: Revise creation of anatomical templates

### DIFF
--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -1,7 +1,6 @@
-from pathlib import Path
-
+"""Base anatomical preprocessing."""
 from nipype.pipeline import engine as pe
-from nipype.interfaces import utility as niu, fsl
+from nipype.interfaces import utility as niu
 
 
 def init_infant_anat_wf(
@@ -85,6 +84,7 @@ def init_infant_anat_wf(
 
     from ...utils.misc import fix_multi_source_name
     from .brain_extraction import init_infant_brain_extraction_wf
+    from .preproc import init_anat_template_wf
     from .registration import init_coregistration_wf
     from .segmentation import init_anat_seg_wf
     from .surfaces import init_infant_surface_recon_wf
@@ -192,21 +192,17 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
 
     # Multiple T1w files -> generate average reference
     t1w_template_wf = init_anat_template_wf(
-        longitudinal=False,
-        omp_nthreads=omp_nthreads,
-        num_t1w=num_t1w,
-    )
-
-    t2w_template_wf = init_t2w_template_wf(
         longitudinal=longitudinal,
         omp_nthreads=omp_nthreads,
-        num_t2w=num_t2w,
+        num_maps=num_t1w,
+        name="t1w_template_wf",
     )
 
-    anat_validate = pe.Node(
-        ValidateImage(),
-        name="anat_validate",
-        run_without_submitting=True,
+    t2w_template_wf = init_anat_template_wf(
+        longitudinal=longitudinal,
+        omp_nthreads=omp_nthreads,
+        num_maps=num_t2w,
+        name="t2w_template_wf",
     )
 
     # INU + Brain Extraction
@@ -257,23 +253,16 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
 
     # fmt: off
     wf.connect([
-        (inputnode, t1w_template_wf, [
-            ("t1w", "inputnode.t1w"),
-        ]),
-        (inputnode, t2w_template_wf, [
-            ("t2w", "inputnode.t2w"),
-        ]),
+        (inputnode, t1w_template_wf, [("t1w", "inputnode.in_file"),]),
+        (inputnode, t2w_template_wf, [("t2w", "inputnode.in_file")]),
         (t1w_template_wf, outputnode, [
             ("outputnode.t1w_realign_xfm", "anat_ref_xfms"),
         ]),
-        (t1w_template_wf, anat_validate, [
-            ("outputnode.t1w_ref", "in_file"),
-        ]),
-        (anat_validate, coregistration_wf, [
-            ("out_file", "inputnode.in_t1w"),
-        ]),
         (t2w_template_wf, brain_extraction_wf, [
-            ("outputnode.t2w_ref", "inputnode.in_t2w"),
+            ("outputnode.out_file", "inputnode.in_t2w"),
+        ]),
+        (t1w_template_wf, coregistration_wf, [
+            ("outputnode.out_file", "inputnode.in_t1w_preproc"),
         ]),
         (brain_extraction_wf, coregistration_wf, [
             ("outputnode.t2w_preproc", "inputnode.in_t2w_preproc"),
@@ -384,8 +373,8 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
             ("subjects_dir", "inputnode.subjects_dir"),
             ("t2w", "inputnode.t2w"),
         ]),
-        (anat_validate, surface_recon_wf, [
-            ("out_file", "inputnode.anat_orig"),
+        (t1w_template_wf, surface_recon_wf, [
+            ("outputnode.out_file", "inputnode.anat_orig"),
         ]),
         (be_buffer, surface_recon_wf, [
             ("anat_brain", "inputnode.anat_skullstripped"),
@@ -413,139 +402,4 @@ the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}
         ]),
     ])
     # fmt: on
-    return wf
-
-
-def init_t2w_template_wf(
-    longitudinal, omp_nthreads, num_t2w, name="anat_t2w_template_wf"
-):
-    """
-    Adapts :py:func:`~smriprep.workflows.anatomical.init_anat_template_wf` for T2w image reference
-    """
-    from pkg_resources import resource_filename as pkgr
-    from nipype.interfaces import freesurfer as fs, image, ants
-    from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.interfaces.freesurfer import (
-        StructuralReference,
-        PatchedLTAConvert as LTAConvert,
-    )
-    from niworkflows.interfaces.images import TemplateDimensions, Conform
-    from niworkflows.interfaces.nitransforms import ConcatenateXFMs
-    from niworkflows.utils.misc import add_suffix
-
-    wf = Workflow(name=name)
-
-    inputnode = pe.Node(niu.IdentityInterface(fields=["t2w"]), name="inputnode")
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=["t2w_ref", "t2w_valid_list", "t2_realign_xfm", "out_report"]
-        ),
-        name="outputnode",
-    )
-
-    # 0. Reorient T2w image(s) to RAS and resample to common voxel space
-    t2w_ref_dimensions = pe.Node(TemplateDimensions(), name="t2w_ref_dimensions")
-    t2w_conform = pe.MapNode(Conform(), iterfield="in_file", name="t2w_conform")
-    # fmt:off
-    wf.connect([
-        (inputnode, t2w_ref_dimensions, [('t2w', 't1w_list')]),
-        (t2w_ref_dimensions, t2w_conform, [
-            ('t1w_valid_list', 'in_file'),
-            ('target_zooms', 'target_zooms'),
-            ('target_shape', 'target_shape')]),
-        (t2w_ref_dimensions, outputnode, [('out_report', 'out_report'),
-                                          ('t1w_valid_list', 't2w_valid_list')]),
-    ])
-    # fmt:on
-
-    if num_t2w == 1:
-        get1st = pe.Node(niu.Select(index=[0]), name="get1st")
-        outputnode.inputs.t2w_realign_xfm = [
-            pkgr("smriprep", "data/itkIdentityTransform.txt")
-        ]
-        # fmt:off
-        wf.connect([
-            (t2w_conform, get1st, [('out_file', 'inlist')]),
-            (get1st, outputnode, [('out', 't2w_ref')]),
-        ])
-        # fmt:on
-        return wf
-
-    wf.__desc__ = f"""\
-A T2w-reference map was computed after registration of
-{num_t2w} T2w images (after INU-correction) using
-`mri_robust_template` [FreeSurfer {fs.Info().looseversion() or "<ver>"}, @fs_template].
-"""
-
-    t2w_conform_xfm = pe.MapNode(
-        LTAConvert(in_lta="identity.nofile", out_lta=True),
-        iterfield=["source_file", "target_file"],
-        name="t2w_conform_xfm",
-    )
-
-    # 1a. Correct for bias field: the bias field is an additive factor
-    #     in log-transformed intensity units. Therefore, it is not a linear
-    #     combination of fields and N4 fails with merged images.
-    # 1b. Align and merge if several T1w images are provided
-    n4_correct = pe.MapNode(
-        ants.N4BiasFieldCorrection(dimension=3, copy_header=True),
-        iterfield="input_image",
-        name="n4_correct",
-        n_procs=1,
-    )  # n_procs=1 for reproducibility
-
-    # StructuralReference is fs.RobustTemplate if > 1 volume, copying otherwise
-    t2w_merge = pe.Node(
-        StructuralReference(
-            auto_detect_sensitivity=True,
-            initial_timepoint=1,  # For deterministic behavior
-            intensity_scaling=True,  # 7-DOF (rigid + intensity)
-            subsample_threshold=200,
-            fixed_timepoint=not longitudinal,
-            no_iteration=not longitudinal,
-            transform_outputs=True,
-        ),
-        mem_gb=2 * num_t2w - 1,
-        name="t2w_merge",
-    )
-
-    # 2. Reorient template to RAS, if needed (mri_robust_template may set to LIA)
-    t2w_reorient = pe.Node(image.Reorient(), name="t2w_reorient")
-
-    merge_xfm = pe.MapNode(
-        niu.Merge(2),
-        name="merge_xfm",
-        iterfield=["in1", "in2"],
-        run_without_submitting=True,
-    )
-    concat_xfms = pe.MapNode(
-        ConcatenateXFMs(inverse=True),
-        name="concat_xfms",
-        iterfield=["in_xfms"],
-        run_without_submitting=True,
-    )
-
-    def _set_threads(in_list, maximum):
-        return min(len(in_list), maximum)
-
-    # fmt:off
-    wf.connect([
-        (t2w_ref_dimensions, t2w_conform_xfm, [('t1w_valid_list', 'source_file')]),
-        (t2w_conform, t2w_conform_xfm, [('out_file', 'target_file')]),
-        (t2w_conform, n4_correct, [('out_file', 'input_image')]),
-        (t2w_conform, t2w_merge, [
-            (('out_file', _set_threads, omp_nthreads), 'num_threads'),
-            (('out_file', add_suffix, '_template'), 'out_file')]),
-        (n4_correct, t2w_merge, [('output_image', 'in_files')]),
-        (t2w_merge, t2w_reorient, [('out_file', 'in_file')]),
-        # Combine orientation and template transforms
-        (t2w_conform_xfm, merge_xfm, [('out_lta', 'in1')]),
-        (t2w_merge, merge_xfm, [('transform_outputs', 'in2')]),
-        (merge_xfm, concat_xfms, [('out', 'in_xfms')]),
-        # Output
-        (t2w_reorient, outputnode, [('out_file', 't2w_ref')]),
-        (concat_xfms, outputnode, [('out_xfm', 't2w_realign_xfm')]),
-    ])
-    # fmt:on
-
     return wf

--- a/nibabies/workflows/anatomical/preproc.py
+++ b/nibabies/workflows/anatomical/preproc.py
@@ -1,0 +1,176 @@
+"""Prepare anatomical images for processing."""
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu
+
+
+def init_anat_average_wf(
+    *,
+    bspline_fitting_distance=200,
+    longitudinal=False,
+    omp_nthreads=None,
+    num_maps=1,
+    name="anat_average_wf",
+    sloppy=False,
+):
+    """
+    Adapts :py:func:`~smriprep.workflows.anatomical.init_anat_template_wf` for T2w image reference
+    """
+    from pkg_resources import resource_filename as pkgr
+    from nipype.interfaces.ants import N4BiasFieldCorrection
+
+    from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    from niworkflows.interfaces.header import ValidateImage
+    from niworkflows.interfaces.nibabel import IntensityClip
+    from niworkflows.interfaces.freesurfer import (
+        StructuralReference,
+        PatchedLTAConvert as LTAConvert,
+    )
+    from niworkflows.interfaces.images import TemplateDimensions, Conform
+    from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+    from niworkflows.utils.misc import add_suffix
+
+    wf = Workflow(name=name)
+
+    inputnode = pe.Node(niu.IdentityInterface(fields=["in_files"]), name="inputnode")
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=["out_file", "valid_list", "realign_xfms", "out_report"]
+        ),
+        name="outputnode",
+    )
+
+    # 1. Validate each of the input images
+    validate = pe.MapNode(
+        ValidateImage(),
+        iterfield="in_file",
+        name="validate",
+        run_without_submitting=True,
+    )
+
+    # 2. INU correction of all independent volumes
+    clip_preinu = pe.MapNode(
+        IntensityClip(p_min=45), iterfield="in_file", name="clip_preinu"
+    )
+    correct_inu = pe.MapNode(
+        N4BiasFieldCorrection(
+            dimension=3,
+            save_bias=False,
+            copy_header=True,
+            n_iterations=[50] * (5 - 2 * sloppy),
+            convergence_threshold=1e-7,
+            shrink_factor=4,
+            bspline_fitting_distance=bspline_fitting_distance,
+        ),
+        iterfield="input_image",
+        n_procs=omp_nthreads,
+        name="correct_inu",
+    )
+    clip_postinu = pe.MapNode(
+        IntensityClip(p_min=2.0, p_max=100.0), iterfield="in_file", name="clip_postinu"
+    )
+
+    # 3. Reorient T2w image(s) to RAS and resample to common voxel space
+    ref_dimensions = pe.Node(TemplateDimensions(), name="ref_dimensions")
+    conform = pe.MapNode(Conform(), iterfield="in_file", name="conform")
+    # fmt:off
+    wf.connect([
+        (inputnode, validate, [("in_files", "in_file")]),
+        (validate, clip_preinu, [("out_file", "in_file")]),
+        (clip_preinu, correct_inu, [("out_file", "input_image")]),
+        (correct_inu, clip_postinu, [("output_image", "in_file")]),
+        (clip_postinu, ref_dimensions, [("out_file", "t1w_list")]),
+        (ref_dimensions, conform, [
+            ("t1w_valid_list", "in_file"),
+            ("target_zooms", "target_zooms"),
+            ("target_shape", "target_shape")]),
+        (ref_dimensions, outputnode, [("out_report", "out_report"),
+                                      ("t1w_valid_list", "valid_list")]),
+    ])
+    # fmt:on
+
+    if num_maps == 1:
+        get1st = pe.Node(niu.Select(index=[0]), name="get1st")
+        outputnode.inputs.realign_xfms = [
+            pkgr("smriprep", "data/itkIdentityTransform.txt")
+        ]
+        # fmt:off
+        wf.connect([
+            (conform, get1st, [("out_file", "inlist")]),
+            (get1st, outputnode, [("out", "out_file")]),
+        ])
+        # fmt:on
+        return wf
+
+    from nipype.interfaces import freesurfer as fs
+    from nipype.interfaces.image import Reorient
+
+    wf.__desc__ = f"""\
+An anatomical reference-map was computed after registration of
+{num_maps} images (after INU-correction) using
+`mri_robust_template` [FreeSurfer {fs.Info().looseversion() or "<ver>"}, @fs_template].
+"""
+
+    conform_xfm = pe.MapNode(
+        LTAConvert(in_lta="identity.nofile", out_lta=True),
+        iterfield=["source_file", "target_file"],
+        name="conform_xfm",
+    )
+
+    # 4. StructuralReference is fs.RobustTemplate if > 1 volume, copying otherwise
+    merge = pe.Node(
+        StructuralReference(
+            auto_detect_sensitivity=True,
+            initial_timepoint=1,  # For deterministic behavior
+            intensity_scaling=True,  # 7-DOF (rigid + intensity)
+            subsample_threshold=200,
+            fixed_timepoint=not longitudinal,
+            no_iteration=not longitudinal,
+            transform_outputs=True,
+        ),
+        mem_gb=2 * num_maps - 1,
+        name="merge",
+    )
+
+    # 5. Reorient template to RAS, if needed (mri_robust_template may set to LIA)
+    ensure_ras = pe.Node(Reorient(), name="ensure_ras")
+
+    # 6. Final intensity equalization/conformation
+    clip_final = pe.Node(IntensityClip(p_min=2.0, p_max=99.9), name="clip_final")
+
+    merge_xfm = pe.MapNode(
+        niu.Merge(2),
+        name="merge_xfm",
+        iterfield=["in1", "in2"],
+        run_without_submitting=True,
+    )
+    concat_xfms = pe.MapNode(
+        ConcatenateXFMs(inverse=True),
+        name="concat_xfms",
+        iterfield=["in_xfms"],
+        run_without_submitting=True,
+    )
+
+    def _set_threads(in_list, maximum):
+        return min(len(in_list), maximum)
+
+    # fmt:off
+    wf.connect([
+        (ref_dimensions, conform_xfm, [("t1w_valid_list", "source_file")]),
+        (conform, conform_xfm, [("out_file", "target_file")]),
+        (conform, merge, [
+            ("out_file", "in_file"),
+            (("out_file", _set_threads, omp_nthreads), "num_threads"),
+            (("out_file", add_suffix, "_template"), "out_file")]),
+        (merge, ensure_ras, [("out_file", "in_file")]),
+        # Combine orientation and template transforms
+        (conform_xfm, merge_xfm, [("out_lta", "in1")]),
+        (merge, merge_xfm, [("transform_outputs", "in2")]),
+        (merge_xfm, concat_xfms, [("out", "in_xfms")]),
+        # Output
+        (ensure_ras, clip_final, [("out_file", "in_file")]),
+        (clip_final, outputnode, [("out_file", "out_file")]),
+        (concat_xfms, outputnode, [("out_xfm", "realign_xfms")]),
+    ])
+    # fmt:on
+
+    return wf


### PR DESCRIPTION
Minimize validations, conformations and INU corrections, and gather them up together within
only one workflow for both T1w and T2w paths.

Also simplify the brain extraction and the co-registration workflows accordingly.