### PR TITLE
FIX: FSNative <-> anatomical transforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,7 +208,7 @@ ENV FSLDIR="/opt/fsl" \
     LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH"
 
 # Install FreeSurfer
-COPY --from=mgxd/freesurfer@sha256:0cff94b8e3126a7e10bcecb89712c0852ca0d0aaf04d56e670151558f7b4715a /opt/freesurfer /opt/freesurfer
+COPY --from=nipreps/freesurfer@sha256:2ddc13f0a07b09e282a85d0a1aa715967841b1f4b734371dde98da1d1e87bed8 /opt/freesurfer /opt/freesurfer
 ENV FREESURFER_HOME="/opt/freesurfer"
 ENV SUBJECTS_DIR="$FREESURFER_HOME/subjects" \
     FUNCTIONALS_DIR="$FREESURFER_HOME/sessions" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -208,27 +208,7 @@ ENV FSLDIR="/opt/fsl" \
     LD_LIBRARY_PATH="/opt/fsl/lib:$LD_LIBRARY_PATH"
 
 # Install FreeSurfer
-RUN apt update && \
-    apt-get install -y --no-install-recommends \
-            bc \
-            libgomp1 \
-            perl \
-            tar \
-            tcsh \
-            wget \
-            vim-common \
-            libgl1-mesa-dev \
-            libsm-dev \
-            libxrender-dev \
-            libxmu-dev \
-            unzip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && echo "Downloading FreeSurfer + InfantFS" \
-    && mkdir -p /opt/freesurfer \
-    && curl -fSLO --retry 5 https://github.com/nipreps-containers/freesurfer/releases/download/infant-min-4a14499-fix/infant-freesurfer_dev-4a14499-min.zip \
-    && unzip infant-freesurfer_dev-4a14499-min.zip -d /opt \
-    && rm infant-freesurfer_dev-4a14499-min.zip
+COPY --from=mgxd/freesurfer@sha256:0cff94b8e3126a7e10bcecb89712c0852ca0d0aaf04d56e670151558f7b4715a /opt/freesurfer /opt/freesurfer
 ENV FREESURFER_HOME="/opt/freesurfer"
 ENV SUBJECTS_DIR="$FREESURFER_HOME/subjects" \
     FUNCTIONALS_DIR="$FREESURFER_HOME/sessions" \

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -55,7 +55,11 @@ leveraging the masked, preprocessed T1w and anatomical segmentation.
 
     # inject the intensity-normalized skull-stripped t1w from the brain extraction workflow
     recon = pe.Node(InfantReconAll(age=age_months), name="reconall")
-    fssource = pe.Node(nio.FreeSurferSource(), name='fssource')
+    fssource = pe.Node(
+        nio.FreeSurferSource(),
+        name='fssource',
+        run_without_submitting=True
+    )
 
     fsnative2anat_xfm = pe.Node(
         RobustRegister(auto_sens=True, est_int_scale=True),
@@ -105,17 +109,17 @@ leveraging the masked, preprocessed T1w and anatomical segmentation.
         ]),
         (inputnode, fsnative2anat_xfm, [('anat_skullstripped', 'target_file')]),
         (fssource, fsnative2anat_xfm, [
-            (('norm', _replace_mgz), 'source_file')
-        ])
+            (('norm', _replace_mgz), 'source_file'),
+        ]),
         (fsnative2anat_xfm, anat2fsnative_xfm, [('out_reg_file', 'in_lta')]),
         (fssource, aparc2nii, [
-            ('aseg_aparc', 'in_file'),
+            ('aparc_aseg', 'in_file'),
         ]),
         (aparc2nii, outputnode, [
             ('out_file', 'anat_aparc'),
         ]),
         (fsnative2anat_xfm, outputnode, [
-            ('out', 'fsnative2anat_xfm'),
+            ('out_reg_file', 'fsnative2anat_xfm'),
         ]),
         (anat2fsnative_xfm, outputnode, [
             ('out_lta', 'anat2fsnative_xfm'),

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -55,11 +55,7 @@ leveraging the masked, preprocessed T1w and anatomical segmentation.
 
     # inject the intensity-normalized skull-stripped t1w from the brain extraction workflow
     recon = pe.Node(InfantReconAll(age=age_months), name="reconall")
-    fssource = pe.Node(
-        nio.FreeSurferSource(),
-        name='fssource',
-        run_without_submitting=True
-    )
+    fssource = pe.Node(nio.FreeSurferSource(), name='fssource', run_without_submitting=True)
 
     fsnative2anat_xfm = pe.Node(
         RobustRegister(auto_sens=True, est_int_scale=True),

--- a/nibabies/workflows/bold/registration.py
+++ b/nibabies/workflows/bold/registration.py
@@ -137,17 +137,20 @@ def init_bold_reg_wf(
         name="outputnode",
     )
 
-    # MG: Default to FSL FLIRT to avoid https://github.com/nipreps/nibabies/issues/97
-    # if freesurfer:
-    #     bbr_wf = init_bbreg_wf(use_bbr=use_bbr, bold2t1w_dof=bold2t1w_dof,
-    #                            bold2t1w_init=bold2t1w_init, omp_nthreads=omp_nthreads)
-    # else:
-    bbr_wf = init_fsl_bbr_wf(
-        use_bbr=use_bbr,
-        bold2t1w_dof=bold2t1w_dof,
-        bold2t1w_init=bold2t1w_init,
-        sloppy=sloppy,
-    )
+    if freesurfer:
+        bbr_wf = init_bbreg_wf(
+            use_bbr=use_bbr,
+            bold2t1w_dof=bold2t1w_dof,
+            bold2t1w_init=bold2t1w_init,
+            omp_nthreads=omp_nthreads,
+        )
+    else:
+        bbr_wf = init_fsl_bbr_wf(
+            use_bbr=use_bbr,
+            bold2t1w_dof=bold2t1w_dof,
+            bold2t1w_init=bold2t1w_init,
+            sloppy=sloppy,
+        )
 
     # fmt: off
     workflow.connect([


### PR DESCRIPTION
Closes #222
Closes #97
Supersedes #171


This remedies the problem of incorrect anatomical to/from fsnative xforms. This is likely what we were seeing in #97, and by switching to the FSL BBR workflow, we were not using the `fsnative2anat_xfm` anymore.

## TODO
- [x] This will require bundling a new minimized freesurfer, since `mri_robust_register(.bin)` are not present in the current iteration.
- [x] Re-add FreeSurfer BBR workflow

