### PR TITLE
ENH: Runwise bold reference generation

### DIFF
--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -408,7 +408,7 @@ It is released under the [CC0]\
 
     # Append the functional section to the existing anatomical exerpt
     # That way we do not need to stream down the number of bold datasets
-    anat_preproc_wf.__postdesc__ = getattr(anat_preproc_wf, '__postdesc__', '')
+    anat_preproc_wf.__postdesc__ = getattr(anat_preproc_wf, '__postdesc__') or ''
     func_pre_desc = f"""
 
 Functional data preprocessing
@@ -423,7 +423,7 @@ tasks and sessions), the following preprocessing was performed."""
         if func_preproc_wf is None:
             continue
 
-        func_preproc_wf.__desc__ = func_pre_desc + getattr(func_preproc_wf, '__desc__', '')
+        func_preproc_wf.__desc__ = func_pre_desc + (getattr(func_preproc_wf, '__desc__') or '')
         # fmt:off
         workflow.connect([
             (anat_preproc_wf, func_preproc_wf, [

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -513,7 +513,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
     # Detect dummy scans
     nss_detector = pe.Node(NonsteadyStatesDetector(), name='nss_detector')
-    nss_detector.inputs.inputnode = bold_file
+    nss_detector.inputs.in_file = ref_file
 
     # SLICE-TIME CORRECTION (or bypass) #############################################
     if run_stc:

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -57,6 +57,7 @@ from ...interfaces import DerivativesDataSink
 from ...interfaces.reports import FunctionalSummary
 from ...utils.bids import extract_entities
 from ...utils.misc import combine_meepi_source
+from .boldref import init_infant_epi_reference_wf
 
 # BOLD workflows
 from .confounds import init_bold_confs_wf, init_carpetplot_wf
@@ -127,12 +128,6 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False, existing_derivatives=Non
         LTA-style affine matrix translating from T1w to FreeSurfer-conformed subject space
     fsnative2t1w_xfm
         LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
-    bold_ref
-        BOLD reference file
-    bold_ref_xfm
-        Transform file in LTA format from bold to reference
-    n_dummy_scans
-        Number of nonsteady states at the beginning of the BOLD run
 
     Outputs
     -------
@@ -177,6 +172,7 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False, existing_derivatives=Non
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    from niworkflows.interfaces.bold import NonsteadyStatesDetector
     from niworkflows.interfaces.nibabel import ApplyMask
     from niworkflows.interfaces.utility import DictMerge, KeySelect
     from niworkflows.workflows.epi.refmap import init_epi_reference_wf
@@ -244,9 +240,14 @@ def init_func_preproc_wf(bold_file, has_fieldmap=False, existing_derivatives=Non
     )
 
     # Find associated sbref, if possible
-    entities["suffix"] = "sbref"
-    entities["extension"] = [".nii", ".nii.gz"]  # Overwrite extensions
-    sbref_files = layout.get(scope="raw", return_type="file", **entities)
+    overrides = {
+        "suffix": "sbref",
+        "extension": [".nii", ".nii.gz"],
+    }
+    if config.execution.bids_filters:
+        overrides.update(config.execution.bids_filters.get('sbref', {}))
+    sb_ents = {**entities, **overrides}
+    sbref_files = layout.get(return_type="file", **sb_ents)
 
     sbref_msg = f"No single-band-reference found for {os.path.basename(ref_file)}."
     if sbref_files and "sbref" in config.workflow.ignore:
@@ -319,10 +320,6 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 "anat2std_xfm",
                 "std2anat_xfm",
                 "template",
-                # from bold reference workflow
-                "bold_ref",
-                "bold_ref_xfm",
-                "n_dummy_scans",
                 # from sdcflows (optional)
                 "fmap",
                 "fmap_ref",
@@ -514,12 +511,16 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     )
     bold_confounds_wf.get_node("inputnode").inputs.t1_transform_flags = [False]
 
+    # Detect dummy scans
+    nss_detector = pe.Node(NonsteadyStatesDetector(), name='nss_detector')
+    nss_detector.inputs.inputnode = bold_file
+
     # SLICE-TIME CORRECTION (or bypass) #############################################
     if run_stc:
         bold_stc_wf = init_bold_stc_wf(name="bold_stc_wf", metadata=metadata)
         # fmt:off
         workflow.connect([
-            (inputnode, bold_stc_wf, [('n_dummy_scans', 'inputnode.skip_vols')]),
+            (nss_detector, bold_stc_wf, [('n_dummy', 'inputnode.skip_vols')]),
             (select_bold, bold_stc_wf, [("out", 'inputnode.bold_file')]),
             (bold_stc_wf, boldbuffer, [('outputnode.stc_file', 'bold_file')]),
         ])
@@ -577,8 +578,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         name="bold_final",
     )
 
-    # Mask input BOLD reference image
-    initial_boldref_mask = pe.Node(BrainExtraction(), name="initial_boldref_mask")
+    # Create a reference image for the bold run
+    initial_boldref_wf = init_infant_epi_reference_wf(omp_nthreads, is_sbref=bool(sbref_files))
+    initial_boldref_wf.inputs.inputnode.epi_file = pop_file(sbref_files) or pop_file(bold_file)
 
     # This final boldref will be calculated after bold_bold_trans_wf, which includes one or more:
     # HMC (head motion correction)
@@ -602,8 +604,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         # BOLD buffer has slice-time corrected if it was run, original otherwise
         (boldbuffer, bold_split, [('bold_file', 'in_file')]),
         # HMC
-        (inputnode, bold_hmc_wf, [
-            ('bold_ref', 'inputnode.raw_ref_image')]),
+        (initial_boldref_wf, bold_hmc_wf, [
+            ('outputnode.boldref_file', 'inputnode.raw_ref_image')]),
         (validate_bolds, bold_hmc_wf, [
             (("out_file", pop_file), 'inputnode.bold_file')]),
         (bold_hmc_wf, outputnode, [
@@ -659,8 +661,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.rmsd_file', 'inputnode.rmsd_file')]),
         (bold_reg_wf, bold_confounds_wf, [
             ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
-        (inputnode, bold_confounds_wf, [
-            ('n_dummy_scans', 'inputnode.skip_vols')]),
+        (nss_detector, bold_confounds_wf, [
+            ('n_dummy', 'inputnode.skip_vols')]),
         (bold_final, bold_confounds_wf, [
             ('bold', 'inputnode.bold'),
             ('mask', 'inputnode.bold_mask'),
@@ -672,7 +674,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ('outputnode.tcompcor_mask', 'tcompcor_mask'),
         ]),
         # Summary
-        (inputnode, summary, [('n_dummy_scans', 'algo_dummy_scans')]),
+        (nss_detector, summary, [('n_dummy', 'algo_dummy_scans')]),
         (bold_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
         (outputnode, summary, [('confounds', 'confounds_file')]),
         # Select echo indices for original/validated BOLD files
@@ -874,8 +876,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                     ('bold_file', 'inputnode.name_source')]),
                 (bold_hmc_wf, ica_aroma_wf, [
                     ('outputnode.movpar_file', 'inputnode.movpar_file')]),
-                (inputnode, ica_aroma_wf, [
-                    ('n_dummy_scans', 'inputnode.skip_vols')]),
+                (nss_detector, ica_aroma_wf, [
+                    ('n_dummy', 'inputnode.skip_vols')]),
                 (bold_confounds_wf, join, [
                     ('outputnode.confounds_file', 'in_file')]),
                 (bold_confounds_wf, mrg_conf_metadata,
@@ -1051,9 +1053,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 ("outputnode.bold", "inputnode.in_files"),
             ]),
         ] if not multiecho else [
-            (inputnode, initial_boldref_mask, [('bold_ref', 'in_file')]),
-            (initial_boldref_mask, bold_t2s_wf, [
-                ("out_mask", "inputnode.bold_mask"),
+            (initial_boldref_wf, bold_t2s_wf, [
+                ("outputnode.boldref_mask", "inputnode.bold_mask"),
             ]),
             (bold_bold_trans_wf, join_echos, [
                 ("outputnode.bold", "bold_files"),
@@ -1125,14 +1126,13 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ("fmap_coeff", "inputnode.fmap_coeff"),
             ("fmap_mask", "inputnode.fmap_mask")]),
         (output_select, summary, [("sdc_method", "distortion_correction")]),
-        (inputnode, initial_boldref_mask, [('bold_ref', 'in_file')]),
-        (inputnode, coeff2epi_wf, [
-            ("bold_ref", "inputnode.target_ref")]),
-        (initial_boldref_mask, coeff2epi_wf, [
-            ("out_mask", "inputnode.target_mask")]),  # skull-stripped brain
+        (initial_boldref_wf, coeff2epi_wf, [
+            ("outputnode.boldref_file", "inputnode.target_ref")]),
+        (initial_boldref_wf, coeff2epi_wf, [
+            ("outputnode.boldref_mask", "inputnode.target_mask")]),  # skull-stripped brain
         (coeff2epi_wf, unwarp_wf, [
             ("outputnode.fmap_coeff", "inputnode.fmap_coeff")]),
-        (inputnode, sdc_report, [("bold_ref", "before")]),
+        (initial_boldref_wf, sdc_report, [("outputnode.boldref_file", "before")]),
         (bold_hmc_wf, unwarp_wf, [
             ("outputnode.xforms", "inputnode.hmc_xforms")]),
         (bold_split, unwarp_wf, [

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -580,7 +580,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
     # Create a reference image for the bold run
     initial_boldref_wf = init_infant_epi_reference_wf(omp_nthreads, is_sbref=bool(sbref_files))
-    initial_boldref_wf.inputs.inputnode.epi_file = pop_file(sbref_files) or pop_file(bold_file)
+    initial_boldref_wf.inputs.inputnode.epi_file = (
+        pop_file(sbref_files) if sbref_files else ref_file
+    )
 
     # This final boldref will be calculated after bold_bold_trans_wf, which includes one or more:
     # HMC (head motion correction)

--- a/nibabies/workflows/bold/boldref.py
+++ b/nibabies/workflows/bold/boldref.py
@@ -71,7 +71,7 @@ def init_infant_epi_reference_wf(
     # fmt:on
     if not is_sbref:
         select_frames = pe.Node(
-            niu.Function(function=_select_frames, output_names=['t_mask']),
+            niu.Function(function=_select_frames, output_names=['t_masks']),
             name='select_frames',
         )
         select_frames.inputs.start_frame = start_frame

--- a/nibabies/workflows/bold/boldref.py
+++ b/nibabies/workflows/bold/boldref.py
@@ -63,9 +63,9 @@ def init_infant_epi_reference_wf(
 
     # fmt:off
     wf.connect([
-        (inputnode, epi_reference_wf, [('epi_file', 'in_files')]),
-        (epi_reference_wf, boldref_mask, [('epi_ref_file', 'in_file')]),
-        (epi_reference_wf, outputnode, [('epi_ref_file', 'boldref_file')]),
+        (inputnode, epi_reference_wf, [('epi_file', 'inputnode.in_files')]),
+        (epi_reference_wf, boldref_mask, [('outputnode.epi_ref_file', 'in_file')]),
+        (epi_reference_wf, outputnode, [('outputnode.epi_ref_file', 'boldref_file')]),
         (boldref_mask, outputnode, [('out_mask', 'boldref_mask')]),
     ])
     # fmt:on
@@ -78,7 +78,7 @@ def init_infant_epi_reference_wf(
         # fmt:off
         wf.connect([
             (inputnode, select_frames, [('epi_file', 'in_file')]),
-            (select_frames, epi_reference_wf, [('t_mask', 't_mask')]),
+            (select_frames, epi_reference_wf, [('t_masks', 'inputnode.t_masks')]),
         ])
         # fmt:on
     return wf

--- a/nibabies/workflows/bold/boldref.py
+++ b/nibabies/workflows/bold/boldref.py
@@ -1,0 +1,97 @@
+import nipype.interfaces.utility as niu
+import nipype.pipeline.engine as pe
+
+
+def init_infant_epi_reference_wf(
+    omp_nthreads: int,
+    is_sbref: bool = False,
+    start_frame: int = 17,
+    name: str = 'infant_epi_reference_wf',
+) -> pe.Workflow:
+    """
+    Workflow to generate a reference map from one or more infant EPI images.
+
+    If any single-band references are provided, the reference map will be calculated from those.
+
+    If no single-band references are provided, the BOLD files are used.
+    To account for potential increased motion on the start of image acquisition, this
+    workflow discards a bigger chunk of the initial frames.
+
+    Parameters
+    ----------
+    omp_nthreads
+        Maximum number of threads an individual process may use
+    has_sbref
+        A single-band reference is provided.
+    start_frame
+        BOLD frame to start creating the reference map from. Any earlier frames are discarded.
+
+    Inputs
+    ------
+    bold_file
+        BOLD EPI file
+    sbref_file
+        single-band reference EPI
+
+    Outputs
+    -------
+    boldref_file
+        The generated reference map
+    boldref_mask
+        Binary brain mask of the ``boldref_file``
+    boldref_xfm
+        Rigid-body transforms in LTA format
+
+    """
+    from niworkflows.workflows.epi.refmap import init_epi_reference_wf
+    from sdcflows.interfaces.brainmask import BrainExtraction
+
+    wf = pe.Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['epi_file']),
+        name='inputnode',
+    )
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['boldref_file', 'boldref_mask']),
+        name='outputnode',
+    )
+
+    epi_reference_wf = init_epi_reference_wf(omp_nthreads)
+
+    boldref_mask = pe.Node(BrainExtraction(), name='boldref_mask')
+
+    # fmt:off
+    wf.connect([
+        (inputnode, epi_reference_wf, [('epi_file', 'in_files')]),
+        (epi_reference_wf, boldref_mask, [('epi_ref_file', 'in_file')]),
+        (epi_reference_wf, outputnode, [('epi_ref_file', 'boldref_file')]),
+        (boldref_mask, outputnode, [('out_mask', 'boldref_mask')]),
+    ])
+    # fmt:on
+    if not is_sbref:
+        select_frames = pe.Node(
+            niu.Function(function=_select_frames, output_names=['t_mask']),
+            name='select_frames',
+        )
+        select_frames.inputs.start_frame = start_frame
+        # fmt:off
+        wf.connect([
+            (inputnode, select_frames, [('epi_file', 'in_file')]),
+            (select_frames, epi_reference_wf, [('t_mask', 't_mask')]),
+        ])
+        # fmt:on
+    return wf
+
+
+def _select_frames(in_file: str, start_frame: int) -> list:
+    import nibabel as nb
+    import numpy as np
+
+    img = nb.load(in_file)
+    img_len = img.shape[3]
+    if start_frame >= img_len:
+        start_frame = img_len - 1
+    t_mask = np.array([False] * img_len, dtype=bool)
+    t_mask[start_frame:] = True
+    return list(t_mask)

--- a/nibabies/workflows/bold/stc.py
+++ b/nibabies/workflows/bold/stc.py
@@ -124,17 +124,13 @@ BOLD runs were slice-time corrected to {tzero:0.3g}s ({frac:g} of slice acquisit
 
     copy_xform = pe.Node(CopyXForm(), name="copy_xform", mem_gb=0.1)
 
-    workflow.connect(
-        [
-            (
-                inputnode,
-                slice_timing_correction,
-                [("bold_file", "in_file"), ("skip_vols", "ignore")],
-            ),
-            (slice_timing_correction, copy_xform, [("out_file", "in_file")]),
-            (inputnode, copy_xform, [("bold_file", "hdr_file")]),
-            (copy_xform, outputnode, [("out_file", "stc_file")]),
-        ]
-    )
-
+    # fmt:off
+    workflow.connect([
+        (inputnode, slice_timing_correction, [("bold_file", "in_file"),
+                                              ("skip_vols", "ignore")]),
+        (slice_timing_correction, copy_xform, [("out_file", "in_file")]),
+        (inputnode, copy_xform, [("bold_file", "hdr_file")]),
+        (copy_xform, outputnode, [("out_file", "stc_file")]),
+    ])
+    # fmt:on
     return workflow


### PR DESCRIPTION
Closes #253 

This PR reverts bold reference generation to being calculated per run.

Included is a new workflow `init_infant_epi_reference_wf` that uses the following heuristic is used to generate the reference map:
1) Matching single-band reference to BOLD image
1) BOLD image (first 16 volumes dropped to avoid excessive motion if participant is startled)