### PR TITLE
CI: Attempt to pull most recent dev version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
                 docker pull ubuntu:focal
                 docker tag ubuntu:focal localhost:5000/ubuntu
                 docker push localhost:5000/ubuntu
-                # docker pull nipreps/nibabies:latest
+                docker pull nipreps/nibabies:unstable || true
             fi
       - run:
           name: Build Docker image


### PR DESCRIPTION
- In cases where the Docker file changes drastically, this will speed up builds
- This will likely want to be changed in `maint/` branches to account for Dockerfile changes across versions