### PR TITLE
DOCKER: Strip ABI tag from libQt5Core.so.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -321,6 +321,9 @@ RUN echo "${VERSION}" > /src/nibabies/nibabies/VERSION && \
     pip install --no-cache-dir -e "/src/nibabies[all]" && \
     rm ${FREESURFER_HOME}/build-stamp.txt
 
+# ABI tags can interfere when running on Singularity
+RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
+
 # Final settings
 RUN ldconfig
 WORKDIR /tmp


### PR DESCRIPTION
As we saw in nipreps/fmriprep#2535, this can help Singularity errors