### PR TITLE
STY/TEST: Set global style and doctest options

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,4 +22,3 @@ jobs:
     - uses: jpetrucciani/black-check@master
       with:
         path: 'nibabies/'
-        black_flags: '--line-length 99 --exclude nibabies/_version.py'

--- a/nibabies/interfaces/confounds.py
+++ b/nibabies/interfaces/confounds.py
@@ -104,8 +104,7 @@ class GatherConfounds(SimpleInterface):
     >>> res.outputs.confounds_list
     ['Global signals', 'DVARS']
 
-    >>> pd.read_csv(res.outputs.confounds_file, sep='\s+', index_col=None,
-    ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
+    >>> pd.read_csv(res.outputs.confounds_file, sep='\s+', index_col=None, engine='python')
          a    b
     0  0.1  0.2
 
@@ -199,8 +198,7 @@ def _gather_confounds(
     >>> confound_list
     ['Global signals', 'DVARS']
 
-    >>> pd.read_csv(out_file, sep='\s+', index_col=None,
-    ...             engine='python')  # doctest: +NORMALIZE_WHITESPACE
+    >>> pd.read_csv(out_file, sep='\s+', index_col=None, engine='python')
        global_signal  std_dvars
     0            0.1        0.2
     >>> tmpdir.cleanup()

--- a/nibabies/interfaces/multiecho.py
+++ b/nibabies/interfaces/multiecho.py
@@ -72,7 +72,7 @@ class T2SMap(CommandLine):
     ...     data_dir / 'sub-01_run-01_echo-2_bold.nii.gz',
     ...     data_dir / 'sub-01_run-01_echo-3_bold.nii.gz']
     >>> t2smap.inputs.echo_times = [0.013, 0.027, 0.043]
-    >>> t2smap.cmdline  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> t2smap.cmdline
     't2smap -d .../sub-01_run-01_echo-1_bold.nii.gz \
     .../sub-01_run-01_echo-2_bold.nii.gz \
     .../sub-01_run-01_echo-3_bold.nii.gz -e 13.0 27.0 43.0 --fittype curvefit'

--- a/nibabies/interfaces/workbench.py
+++ b/nibabies/interfaces/workbench.py
@@ -164,13 +164,13 @@ class CiftiCreateDenseFromTemplate(WBCommand):
     >>> frmtpl.inputs.series = True
     >>> frmtpl.inputs.series_step = 0.8
     >>> frmtpl.inputs.series_start = 0
-    >>> frmtpl.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> frmtpl.cmdline
     'wb_command -cifti-create-dense-from-template .../func.dtseries.nii \
     template_func.dtseries.nii -series 0.8 0.0'
 
     >>> frmtpl.inputs.volume = [("OTHER", data_dir / 'functional.nii', True), \
         ("PUTAMEN_LEFT", data_dir / 'functional.nii')]
-    >>> frmtpl.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> frmtpl.cmdline
     'wb_command -cifti-create-dense-from-template .../func.dtseries.nii \
     template_func.dtseries.nii -series 0.8 0.0 \
     -volume OTHER .../functional.nii -from-cropped \
@@ -328,7 +328,7 @@ class CiftiCreateDenseTimeseries(WBCommand):
     >>> createdts = CiftiCreateDenseTimeseries()
     >>> createdts.inputs.volume_data = data_dir /'functional.nii'
     >>> createdts.inputs.volume_structure_labels = data_dir / 'atlas.nii'
-    >>> createdts.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> createdts.cmdline
     'wb_command -cifti-create-dense-timeseries out.dtseries.nii \
     -volume .../functional.nii .../atlas.nii'
     """
@@ -465,7 +465,7 @@ class CiftiCreateLabel(WBCommand):
     >>> lab = wb.CiftiCreateLabel()
     >>> lab.inputs.volume_label = data_dir / "functional.nii"
     >>> lab.inputs.structure_label_volume = data_dir / "functional.nii"
-    >>> lab.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> lab.cmdline
     'wb_command -cifti-create-label out.dlabel.nii -volume .../functional.nii .../functional.nii'
     """
 
@@ -944,7 +944,7 @@ class CiftiResample(WBCommand):
     >>> res.inputs.volume_method = "CUBIC"
     >>> res.inputs.out_file = "resampled.dtseries.nii"
     >>> res.inputs.volume_predilate = 10
-    >>> res.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> res.cmdline
     'wb_command -cifti-resample .../func.dtseries.nii COLUMN .../func.dlabel.nii COLUMN \
     ADAP_BARY_AREA CUBIC resampled.dtseries.nii -volume-predilate 10'
     """
@@ -1050,7 +1050,7 @@ class CiftiSeparate(WBCommand):
     >>> separate.inputs.in_file = data_dir / "func.dtseries.nii"
     >>> separate.inputs.direction = "COLUMN"
     >>> separate.inputs.volume_all_file = "volume_all.nii.gz"
-    >>> separate.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> separate.cmdline
     'wb_command -cifti-separate .../func.dtseries.nii COLUMN \
     -volume-all volume_all.nii.gz'
 
@@ -1058,7 +1058,7 @@ class CiftiSeparate(WBCommand):
     >>> separate.inputs.metric = [("CORTEX_LEFT", "cortexleft.func.gii")]
     >>> separate.inputs.volume = [("HIPPOCAMPUS_LEFT", "hippoL.nii.gz"), \
         ("HIPPOCAMPUS_RIGHT", "hippoR.nii.gz", "hippoR.roi.nii.gz")]
-    >>> separate.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> separate.cmdline
     'wb_command -cifti-separate .../func.dtseries.nii COLUMN \
     -volume-all volume_all.nii.gz -metric CORTEX_LEFT cortexleft.func.gii \
     -volume HIPPOCAMPUS_LEFT hippoL.nii.gz \
@@ -1216,7 +1216,7 @@ class VolumeAffineResample(WBCommand):
     >>> resample.inputs.volume_space = data_dir /'anatomical.nii'
     >>> resample.inputs.method = 'CUBIC'
     >>> resample.inputs.affine = data_dir / 'func_to_struct.mat'
-    >>> resample.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> resample.cmdline
     'wb_command -volume-resample .../functional.nii .../anatomical.nii CUBIC \
     resampled_functional.nii.gz -affine .../func_to_struct.mat'
 
@@ -1225,7 +1225,7 @@ class VolumeAffineResample(WBCommand):
     for references.
 
     >>> resample.inputs.flirt = True
-    >>> resample.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> resample.cmdline
     'wb_command -volume-resample .../functional.nii .../anatomical.nii CUBIC \
     resampled_functional.nii.gz -affine .../func_to_struct.mat \
     -flirt .../functional.nii .../anatomical.nii'
@@ -1235,7 +1235,7 @@ class VolumeAffineResample(WBCommand):
 
     >>> resample.inputs.flirt_source_volume = data_dir / 'epi.nii'
     >>> resample.inputs.flirt_target_volume = data_dir /'T1w.nii'
-    >>> resample.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> resample.cmdline
     'wb_command -volume-resample .../functional.nii .../anatomical.nii CUBIC \
     resampled_functional.nii.gz -affine .../func_to_struct.mat \
     -flirt .../epi.nii .../T1w.nii'
@@ -1295,7 +1295,7 @@ class VolumeAllLabelsToROIs(WBCommand):
     >>> rois = VolumeAllLabelsToROIs()
     >>> rois.inputs.in_file = data_dir / 'atlas.nii'
     >>> rois.inputs.label_map = 1
-    >>> rois.cmdline  #doctest: +ELLIPSIS
+    >>> rois.cmdline
     'wb_command -volume-all-labels-to-rois .../atlas.nii 1 atlas_rois.nii.gz'
     """
 
@@ -1344,7 +1344,7 @@ class VolumeLabelExportTable(WBCommand):
     >>> label_export = VolumeLabelExportTable()
     >>> label_export.inputs.in_file = data_dir / 'atlas.nii'
     >>> label_export.inputs.label_map = 1
-    >>> label_export.cmdline  #doctest: +ELLIPSIS
+    >>> label_export.cmdline
     'wb_command -volume-label-export-table .../atlas.nii 1 atlas_labels.txt'
     """
 
@@ -1432,7 +1432,7 @@ class VolumeLabelImport(WBCommand):
     >>> label_import = VolumeLabelImport()
     >>> label_import.inputs.in_file = data_dir / 'atlas.nii'
     >>> label_import.inputs.label_list_file = data_dir / 'label_list.txt'
-    >>> label_import.cmdline  #doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> label_import.cmdline
     'wb_command -volume-label-import .../atlas.nii .../label_list.txt \
     atlas_labels.nii.gz'
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 99
+target-version = ['py37']
+skip-string-normalization = true
+extend-exclude = '_version.py|versioneer.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
 line-length = 99
-target-version = ['py37']
+target-version = ['py39']
 skip-string-normalization = true
 extend-exclude = '_version.py|versioneer.py'

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,3 +104,6 @@ ignore =
     W503
     E203
 exclude=*build/
+
+[tool:pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS


### PR DESCRIPTION
I set `skip-string-normalization` just to avoid automatic formatters from making unnecessary changes and polluting PRs. Probably not relevant since you've already converted, so I can remove it if you prefer.