### PR TITLE
MAINT: Force all git-annex dependencies to be installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
           command: |
             if [[ ! -d /tmp/data/bcp ]]; then
               apk update && apk add --no-cache ca-certificates coreutils
-              conda install -y -c anaconda -c conda-forge git-annex datalad
+              conda install -y -c conda-forge git-annex=*=alldep*   datalad
               # set config because datalad says so
               git config --global user.name "Nipreps CI"
               git config --global user.email "nipreps@gmail.com"


### PR DESCRIPTION
`git` was not being installed when installing `git-annex` from conda.

```
##############################################################################
#                                                                            #
# Standalone distribution of git-annex was installed, instead of the         #
# standard distribution, likely due to package conflicts in the target       #
# environment.  The standalone distribution may have issues (e.g. be slower, #
# or not pass the expected environment to some external programs);           #
# the standard distribution should be used when possible.                    #
# You can force installation of the standard version by adding =alldep* to   #
# the build string of the package specification, e.g.                        #
#                                                                            #
# conda install -c conda-forge git-annex=*=alldep*                           #
#                                                                            #
# However, this might cause an older git-annex version to be installed,      #
# if later versions' dependencies conflict with other packages               #
# in the target environment.                                                 #
#                                                                            #
# For more info on the standalone git-annex distribution see                 #
# https://git-annex.branchable.com/install/Linux_standalone/                 #
#                                                                            #
##############################################################################
```