### PR TITLE
ENH: Remove infant recon all age cap

### DIFF
--- a/nibabies/interfaces/freesurfer.py
+++ b/nibabies/interfaces/freesurfer.py
@@ -33,7 +33,6 @@ class InfantReconAllInputSpec(CommandLineInputSpec):
     )
     age = traits.Range(
         low=0,
-        high=24,
         argstr="--age %d",
         desc="Subject age in months",
     )


### PR DESCRIPTION
Allows for >24 month processing.

Initial testing with 25/26 months showed reasonable results.