### PR TITLE
MAINT: Only alter pybids config in legacy versions

### DIFF
--- a/nibabies/__init__.py
+++ b/nibabies/__init__.py
@@ -7,8 +7,10 @@ del get_versions
 # Can be removed once minimum PyBIDS dependency hits 0.14
 try:
     import bids
+    from packaging.version import Version
 
-    bids.config.set_option("extension_initial_dot", True)
+    if Version(bids.__version__) < Version("0.14.0"):
+        bids.config.set_option("extension_initial_dot", True)
 except (ImportError, ValueError):
     pass
 else:


### PR DESCRIPTION
To remove the pesky import warning

```
FutureWarning: Setting 'extension_initial_dot' will be removed in pybids 0.16.
  warnings.warn("Setting 'extension_initial_dot' will be removed in pybids 0.16.",
```