### PR TITLE
FIX: T1 BOLD coregistration

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -626,6 +626,7 @@ def parse_args(args=None, namespace=None):
     # Initialize --output-spaces if not defined
     if config.execution.output_spaces is None:
         # TODO: Set a default volumetric output space
+        pass
 
     # Retrieve logging level
     build_log = config.loggers.cli

--- a/nibabies/workflows/bold/registration.py
+++ b/nibabies/workflows/bold/registration.py
@@ -131,16 +131,14 @@ def init_bold_reg_wf(
         name='outputnode'
     )
 
-    # if freesurfer:
-    #     bbr_wf = init_bbreg_wf(use_bbr=use_bbr, bold2t1w_dof=bold2t1w_dof,
-    #                            bold2t1w_init=bold2t1w_init, omp_nthreads=omp_nthreads)
-    # else:
-    #     bbr_wf = init_fsl_bbr_wf(use_bbr=use_bbr, bold2t1w_dof=bold2t1w_dof,
-    #                              bold2t1w_init=bold2t1w_init, sloppy=sloppy)
-    # Replace with volumetric registration until better WM/GM contrasts
-
-    bbr_wf = init_fsl_bbr_wf(use_bbr=False, bold2t1w_dof=bold2t1w_dof,
-                             bold2t1w_init=bold2t1w_init, sloppy=sloppy)
+    # Default to no bbr for the moment
+    use_bbr = False
+    if freesurfer:
+        bbr_wf = init_bbreg_wf(use_bbr=use_bbr, bold2t1w_dof=bold2t1w_dof,
+                               bold2t1w_init=bold2t1w_init, omp_nthreads=omp_nthreads)
+    else:
+        bbr_wf = init_fsl_bbr_wf(use_bbr=use_bbr, bold2t1w_dof=bold2t1w_dof,
+                                 bold2t1w_init=bold2t1w_init, sloppy=sloppy)
 
     workflow.connect([
         (inputnode, bbr_wf, [


### PR DESCRIPTION
- Default to `mri_coreg` if FreeSurfer is available
  - FSL FLIRT not ideal, but usable when FS not available