### PR TITLE
ENH: T1-only processing

### DIFF
--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -10,7 +10,13 @@ from smriprep.workflows.surfaces import init_gifti_surface_wf
 from ...interfaces.freesurfer import InfantReconAll
 
 
-def init_infant_surface_recon_wf(*, age_months, use_aseg=False, name="infant_surface_recon_wf"):
+def init_infant_surface_recon_wf(
+    *,
+    age_months,
+    use_aseg=False,
+    use_t2w=False,
+    name="infant_surface_recon_wf"
+):
     wf = pe.Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(


### PR DESCRIPTION
- Allow users to run nibabies with only T1w anatomical.
However, this is not recommended, and a warning will be spit out.