### PR TITLE
RF/ENH: Rework workflow generation

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -796,8 +796,13 @@ applied."""
     if missing_subjects:
         parser.error(
             "One or more participant labels were not found in the BIDS directory: "
-            "%s." % ", ".join(missing_subjects)
+            f"{', '.join(missing_subjects)}."
         )
 
     config.execution.participant_label = sorted(participant_label)
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]
+
+    # finally, write config to file
+    config_file = config.execution.work_dir / config.execution.run_uuid / "config.toml"
+    config_file.parent.mkdir(exist_ok=True, parents=True)
+    config.to_filename(config_file)

--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -16,6 +16,7 @@ def main():
     from .parser import parse_args
     from .workflow import build_boilerplate, build_workflow
 
+    _cwd = os.getcwd()
     # Revert OMP_NUM_THREADS + other runtime set environment variables
     atexit.register(config.restore_env)
 
@@ -39,7 +40,7 @@ def main():
             _pool = ProcessPoolExecutor(
                 max_workers=config.nipype.nprocs,
                 initializer=config._process_initializer,
-                initargs=(config.execution.cwd, config.nipype.omp_nthreads),
+                initargs=(_cwd, config.nipype.omp_nthreads),
             )
 
         # build the workflow within the same process

--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -43,8 +43,13 @@ def main():
                 initargs=(_cwd, config.nipype.omp_nthreads),
             )
 
+        config_file = config.execution.work_dir / config.execution.run_uuid / "config.toml"
+        config_file.parent.mkdir(exist_ok=True, parents=True)
+        config.to_filename(config_file)
+
         # build the workflow within the same process
-        retval = build_workflow()
+        # it still needs to be saved / loaded to be properly initialized
+        retval = build_workflow(config_file)
         retcode = retval['return_code']
         nibabies_wf = retval['workflow']
 

--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -6,148 +6,130 @@ from .. import config
 
 def main():
     """Entry point."""
+    import atexit
     import gc
+    import os
     import sys
-    from multiprocessing import Manager, Process
-    from os import EX_SOFTWARE
     from pathlib import Path
 
     from ..utils.bids import write_bidsignore, write_derivative_description
-    from ..workflows import init_nibabies_wf
     from .parser import parse_args
+    from .workflow import build_boilerplate, build_workflow
+
+    # Revert OMP_NUM_THREADS + other runtime set environment variables
+    atexit.register(config.restore_env)
 
     parse_args()
 
-    # sentry_sdk = None
-    # if not config.execution.notrack:
-    #     import sentry_sdk
-    #     from ..utils.sentry import sentry_setup
-
-    #     sentry_setup()
-
-    # CRITICAL Save the config to a file. This is necessary because the execution graph
-    # is built as a separate process to keep the memory footprint low. The most
-    # straightforward way to communicate with the child process is via the filesystem.
-    config_file = config.execution.work_dir / config.execution.run_uuid / "config.toml"
-    config_file.parent.mkdir(exist_ok=True, parents=True)
-    config.to_filename(config_file)
-
     if "participant" in config.workflow.analysis_level:
-        nibabies_wf = init_nibabies_wf()
-        if nibabies_wf is None:
-            sys.exit(EX_SOFTWARE)
+        _pool = None
+        if config.nipype.plugin == "MultiProc":
+            import multiprocessing as mp
+            from concurrent.futures import ProcessPoolExecutor
+            from contextlib import suppress
 
-    if config.execution.reports_only:
-        sys.exit(int(retcode > 0))
+            # should drastically reduce VMS
+            # see https://github.com/nipreps/mriqc/pull/984 for more details
+            os.environ["OMP_NUM_THREADS"] = "1"
 
-    if nibabies_wf and config.execution.write_graph:
-        nibabies_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
+            with suppress(RuntimeError):
+                mp.set_start_method("fork")
+            gc.collect()
 
-    retcode = retcode or (nibabies_wf is None) * EX_SOFTWARE
-    if retcode != 0:
-        sys.exit(retcode)
-
-    # Generate boilerplate
-    with Manager() as mgr:
-        from .workflow import build_boilerplate
-
-        p = Process(target=build_boilerplate, args=(str(config_file), nibabies_wf))
-        p.start()
-        p.join()
-
-    if config.execution.boilerplate_only:
-        sys.exit(int(retcode > 0))
-
-    # Sentry tracking
-    # if sentry_sdk is not None:
-    #     with sentry_sdk.configure_scope() as scope:
-    #         scope.set_tag("run_uuid", config.execution.run_uuid)
-    #         scope.set_tag("npart", len(config.execution.participant_label))
-    #     sentry_sdk.add_breadcrumb(message="nibabies started", level="info")
-    #     sentry_sdk.capture_message("nibabies started", level="info")
-
-    config.loggers.workflow.log(
-        15,
-        "\n".join(["nibabies config:"] + ["\t\t%s" % s for s in config.dumps().splitlines()]),
-    )
-    config.loggers.workflow.log(25, "nibabies started!")
-    # errno = 1  # Default is error exit unless otherwise set
-    try:
-        nibabies_wf.run(**config.nipype.get_plugin())
-    except Exception as e:
-        # if not config.execution.notrack:
-        #     from ..utils.sentry import process_crashfile
-
-        #     crashfolders = [
-        #         config.execution.nibabies_dir,
-        #         / "sub-{}".format(s)
-        #         / "log"
-        #         / config.execution.run_uuid
-        #         for s in config.execution.participant_label
-        #     ]
-        #     for crashfolder in crashfolders:
-        #         for crashfile in crashfolder.glob("crash*.*"):
-        #             process_crashfile(crashfile)
-
-        #     if "Workflow did not execute cleanly" not in str(e):
-        #         sentry_sdk.capture_exception(e)
-        config.loggers.workflow.critical("nibabies failed: %s", e)
-        raise
-    else:
-        config.loggers.workflow.log(25, "nibabies finished successfully!")
-        # if not config.execution.notrack:
-        #     success_message = "nibabies finished without errors"
-        #     sentry_sdk.add_breadcrumb(message=success_message, level="info")
-        #     sentry_sdk.capture_message(success_message, level="info")
-
-        # Bother users with the boilerplate only iff the workflow went okay.
-        boiler_file = config.execution.nibabies_dir / "logs" / "CITATION.md"
-        if boiler_file.exists():
-            if config.environment.exec_env in (
-                "singularity",
-                "docker",
-                "nibabies-docker",
-            ):
-                boiler_file = Path("<OUTPUT_PATH>") / boiler_file.relative_to(
-                    config.execution.output_dir
-                )
-            config.loggers.workflow.log(
-                25,
-                "Works derived from this nibabies execution should include the "
-                f"boilerplate text found in {boiler_file}.",
+            _pool = ProcessPoolExecutor(
+                max_workers=config.nipype.nprocs,
+                initializer=config._process_initializer,
+                initargs=(config.execution.cwd, config.nipype.omp_nthreads),
             )
 
-        if config.workflow.run_reconall:
-            from niworkflows.utils.misc import _copy_any
-            from templateflow import api
+        # build the workflow within the same process
+        retval = build_workflow()
+        retcode = retval['return_code']
+        nibabies_wf = retval['workflow']
 
-            dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
-            _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aseg_dseg.tsv"))
-            _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aparcaseg_dseg.tsv"))
-        # errno = 0
-    finally:
-        from pkg_resources import resource_filename as pkgrf
+        if nibabies_wf is None:
+            if config.execution.reports_only:
+                sys.exit(int(retcode > 0))
+            sys.exit(os.EX_SOFTWARE)
 
-        from ..reports.core import generate_reports
+        if config.execution.write_graph:
+            nibabies_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
 
-        # Generate reports phase
-        generate_reports(
-            config.execution.participant_label,
-            config.execution.session_id,
-            config.execution.nibabies_dir,
-            config.execution.run_uuid,
-            config=pkgrf("nibabies", "data/reports-spec.yml"),
-            packagename="nibabies",
+        if retcode != 0:
+            sys.exit(retcode)
+
+        # generate boilerplate
+        build_boilerplate(nibabies_wf)
+        if config.execution.boilerplate_only:
+            sys.exit(0)
+
+        gc.collect()
+
+        config.loggers.workflow.log(
+            15,
+            "\n".join(["nibabies config:"] + ["\t\t%s" % s for s in config.dumps().splitlines()]),
         )
-        write_derivative_description(config.execution.bids_dir, config.execution.nibabies_dir)
-        write_bidsignore(config.execution.nibabies_dir)
+        config.loggers.workflow.log(25, "nibabies started!")
 
-        # if failed_reports and not config.execution.notrack:
-        #     sentry_sdk.capture_message(
-        #         "Report generation failed for %d subjects" % failed_reports,
-        #         level="error",
-        #     )
-        # sys.exit(int((errno + failed_reports) > 0))
+        # Hack MultiProc's pool to reduce VMS
+        _plugin = config.nipype.get_plugin()
+        if _pool:
+            from nipype.pipeline.plugins.multiproc import MultiProcPlugin
+
+            multiproc = MultiProcPlugin(plugin_args=config.nipype.plugin_args)
+            multiproc.pool = _pool
+            _plugin = {"plugin": multiproc}
+
+        gc.collect()
+        try:
+            nibabies_wf.run(**_plugin)
+        except Exception as e:
+            config.loggers.workflow.critical("nibabies failed: %s", e)
+            raise
+        else:
+            config.loggers.workflow.log(25, "nibabies finished successfully!")
+
+            # Bother users with the boilerplate only iff the workflow went okay.
+            boiler_file = config.execution.nibabies_dir / "logs" / "CITATION.md"
+            if boiler_file.exists():
+                if config.environment.exec_env in (
+                    "singularity",
+                    "docker",
+                    "nibabies-docker",
+                ):
+                    boiler_file = Path("<OUTPUT_PATH>") / boiler_file.relative_to(
+                        config.execution.output_dir
+                    )
+                config.loggers.workflow.log(
+                    25,
+                    "Works derived from this nibabies execution should include the "
+                    f"boilerplate text found in {boiler_file}.",
+                )
+
+            if config.workflow.run_reconall:
+                from niworkflows.utils.misc import _copy_any
+                from templateflow import api
+
+                dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
+                _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aseg_dseg.tsv"))
+                _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aparcaseg_dseg.tsv"))
+        # errno = 0
+        finally:
+            from pkg_resources import resource_filename as pkgrf
+
+            from ..reports.core import generate_reports
+
+            # Generate reports phase
+            generate_reports(
+                config.execution.participant_label,
+                config.execution.session_id,
+                config.execution.nibabies_dir,
+                config.execution.run_uuid,
+                config=pkgrf("nibabies", "data/reports-spec.yml"),
+                packagename="nibabies",
+            )
+            write_derivative_description(config.execution.bids_dir, config.execution.nibabies_dir)
+            write_bidsignore(config.execution.nibabies_dir)
 
 
 if __name__ == "__main__":

--- a/nibabies/cli/workflow.py
+++ b/nibabies/cli/workflow.py
@@ -10,7 +10,7 @@ a hard-limited memory-scope.
 """
 
 
-def build_workflow():
+def build_workflow(config_file):
     """Create the Nipype Workflow that supports the whole execution graph."""
     from niworkflows.utils.bids import check_pipeline_version, collect_participants
     from niworkflows.utils.misc import check_valid_fs_license
@@ -20,6 +20,8 @@ def build_workflow():
     from ..utils.misc import check_deps
     from ..workflows.base import init_nibabies_wf
 
+    # initalize config
+    config.load(config_file)
     build_logger = config.loggers.workflow
 
     nibabies_dir = config.execution.nibabies_dir

--- a/nibabies/cli/workflow.py
+++ b/nibabies/cli/workflow.py
@@ -10,7 +10,7 @@ a hard-limited memory-scope.
 """
 
 
-def build_workflow(config_file, retval):
+def build_workflow():
     """Create the Nipype Workflow that supports the whole execution graph."""
     from niworkflows.utils.bids import check_pipeline_version, collect_participants
     from niworkflows.utils.misc import check_valid_fs_license
@@ -20,19 +20,17 @@ def build_workflow(config_file, retval):
     from ..utils.misc import check_deps
     from ..workflows.base import init_nibabies_wf
 
-    config.load(config_file)
-    build_log = config.loggers.workflow
+    build_logger = config.loggers.workflow
 
     nibabies_dir = config.execution.nibabies_dir
     version = config.environment.version
 
-    retval["return_code"] = 1
-    retval["workflow"] = None
+    retval = {"return_code": 1, "workflow": None}
 
     # warn if older results exist: check for dataset_description.json in output folder
     msg = check_pipeline_version(version, nibabies_dir / "dataset_description.json")
     if msg is not None:
-        build_log.warning(msg)
+        build_logger.warning(msg)
 
     # Please note this is the input folder's dataset_description.json
     dset_desc_path = config.execution.bids_dir / "dataset_description.json"
@@ -57,7 +55,7 @@ def build_workflow(config_file, retval):
     if config.execution.reports_only:
         from pkg_resources import resource_filename as pkgrf
 
-        build_log.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
+        build_logger.log(25, "Running --reports-only on participants %s", ", ".join(subject_list))
         retval["return_code"] = generate_reports(
             subject_list,
             nibabies_dir,
@@ -82,13 +80,13 @@ def build_workflow(config_file, retval):
     if config.execution.fs_subjects_dir:
         init_msg += f"""
       * Pre-run FreeSurfer's SUBJECTS_DIR: {config.execution.fs_subjects_dir}."""
-    build_log.log(25, init_msg)
+    build_logger.log(25, init_msg)
 
     retval["workflow"] = init_nibabies_wf(subjects_sessions)
 
     # Check for FS license after building the workflow
     if not check_valid_fs_license():
-        build_log.critical(
+        build_logger.critical(
             """\
 ERROR: a valid license file is required for FreeSurfer to run. nibabies looked for an existing \
 license file at several paths, in this order: 1) command line argument ``--fs-license-file``; \
@@ -101,15 +99,15 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     # Check workflow for missing commands
     missing = check_deps(retval["workflow"])
     if missing:
-        build_log.critical(
+        build_logger.critical(
             "Cannot run nibabies. Missing dependencies:%s",
             "\n\t* ".join([""] + [f"{cmd} (Interface: {iface})" for iface, cmd in missing]),
         )
         retval["return_code"] = 127  # 127 == command not found.
         return retval
 
-    config.to_filename(config_file)
-    build_log.info(
+    # config.to_filename(config_file)
+    build_logger.info(
         "NiBabies workflow graph with %d nodes built successfully.",
         len(retval["workflow"]._get_all_nodes()),
     )
@@ -117,11 +115,10 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     return retval
 
 
-def build_boilerplate(config_file, workflow):
+def build_boilerplate(workflow):
     """Write boilerplate in an isolated process."""
     from .. import config
 
-    config.load(config_file)
     logs_path = config.execution.nibabies_dir / "logs"
     boilerplate = workflow.visit_desc()
     citation_files = {ext: logs_path / f"CITATION.{ext}" for ext in ("bib", "tex", "md", "html")}

--- a/nibabies/cli/workflow.py
+++ b/nibabies/cli/workflow.py
@@ -124,9 +124,7 @@ def build_boilerplate(config_file, workflow):
     config.load(config_file)
     logs_path = config.execution.nibabies_dir / "logs"
     boilerplate = workflow.visit_desc()
-    citation_files = {
-        ext: logs_path / ("CITATION.%s" % ext) for ext in ("bib", "tex", "md", "html")
-    }
+    citation_files = {ext: logs_path / f"CITATION.{ext}" for ext in ("bib", "tex", "md", "html")}
 
     if boilerplate:
         # To please git-annex users and also to guarantee consistency

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -517,6 +517,8 @@ class workflow(_Config):
 
     age_months = None
     """Age (in months)"""
+    analysis_level = "participant"
+    """Level of analysis."""
     anat_only = False
     """Execute the anatomical preprocessing only."""
     aroma_err_on_warn = None

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -80,7 +80,7 @@ except ImportError:
     # <= 3.7
     from importlib_metadata import version as get_version
 
-__version__ = get_version("mriqc")
+__version__ = get_version("nibabies")
 _pre_exec_env = dict(os.environ)
 
 # Disable NiPype etelemetry always

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -68,54 +68,39 @@ The :py:mod:`config` is responsible for other conveniency actions.
 
 """
 import os
+import random
 import sys
-from multiprocessing import set_start_method
+from pathlib import Path
+from time import strftime
+from uuid import uuid4
+
+try:
+    from importlib.metadata import version as get_version
+except ImportError:
+    # <= 3.7
+    from importlib_metadata import version as get_version
+
+__version__ = get_version("mriqc")
+_pre_exec_env = dict(os.environ)
 
 # Disable NiPype etelemetry always
 _disable_et = bool(os.getenv("NO_ET") is not None or os.getenv("NIPYPE_NO_ET") is not None)
 os.environ["NIPYPE_NO_ET"] = "1"
 os.environ["NO_ET"] = "1"
 
-CONFIG_FILENAME = "nibabies.toml"
-
-try:
-    set_start_method("forkserver")
-except RuntimeError:
-    pass  # context has been already set
-finally:
-    # Defer all custom import for after initializing the forkserver and
-    # ignoring the most annoying warnings
-    import random
-    from pathlib import Path
-    from time import strftime
-    from uuid import uuid4
-
-    from nipype import __version__ as _nipype_ver
-    from templateflow import __version__ as _tf_ver
-
-    from . import __version__
-
-if not hasattr(sys, "_is_pytest_session"):
-    sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
-# Disable all warnings in main and children processes only on production versions
-if not any(
-    (
-        "+" in __version__,
-        __version__.endswith(".dirty"),
-        os.getenv("NIBABIES_DEV", "0").lower() in ("1", "on", "true", "y", "yes"),
-    )
-):
-    from ._warnings import logging
-
-    os.environ["PYTHONWARNINGS"] = "ignore"
-elif os.getenv("NIBABIES_WARNINGS", "0").lower() in ("1", "on", "true", "y", "yes"):
-    # allow disabling warnings on development versions
-    # https://github.com/nipreps/fmriprep/pull/2080#discussion_r409118765
-    from ._warnings import logging
-
-    os.environ["PYTHONWARNINGS"] = "ignore"
-else:
+_yes_flags = ("1", "on", "true", "y", "yes")
+# Only show warnings if requested
+if os.getenv("NIBABIES_SHOW_WARNINGS", "0").lower() in _yes_flags:
     import logging
+else:
+    from ._warnings import logging
+
+    if not hasattr(sys, "_is_pytest_session"):
+        sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
+
+    if not "+" in __version__ or __version__.endswith(".dirty"):
+        # Disable all warnings in main and children processes only on production versions
+        os.environ["PYTHONWARNINGS"] = "ignore"
 
 logging.addLevelName(25, "IMPORTANT")  # Add a new level between INFO and WARNING
 logging.addLevelName(15, "VERBOSE")  # Add a new level between INFO and DEBUG
@@ -143,7 +128,7 @@ if os.getenv("IS_DOCKER_8395080871"):
     _cgroup = Path("/proc/1/cgroup")
     if _cgroup.exists() and "docker" in _cgroup.read_text():
         _docker_ver = os.getenv("DOCKER_VERSION_8395080871")
-        _exec_env = "nibabies-docker" if _docker_ver else "docker"
+        _exec_env = "docker"
     del _cgroup
 
 _fs_license = os.getenv("FS_LICENSE")
@@ -153,9 +138,7 @@ if not _fs_license and os.getenv("FREESURFER_HOME"):
         _fs_license = str(Path(_fs_home) / "license.txt")
     del _fs_home
 
-_templateflow_home = Path(
-    os.getenv("TEMPLATEFLOW_HOME", os.path.join(os.getenv("HOME"), ".cache", "templateflow"))
-)
+_templateflow_home = Path(os.getenv("TEMPLATEFLOW_HOME", Path.home() / ".cache" / "templateflow"))
 
 try:
     from psutil import virtual_memory
@@ -182,6 +165,32 @@ try:
 except Exception:
     pass
 
+_memory_gb = None
+try:
+    if "linux" in sys.platform:
+        with open("/proc/meminfo", "r") as f_in:
+            _meminfo_lines = f_in.readlines()
+            _mem_total_line = [line for line in _meminfo_lines if "MemTotal" in line][0]
+            _mem_total = float(_mem_total_line.split()[1])
+            _memory_gb = _mem_total / (1024.0**2)
+    elif "darwin" in sys.platform:
+        _mem_str = os.popen("sysctl hw.memsize").read().strip().split(" ")[-1]
+        _memory_gb = float(_mem_str) / (1024.0**3)
+except Exception:
+    pass
+
+_available_cpus = os.cpu_count()
+# attempt a more accurate CPU count (PID restriction, etc)
+try:
+    import psutil
+
+    _available_cpus = len(psutil.Process().cpu_affinity())
+except (AttributeError, ImportError, NotImplementedError):
+    if hasattr(os, "sched_getaffinity"):
+        _available_cpus = len(os.sched_getaffinity(0))
+
+# Reduce numpy's vms by limiting OMP_NUM_THREADS
+_default_omp_threads = int(os.getenv("OMP_NUM_THREADS", _available_cpus))
 
 # Debug modes are names that influence the exposure of internal details to
 # the user, either through additional derivatives or increased verbosity
@@ -265,12 +274,14 @@ class environment(_Config):
     """Linux's kernel virtual memory overcommit policy."""
     overcommit_limit = _oc_limit
     """Linux's kernel virtual memory overcommit limits."""
-    nipype_version = _nipype_ver
+    nipype_version = get_version("nipype")
     """Nipype's current version."""
-    templateflow_version = _tf_ver
+    templateflow_version = get_version("templateflow")
     """The TemplateFlow client version installed."""
     version = __version__
     """*NiBabies*'s version."""
+    _pre_env = _pre_exec_env
+    """Environmental variables set prior to execution."""
 
 
 class nipype(_Config):
@@ -282,9 +293,9 @@ class nipype(_Config):
     """Run NiPype's tool to enlist linked libraries for every interface."""
     memory_gb = None
     """Estimation in GB of the RAM this workflow can allocate at any given time."""
-    nprocs = os.cpu_count()
+    nprocs = _available_cpus
     """Number of processes (compute tasks) that can be run in parallel (multiprocessing only)."""
-    omp_nthreads = None
+    omp_nthreads = _default_omp_threads
     """Number of CPUs a single process can access for multithreaded execution."""
     plugin = "MultiProc"
     """NiPype's execution plugin."""
@@ -745,3 +756,20 @@ def init_spaces(checkpoint=True):
 
     # Make the SpatialReferences object available
     workflow.spaces = spaces
+
+
+def _process_initializer(cwd, omp_nthreads):
+    """Initialize the environment of the child process."""
+    os.chdir(cwd)
+    os.environ["NIPYPE_NO_ET"] = "1"
+    os.environ["OMP_NUM_THREADS"] = f"{omp_nthreads}"
+
+
+def restore_env():
+    """Restore the original environment."""
+
+    for k in os.environ.keys():
+        if k in environment._pre_env:
+            os.environ[k] = environment._pre_env[k]
+        else:
+            del os.environ[k]

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -98,7 +98,7 @@ else:
     if not hasattr(sys, "_is_pytest_session"):
         sys._is_pytest_session = False  # Trick to avoid sklearn's FutureWarnings
 
-    if not "+" in __version__ or __version__.endswith(".dirty"):
+    if "+" not in __version__ or not __version__.endswith(".dirty"):
         # Disable all warnings in main and children processes only on production versions
         os.environ["PYTHONWARNINGS"] = "ignore"
 

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -506,9 +506,7 @@ class execution(_Config):
 # These variables are not necessary anymore
 del _fs_license
 del _exec_env
-del _nipype_ver
 del _templateflow_home
-del _tf_ver
 del _free_mem_at_start
 del _oc_limit
 del _oc_policy


### PR DESCRIPTION
- Builds workflow / boilerplate within the same process, which will greatly simplify debugging. 
- Less warnings by default, but can be re-added setting the `NIBABIES_SHOW_WARNINGS` envvar to a true value.
- Set `OMP_NUM_THREADS` envvar to 1 when constructing the workflow. This has been shown to greatly reduce VMS (see nipreps/mriqc#984)