### PR TITLE
ENH: Prioritize sbrefs when creating BOLD reference image

### DIFF
--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -116,6 +116,7 @@ def group_bolds_ref(
     layout: BIDSLayout,
     subject: str,
     sessions: Optional[list] = None,
+    get_sbrefs: bool = True,
 ) -> dict:
     """
     Extracts BOLD files from a BIDS dataset and combines them into buckets.
@@ -195,7 +196,7 @@ def group_bolds_ref(
             if 'echo' in entities:
                 # create unique id by dropping "_echo-{i}"
                 multiecho_id = re.sub(r"_echo-\d+", "", bold.filename)
-            else:
+            elif get_sbrefs:
                 # search for an sbref
                 # due to lack of experience, avoid handling sbrefs with multi-echo data
                 entities['suffix'] = 'sbref'

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -435,14 +435,17 @@ tasks and sessions), the following preprocessing was performed.
     func_preproc_wfs = []
     has_fieldmap = bool(fmap_estimators)
     for idx, grouping in enumerate(bold_groupings.values()):
+        # the EPI reference workflow will take in either a list of BOLDS or SBRefs
+        has_sbrefs = bool(grouping.sbref_files)
         bold_ref_wf = init_epi_reference_wf(
-            auto_bold_nss=True,
+            auto_bold_nss=not has_sbrefs,
             name=f"bold_reference_wf{idx}",
             omp_nthreads=config.nipype.omp_nthreads,
         )
-        bold_files = grouping.files
-        bold_ref_wf.inputs.inputnode.in_files = grouping.files
+        # use sbrefs if available
+        bold_ref_wf.inputs.inputnode.in_files = grouping.sbref_files or grouping.files
 
+        bold_files = grouping.files
         if grouping.multiecho_id is not None:
             bold_files = [bold_files]
         for idx, bold_file in enumerate(bold_files):


### PR DESCRIPTION
Closes #247 

This PR reworks BOLD reference image creation.

- Adds a new parameter `get_sbrefs` to `group_bolds_ref()` which enables searching for a complimentary BOLD file. If found, the sbref file(s) found are to be used in the `init_epi_reference_wf()` instead of the BOLD file.