### PR TITLE
ENH: Add interface for reorienting images

### DIFF
--- a/nibabies/interfaces/nibabel.py
+++ b/nibabies/interfaces/nibabel.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+from nipype.interfaces.base import (
+    BaseInterfaceInputSpec,
+    File,
+    SimpleInterface,
+    TraitedSpec,
+    traits,
+)
+
+
+class ReorientImageInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="Moving file")
+    target_file = File(
+        exists=True, xor=["target_orientation"], desc="Reference file to reorient to"
+    )
+    target_orientation = traits.Str(
+        xor=["target_file"], desc="Axis codes of coordinate system to reorient to"
+    )
+
+
+class ReorientImageOutputSpec(TraitedSpec):
+    out_file = File(desc="Reoriented file")
+
+
+class ReorientImage(SimpleInterface):
+    input_spec = ReorientImageInputSpec
+    output_spec = ReorientImageOutputSpec
+
+    def _run_interface(self, runtime):
+        self._results["out_file"] = reorient_image(
+            self.inputs.in_file,
+            target_file=self.inputs.target_file,
+            target_ornt=self.inputs.target_orientation,
+        )
+        return runtime
+
+
+def reorient_image(
+    in_file: str, *, target_file: str = None, target_ornt: str = None, newpath: str = None
+) -> str:
+    """
+    Reorient an image.
+
+    New orientation targets can be either another image, or a string representation of the
+    orientation axis.
+
+    Parameters
+    ----------
+    in_file : Image to be reoriented
+    target_file : Reference image of desired orientation
+    target_ornt : Orientation denoted by the first letter of each axis (i.e., "RAS", "LPI")
+    """
+    import nibabel as nb
+
+    img = nb.load(in_file)
+    img_axcodes = nb.aff2axcodes(img.affine)
+    in_ornt = nb.orientations.axcodes2ornt(img_axcodes)
+
+    if target_file:
+        target_img = nb.load(target_file)
+        target_ornt = nb.aff2axcodes(target_img.affine)
+
+    out_ornt = nb.orientations.axcodes2ornt(target_ornt)
+    ornt_xfm = nb.orientations.ornt_transform(in_ornt, out_ornt)
+    reoriented = img.as_reoriented(ornt_xfm)
+
+    if newpath is None:
+        newpath = Path()
+    out_file = str((Path(newpath) / "reoriented.nii.gz").absolute())
+    reoriented.to_filename(out_file)
+    return out_file

--- a/nibabies/interfaces/tests/test_nibabel.py
+++ b/nibabies/interfaces/tests/test_nibabel.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from uuid import uuid4
+
+import nibabel as nb
+import numpy as np
+import pytest
+
+from ..nibabel import ReorientImage
+
+
+def create_save_img(ornt: str):
+    data = np.random.rand(2, 2, 2)
+    img = nb.Nifti1Image(data, affine=np.eye(4))
+    # img will alway be in RAS at the start
+    ras = nb.orientations.axcodes2ornt("RAS")
+    if ornt != 'RAS':
+        new = nb.orientations.axcodes2ornt(ornt)
+        xfm = nb.orientations.ornt_transform(ras, new)
+        img = img.as_reoriented(xfm)
+    out_file = f'{uuid4()}.nii.gz'
+    img.to_filename(out_file)
+    return out_file
+
+
+@pytest.mark.parametrize(
+    "in_ornt,out_ornt",
+    [
+        ("RAS", "RAS"),
+        ("RAS", "LAS"),
+        ("LAS", "RAS"),
+        ("RAS", "RPI"),
+        ("LPI", "RAS"),
+    ],
+)
+def test_reorient_image(tmpdir, in_ornt, out_ornt):
+    tmpdir.chdir()
+
+    in_file = create_save_img(ornt=in_ornt)
+    in_img = nb.load(in_file)
+    assert ''.join(nb.aff2axcodes(in_img.affine)) == in_ornt
+
+    # test string representation
+    res = ReorientImage(in_file=in_file, target_orientation=out_ornt).run()
+    out_file = res.outputs.out_file
+    out_img = nb.load(out_file)
+    assert ''.join(nb.aff2axcodes(out_img.affine)) == out_ornt
+    Path(out_file).unlink()
+
+    # test with target file
+    target_file = create_save_img(ornt=out_ornt)
+    target_img = nb.load(target_file)
+    assert ''.join(nb.aff2axcodes(target_img.affine)) == out_ornt
+    res = ReorientImage(in_file=in_file, target_file=target_file).run()
+    out_file = res.outputs.out_file
+    out_img = nb.load(out_file)
+    assert ''.join(nb.aff2axcodes(out_img.affine)) == out_ornt
+
+    # cleanup
+    for f in (in_file, target_file, out_file):
+        Path(f).unlink()

--- a/nibabies/workflows/bold/resampling.py
+++ b/nibabies/workflows/bold/resampling.py
@@ -640,6 +640,7 @@ def init_bold_grayords_wf(grayord_density, mem_gb, repetition_time, name="bold_g
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.utility import KeySelect
 
+    from ...interfaces.nibabel import ReorientImage
     from ...interfaces.workbench import CiftiCreateDenseTimeseries
 
     workflow = Workflow(name=name)
@@ -732,10 +733,13 @@ surface space.
         name="split_surfaces",
     )
 
+    reorient_data = pe.Node(ReorientImage(target_orientation="LAS"), name="reorient_data")
+    reorient_labels = reorient_data.clone(name="reorient_labels")
+
     gen_cifti = pe.Node(CiftiCreateDenseTimeseries(timestep=repetition_time), name="gen_cifti")
-    gen_cifti.inputs.volume_structure_labels = str(
-        tf.api.get("MNI152NLin6Asym", resolution=2, atlas="HCP", suffix="dseg")
-    )
+    # gen_cifti.inputs.volume_structure_labels = str(
+    #     tf.api.get("MNI152NLin6Asym", resolution=2, atlas="HCP", suffix="dseg")
+    # )
     gen_cifti.inputs.roi_left = tf.api.get(
         "fsLR", density=fslr_density, hemi="L", desc="nomedialwall", suffix="dparc"
     )
@@ -750,9 +754,10 @@ surface space.
 
     # fmt: off
     workflow.connect([
-        (inputnode, gen_cifti, [
-            ('subcortical_volume', 'volume_data'),
-            ('subcortical_labels', 'volume_structure_labels')]),
+        (inputnode, reorient_data, [("subcortical_volume", "in_file")]),
+        (inputnode, reorient_labels, [("subcortical_labels", "in_file")]),
+        (reorient_data, gen_cifti, [("out_file", "volume_data")]),
+        (reorient_labels, gen_cifti, [("out_file", "volume_structure_labels")]),
         (inputnode, select_fs_surf, [('surf_files', 'surf_files'),
                                      ('surf_refs', 'keys')]),
         (select_fs_surf, resample, [('surf_files', 'in_file')]),

--- a/nibabies/workflows/bold/resampling.py
+++ b/nibabies/workflows/bold/resampling.py
@@ -737,9 +737,6 @@ surface space.
     reorient_labels = reorient_data.clone(name="reorient_labels")
 
     gen_cifti = pe.Node(CiftiCreateDenseTimeseries(timestep=repetition_time), name="gen_cifti")
-    # gen_cifti.inputs.volume_structure_labels = str(
-    #     tf.api.get("MNI152NLin6Asym", resolution=2, atlas="HCP", suffix="dseg")
-    # )
     gen_cifti.inputs.roi_left = tf.api.get(
         "fsLR", density=fslr_density, hemi="L", desc="nomedialwall", suffix="dparc"
     )


### PR DESCRIPTION
Closes #228 

Adds a new interface `ReorientImage`, which should be ported to niworkflows, to handle reorientations. This interface is leveraged just before the CIFTI creation, to the subcortical volume and labels.