### PR TITLE
FIX: Vastly improve multi-echo handling

### DIFF
--- a/nibabies/interfaces/multiecho.py
+++ b/nibabies/interfaces/multiecho.py
@@ -1,7 +1,25 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
 """
 Multi-echo EPI
 ~~~~~~~~~~~~~~
@@ -19,49 +37,45 @@ import os
 
 from nipype import logging
 from nipype.interfaces.base import (
-    CommandLine,
-    CommandLineInputSpec,
-    File,
-    TraitedSpec,
-    traits,
-)
+    traits, TraitedSpec, File,
+    CommandLine, CommandLineInputSpec)
 
-LOGGER = logging.getLogger("nipype.interface")
+LOGGER = logging.getLogger('nipype.interface')
 
 
 class T2SMapInputSpec(CommandLineInputSpec):
-    in_files = traits.List(
-        File(exists=True),
-        argstr="-d %s",
-        position=1,
-        mandatory=True,
-        minlen=3,
-        desc="multi-echo BOLD EPIs",
-    )
-    echo_times = traits.List(
-        traits.Float, argstr="-e %s", position=2, mandatory=True, minlen=3, desc="echo times"
-    )
-    fittype = traits.Enum(
-        "curvefit",
-        "loglin",
-        argstr="--fittype %s",
-        position=3,
-        usedefault=True,
-        desc=(
-            "Desired fitting method: "
-            '"loglin" means that a linear model is fit '
-            "to the log of the data. "
-            '"curvefit" means that a more computationally '
-            "demanding monoexponential model is fit "
-            "to the raw data."
-        ),
-    )
+    in_files = traits.List(File(exists=True),
+                           argstr='-d %s',
+                           position=1,
+                           mandatory=True,
+                           minlen=3,
+                           desc='multi-echo BOLD EPIs')
+    echo_times = traits.List(traits.Float,
+                             argstr='-e %s',
+                             position=2,
+                             mandatory=True,
+                             minlen=3,
+                             desc='echo times')
+    mask_file = File(argstr='--mask %s',
+                     position=3,
+                     desc='mask file',
+                     exists=True)
+    fittype = traits.Enum('curvefit', 'loglin',
+                          argstr='--fittype %s',
+                          position=4,
+                          usedefault=True,
+                          desc=('Desired fitting method: '
+                                '"loglin" means that a linear model is fit '
+                                'to the log of the data. '
+                                '"curvefit" means that a more computationally '
+                                'demanding monoexponential model is fit '
+                                'to the raw data.'))
 
 
 class T2SMapOutputSpec(TraitedSpec):
-    t2star_map = File(exists=True, desc="limited T2* map")
-    s0_map = File(exists=True, desc="limited S0 map")
-    optimal_comb = File(exists=True, desc="optimally combined ME-EPI time series")
+    t2star_map = File(exists=True, desc='limited T2* map')
+    s0_map = File(exists=True, desc='limited S0 map')
+    optimal_comb = File(exists=True, desc='optimally combined ME-EPI time series')
 
 
 class T2SMap(CommandLine):
@@ -71,32 +85,30 @@ class T2SMap(CommandLine):
 
     Example
     =======
-    >>> from nibabies.interfaces import multiecho
+    >>> from fmriprep.interfaces import multiecho
     >>> t2smap = multiecho.T2SMap()
-    >>> t2smap.inputs.in_files = [
-    ...     data_dir / 'sub-01_run-01_echo-1_bold.nii.gz',
-    ...     data_dir / 'sub-01_run-01_echo-2_bold.nii.gz',
-    ...     data_dir / 'sub-01_run-01_echo-3_bold.nii.gz']
+    >>> t2smap.inputs.in_files = ['sub-01_run-01_echo-1_bold.nii.gz', \
+                                  'sub-01_run-01_echo-2_bold.nii.gz', \
+                                  'sub-01_run-01_echo-3_bold.nii.gz']
     >>> t2smap.inputs.echo_times = [0.013, 0.027, 0.043]
-    >>> t2smap.cmdline
-    't2smap -d .../sub-01_run-01_echo-1_bold.nii.gz \
-    .../sub-01_run-01_echo-2_bold.nii.gz \
-    .../sub-01_run-01_echo-3_bold.nii.gz -e 13.0 27.0 43.0 --fittype curvefit'
-    """
+    >>> t2smap.cmdline  # doctest: +ELLIPSIS
+    't2smap -d sub-01_run-01_echo-1_bold.nii.gz sub-01_run-01_echo-2_bold.nii.gz \
+sub-01_run-01_echo-3_bold.nii.gz -e 13.0 27.0 43.0 --fittype curvefit'
 
-    _cmd = "t2smap"
+    """
+    _cmd = 't2smap'
     input_spec = T2SMapInputSpec
     output_spec = T2SMapOutputSpec
 
     def _format_arg(self, name, trait_spec, value):
-        if name == "echo_times":
+        if name == 'echo_times':
             value = [te * 1000 for te in value]
         return super(T2SMap, self)._format_arg(name, trait_spec, value)
 
     def _list_outputs(self):
         outputs = self._outputs().get()
         out_dir = os.getcwd()
-        outputs["t2star_map"] = os.path.join(out_dir, "T2starmap.nii.gz")
-        outputs["s0_map"] = os.path.join(out_dir, "S0map.nii.gz")
-        outputs["optimal_comb"] = os.path.join(out_dir, "desc-optcom_bold.nii.gz")
+        outputs['t2star_map'] = os.path.join(out_dir, 'T2starmap.nii.gz')
+        outputs['s0_map'] = os.path.join(out_dir, 'S0map.nii.gz')
+        outputs['optimal_comb'] = os.path.join(out_dir, 'desc-optcom_bold.nii.gz')
         return outputs

--- a/nibabies/interfaces/multiecho.py
+++ b/nibabies/interfaces/multiecho.py
@@ -37,39 +37,52 @@ import os
 
 from nipype import logging
 from nipype.interfaces.base import (
-    traits, TraitedSpec, File,
-    CommandLine, CommandLineInputSpec)
+    CommandLine,
+    CommandLineInputSpec,
+    File,
+    TraitedSpec,
+    traits,
+)
 
 LOGGER = logging.getLogger('nipype.interface')
 
 
 class T2SMapInputSpec(CommandLineInputSpec):
-    in_files = traits.List(File(exists=True),
-                           argstr='-d %s',
-                           position=1,
-                           mandatory=True,
-                           minlen=3,
-                           desc='multi-echo BOLD EPIs')
-    echo_times = traits.List(traits.Float,
-                             argstr='-e %s',
-                             position=2,
-                             mandatory=True,
-                             minlen=3,
-                             desc='echo times')
-    mask_file = File(argstr='--mask %s',
-                     position=3,
-                     desc='mask file',
-                     exists=True)
-    fittype = traits.Enum('curvefit', 'loglin',
-                          argstr='--fittype %s',
-                          position=4,
-                          usedefault=True,
-                          desc=('Desired fitting method: '
-                                '"loglin" means that a linear model is fit '
-                                'to the log of the data. '
-                                '"curvefit" means that a more computationally '
-                                'demanding monoexponential model is fit '
-                                'to the raw data.'))
+    in_files = traits.List(
+        File(exists=True),
+        argstr='-d %s',
+        position=1,
+        mandatory=True,
+        minlen=3,
+        desc='multi-echo BOLD EPIs',
+    )
+    echo_times = traits.List(
+        traits.Float,
+        argstr='-e %s',
+        position=2,
+        mandatory=True,
+        minlen=3,
+        desc='echo times',
+    )
+    mask_file = File(
+        argstr='--mask %s',
+        position=3,
+        desc='mask file',
+        exists=True,
+    )
+    fittype = traits.Enum(
+        'curvefit',
+        'loglin',
+        argstr='--fittype %s',
+        position=4,
+        usedefault=True,
+        desc='Desired fitting method: '
+        '"loglin" means that a linear model is fit '
+        'to the log of the data. '
+        '"curvefit" means that a more computationally '
+        'demanding monoexponential model is fit '
+        'to the raw data.',
+    )
 
 
 class T2SMapOutputSpec(TraitedSpec):
@@ -85,7 +98,7 @@ class T2SMap(CommandLine):
 
     Example
     =======
-    >>> from fmriprep.interfaces import multiecho
+    >>> from nibabies.interfaces import multiecho
     >>> t2smap = multiecho.T2SMap()
     >>> t2smap.inputs.in_files = ['sub-01_run-01_echo-1_bold.nii.gz', \
                                   'sub-01_run-01_echo-2_bold.nii.gz', \
@@ -96,6 +109,7 @@ class T2SMap(CommandLine):
 sub-01_run-01_echo-3_bold.nii.gz -e 13.0 27.0 43.0 --fittype curvefit'
 
     """
+
     _cmd = 't2smap'
     input_spec = T2SMapInputSpec
     output_spec = T2SMapOutputSpec

--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -6,7 +6,7 @@ import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import IO, Union
+from typing import IO, List, Union
 
 
 @dataclass
@@ -17,7 +17,7 @@ class BOLDGrouping:
     pe_dir: str
     readout: float
     multiecho_id: str = None
-    files: list[IO] = field(default_factory=list)
+    files: List[IO] = field(default_factory=list)
 
     @property
     def name(self) -> str:

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -428,7 +428,7 @@ tasks and sessions), the following preprocessing was performed.
     bold_groupings = group_bolds_ref(
         layout=config.execution.layout,
         subject=subject_id,
-        session_id=session_id,
+        sessions=session_id,
     )
 
     func_preproc_wfs = []

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -400,7 +400,7 @@ It is released under the [CC0]\
         fmap_estimators = find_estimators(
             layout=config.execution.layout,
             subject=subject_id,
-            sessions=session_id,
+            sessions=[session_id],
             fmapless=False,  # config.workflow.use_syn,
             force_fmapless=False,  # config.workflow.force_syn,
         )
@@ -428,12 +428,12 @@ tasks and sessions), the following preprocessing was performed.
     bold_groupings = group_bolds_ref(
         layout=config.execution.layout,
         subject=subject_id,
-        sessions=session_id,
+        sessions=[session_id],
     )
 
     func_preproc_wfs = []
     has_fieldmap = bool(fmap_estimators)
-    for idx, grouping in enumerate(bold_groupings):
+    for idx, grouping in enumerate(bold_groupings.values()):
         bold_ref_wf = init_epi_reference_wf(
             auto_bold_nss=True,
             name=f"bold_reference_wf{idx}",

--- a/nibabies/workflows/bold/t2s.py
+++ b/nibabies/workflows/bold/t2s.py
@@ -68,10 +68,7 @@ echoes following the method described in [@posse_t2s].
 The optimally combined time series was carried forward as the *preprocessed BOLD*.
 """
 
-    inputnode = pe.Node(
-        niu.IdentityInterface(fields=["bold_file", "bold_mask"]),
-        name="inputnode"
-    )
+    inputnode = pe.Node(niu.IdentityInterface(fields=["bold_file", "bold_mask"]), name="inputnode")
 
     outputnode = pe.Node(niu.IdentityInterface(fields=["bold"]), name="outputnode")
 

--- a/nibabies/workflows/bold/t2s.py
+++ b/nibabies/workflows/bold/t2s.py
@@ -68,7 +68,10 @@ echoes following the method described in [@posse_t2s].
 The optimally combined time series was carried forward as the *preprocessed BOLD*.
 """
 
-    inputnode = pe.Node(niu.IdentityInterface(fields=["bold_file"]), name="inputnode")
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=["bold_file", "bold_mask"]),
+        name="inputnode"
+    )
 
     outputnode = pe.Node(niu.IdentityInterface(fields=["bold"]), name="outputnode")
 
@@ -78,7 +81,8 @@ The optimally combined time series was carried forward as the *preprocessed BOLD
 
     # fmt: off
     workflow.connect([
-        (inputnode, t2smap_node, [('bold_file', 'in_files')]),
+        (inputnode, t2smap_node, [('bold_file', 'in_files'),
+                                  ('bold_mask', 'mask_file')]),
         (t2smap_node, outputnode, [('optimal_comb', 'bold')]),
     ])
     # fmt: on

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     scipy ~= 1.6.0; python_version<'3.8'
     sdcflows @ git+https://github.com/nipreps/sdcflows.git@master
     smriprep ~= 0.8.1
+    tedana ~= 0.0.12
     templateflow >= 0.6.0
     toml
 test_requires =


### PR DESCRIPTION
Closes #210. Multiecho support has been extremely limited due to a lack of test data. Now that we have access to some data, this PR expands nibabies capabilities.

## Rework
- The `group_bolds_ref` function has been reworked to use a new class, `BOLDGrouping`, to facilitate support for binning both single/multi-echo BOLD data.
This allows the passing of multiple BOLD files to the functional preprocessing workflow, which differs from the current implementation of passing each echo separately. Since each echo was passed as its own workflow, no optimal combination was occuring.

## Additions
- Adds `tedana` as a dependency. 

## TODO
In a separate PR, add in T2starmap output resampling, which have recently been added to fMRIPrep.
