### PR TITLE
MAINT: Wrapper fixes

### DIFF
--- a/wrapper/nibabies_wrapper.py
+++ b/wrapper/nibabies_wrapper.py
@@ -29,7 +29,7 @@ __bugreports__ = 'https://github.com/nipreps/nibabies/issues'
 MISSING = """
 Image '{}' is missing
 Would you like to download? [Y/n] """
-PKG_PATH = "/usr/local/miniconda/lib/python3.7/site-packages"
+PKG_PATH = "/usr/local/miniconda/lib/python3.8/site-packages"
 TF_TEMPLATES = (
     "MNI152Lin",
     "MNI152NLin2009cAsym",

--- a/wrapper/nibabies_wrapper.py
+++ b/wrapper/nibabies_wrapper.py
@@ -20,11 +20,11 @@ import os
 import re
 import subprocess
 
-__version__ = "99.99.99"
+__version__ = '99.99.99'
 __copyright__ = (
-    "Copyright 2021, The NiPreps Developers"
+    'Copyright 2021, The NiPreps Developers'
 )
-__bugreports__ = "https://github.com/nipreps/nibabies/issues"
+__bugreports__ = 'https://github.com/nipreps/nibabies/issues'
 
 MISSING = """
 Image '{}' is missing


### PR DESCRIPTION
Closes #107 

- Use single quotes to appease existing `sed` version substitution on release
- Update python patches path