### PR TITLE
ENH: Improve fieldmap support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,6 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -442,6 +442,12 @@ Useful for further Tedana processing post-NiBabies.""",
         default=True,
         help="do not remove median (within mask) from fieldmap",
     )
+    g_fmap.add_argument(
+        "--topup-max-vols",
+        default=5,
+        type=int,
+        help="maximum number of volumes to use with TOPUP, per-series (EPI or BOLD)",
+    )
 
     # SyN-unwarp options
     g_syn = parser.add_argument_group("Specific options for SyN distortion correction")

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -557,6 +557,8 @@ class workflow(_Config):
     spaces = None
     """Keeps the :py:class:`~niworkflows.utils.spaces.SpatialReferences`
     instance keeping standard and nonstandard spaces."""
+    topup_max_vols = 5
+    """Maximum number of volumes to use with TOPUP, per-series (EPI or BOLD)."""
     use_aroma = None
     """Run ICA-:abbr:`AROMA (automatic removal of motion artifacts)`."""
     use_bbr = False

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -484,21 +484,20 @@ Setting-up fieldmap "{estimator.bids_id}" ({estimator.method}) with \
         if estimator.method in (fm.EstimatorType.MAPPED, fm.EstimatorType.PHASEDIFF):
             continue
 
-        suffices = set(s.suffix for s in estimator.sources)
-
-        if estimator.method == fm.EstimatorType.PEPOLAR and sorted(suffices) == ["epi"]:
-            fmap_wf_inputs = getattr(fmap_wf.inputs, f"in_{estimator.bids_id}")
-            fmap_wf_inputs.in_data = [str(s.path) for s in estimator.sources]
-            fmap_wf_inputs.metadata = [s.metadata for s in estimator.sources]
-
-            flatten = fmap_wf.get_node(f"wf_{estimator.bids_id}.flatten")
-            flatten.inputs.max_trs = config.workflow.topup_max_vols
-            continue
+        suffices = [s.suffix for s in estimator.sources]
 
         if estimator.method == fm.EstimatorType.PEPOLAR:
-            raise NotImplementedError(
-                "Sophisticated PEPOLAR schemes (e.g., using DWI+EPI) are unsupported."
-            )
+            if set(suffices) == {"epi"} or sorted(suffices) == ["bold", "epi"]:
+                fmap_wf_inputs = getattr(fmap_wf.inputs, f"in_{estimator.bids_id}")
+                fmap_wf_inputs.in_data = [str(s.path) for s in estimator.sources]
+                fmap_wf_inputs.metadata = [s.metadata for s in estimator.sources]
+
+                flatten = fmap_wf.get_node(f"wf_{estimator.bids_id}.flatten")
+                flatten.inputs.max_trs = config.workflow.topup_max_vols
+            else:
+                raise NotImplementedError(
+                    "Sophisticated PEPOLAR schemes (e.g., using DWI+EPI) are unsupported."
+                )
 
     return workflow
 

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -487,12 +487,12 @@ Setting-up fieldmap "{estimator.bids_id}" ({estimator.method}) with \
         suffices = set(s.suffix for s in estimator.sources)
 
         if estimator.method == fm.EstimatorType.PEPOLAR and sorted(suffices) == ["epi"]:
-            getattr(fmap_wf.inputs, f"in_{estimator.bids_id}").in_data = [
-                str(s.path) for s in estimator.sources
-            ]
-            getattr(fmap_wf.inputs, f"in_{estimator.bids_id}").metadata = [
-                s.metadata for s in estimator.sources
-            ]
+            fmap_wf_inputs = getattr(fmap_wf.inputs, f"in_{estimator.bids_id}")
+            fmap_wf_inputs.in_data = [str(s.path) for s in estimator.sources]
+            fmap_wf_inputs.metadata = [s.metadata for s in estimator.sources]
+
+            flatten = fmap_wf.get_node(f"wf_{estimator.bids_id}.flatten")
+            flatten.inputs.max_trs = config.workflow.topup_max_vols
             continue
 
         if estimator.method == fm.EstimatorType.PEPOLAR:


### PR DESCRIPTION
- Adds `--topup-max-vols` flag to control how many volumes are used with TOPUP.
- Enables susceptibility distortion correction in the case where single phase-encoding fieldmap is used to correct opposite phase-encoding BOLD/EPI runs.

Closes #204 