### PR TITLE
FIX: Clean up generated boilerplate

### DIFF
--- a/nibabies/data/boilerplate.bib
+++ b/nibabies/data/boilerplate.bib
@@ -379,3 +379,16 @@
 	title = {Infant Brain Atlases from Neonates to 1- and 2-Year-Olds},
 	journal = {{PLoS} {ONE}}
 }
+
+@article{infantfs,
+	doi = {10.1016/j.neuroimage.2020.116946},
+	url = {https://doi.org/10.1016%2Fj.neuroimage.2020.116946},
+	year = 2020,
+	month = {sep},
+	publisher = {Elsevier {BV}},
+	volume = {218},
+	pages = {116946},
+	author = {Lilla Zöllei and Juan Eugenio Iglesias and Yangming Ou and P. Ellen Grant and Bruce Fischl},
+	title = {Infant {FreeSurfer}: An automated segmentation and surface extraction pipeline for T1-weighted neuroimaging data of infants 0{\textendash}2 years},
+	journal = {{NeuroImage}}
+}

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -165,12 +165,6 @@ as target template.
 """
     )
 
-    desc += """\
-Brain tissue segmentation of cerebrospinal fluid (CSF),
-white-matter (WM) and gray-matter (GM) was performed on
-the brain-extracted T1w using ANTs JointFusion, distributed with ANTs {ants_ver}.
-"""
-
     wf.__desc__ = desc.format(
         ants_ver=ANTsInfo.version() or "(version unknown)",
         skullstrip_tpl=skull_strip_template.fullname,

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -11,7 +11,9 @@ from ...interfaces.freesurfer import InfantReconAll
 
 
 def init_infant_surface_recon_wf(*, age_months, use_aseg=False, name="infant_surface_recon_wf"):
-    wf = pe.Workflow(name=name)
+    from niworkflows.engine.workflows import LiterateWorkflow
+
+    wf = LiterateWorkflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
@@ -40,6 +42,12 @@ def init_infant_surface_recon_wf(*, age_months, use_aseg=False, name="infant_sur
         ),
         name="outputnode",
     )
+
+    wf.__desc__ = f"""\
+Brain surfaces were reconstructed using `infant_recon_all` [FreeSurfer
+{fs.Info().looseversion() or "<ver>"}, RRID:SCR_001847, @infantfs],
+leveraging the masked, preprocessed T1w and anatomical segmentation.
+"""
 
     gen_recon_outdir = pe.Node(niu.Function(function=_gen_recon_dir), name="gen_recon_outdir")
 


### PR DESCRIPTION
Fixes up boilerplate entries for anatomical segmentations / surfaces.
Adds bib entry for `infant_recon_all`