### PR TITLE
Remap labels from FreeSurfer aseg to MCRIB 

### DIFF
--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -143,6 +143,7 @@ BIDS dataset."""
                 "surfaces",
                 "morphometrics",
                 "anat_aseg",
+                "anat_mcrib",
                 "anat_aparc",
                 "template",
             ]

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -6,6 +6,7 @@ from nipype.interfaces.ants.segmentation import JointFusion
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.interfaces.fixes import FixHeaderRegistration as Registration
+from niworkflows.interfaces.nibabel import MapLabels
 from pkg_resources import resource_filename as pkgr_fn
 from smriprep.utils.misc import apply_lut as _apply_bids_lut
 from smriprep.workflows.anatomical import (
@@ -51,7 +52,7 @@ def init_anat_segmentations_wf(
         name="inputnode",
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["anat_aseg", "anat_dseg", "anat_tpms"]),
+        niu.IdentityInterface(fields=["anat_aseg", "anat_mcrib", "anat_dseg", "anat_tpms"]),
         name="outputnode",
     )
 
@@ -184,6 +185,57 @@ white-matter (WM) and gray-matter (GM) was performed on """
         (split_seg, outputnode, [('out', 'anat_tpms')]),
     ])
     # fmt: on
+    
+    wf.__desc__ += """Segmentation volume label indices were remapped
+                     from FreeSurfer to M-CRIB-compatible format. """
+
+    # dictionary to map labels from aseg to mcrib
+    aseg2mcrib = {
+        2: 51,
+        3: 21,
+        4: 49,
+        5: 0,
+        7: 17,
+        8: 17,
+        10: 43,
+        11: 41,
+        12: 47,
+        13: 47,
+        14: 0,
+        15: 0,
+        16: 19,
+        17: 1,
+        18: 3,
+        26: 41,
+        28: 45,
+        31: 49,
+        41: 52,
+        42: 20,
+        43: 50,
+        44: 0,
+        46: 18,
+        47: 18,
+        49: 42,
+        50: 40,
+        51: 46,
+        52: 46,
+        53: 2,
+        54: 4,
+        58: 40,
+        60: 44,
+        63: 50,
+        253: 48,
+    }
+
+    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
+
+    # fmt:off
+    wf.connect([
+        (out_aseg, map_labels, [("out_file", "in_file")]),
+        (map_labels, outputnode, [("out_file", "anat_mcrib")]),
+    ])
+    # fmt: on
+
     return wf
 
 

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -52,7 +52,7 @@ def init_anat_segmentations_wf(
         name="inputnode",
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["anat_aseg", "anat_mcrib", "anat_dseg", "anat_tpms"]),
+        niu.IdentityInterface(fields=["anat_aseg", "anat_mcrib_aseg", "anat_dseg", "anat_tpms"]),
         name="outputnode",
     )
 

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -176,19 +176,6 @@ white-matter (WM) and gray-matter (GM) was performed on """
     lut_anat_dseg.inputs.lut = _aseg_to_three()
     split_seg = pe.Node(niu.Function(function=_split_segments), name="split_seg")
     out_aseg = validate_aseg if precomp_aseg else jf_label
-    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
-
-    # fmt: off
-    wf.connect([
-        (out_aseg, outputnode, [('out_file', 'anat_aseg')]),
-        (out_aseg, lut_anat_dseg, [('out_file', 'in_dseg')]),
-        (lut_anat_dseg, outputnode, [('out', 'anat_dseg')]),
-        (lut_anat_dseg, split_seg, [('out', 'in_file')]),
-        (split_seg, outputnode, [('out', 'anat_tpms')]),
-        (out_aseg, map_labels, [("out_file", "in_file")]),
-        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
-    ])
-    # fmt: on
 
     wf.__desc__ += """Segmentation volume label indices were remapped
                      from FreeSurfer to M-CRIB-compatible format. """
@@ -230,6 +217,19 @@ white-matter (WM) and gray-matter (GM) was performed on """
         63: 50,
         253: 48,
     }
+    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
+
+    # fmt: off
+    wf.connect([
+        (out_aseg, outputnode, [('out_file', 'anat_aseg')]),
+        (out_aseg, lut_anat_dseg, [('out_file', 'in_dseg')]),
+        (lut_anat_dseg, outputnode, [('out', 'anat_dseg')]),
+        (lut_anat_dseg, split_seg, [('out', 'in_file')]),
+        (split_seg, outputnode, [('out', 'anat_tpms')]),
+        (out_aseg, map_labels, [("out_file", "in_file")]),
+        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
+    ])
+    # fmt: on
 
     return wf
 

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -232,7 +232,7 @@ white-matter (WM) and gray-matter (GM) was performed on """
     # fmt:off
     wf.connect([
         (out_aseg, map_labels, [("out_file", "in_file")]),
-        (map_labels, outputnode, [("out_file", "anat_mcrib")]),
+        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
     ])
     # fmt: on
 

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -185,7 +185,7 @@ white-matter (WM) and gray-matter (GM) was performed on """
         (split_seg, outputnode, [('out', 'anat_tpms')]),
     ])
     # fmt: on
-    
+
     wf.__desc__ += """Segmentation volume label indices were remapped
                      from FreeSurfer to M-CRIB-compatible format. """
 

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -177,7 +177,7 @@ white-matter (WM) and gray-matter (GM) was performed on """
     split_seg = pe.Node(niu.Function(function=_split_segments), name="split_seg")
     out_aseg = validate_aseg if precomp_aseg else jf_label
     map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
-    
+
     # fmt: off
     wf.connect([
         (out_aseg, outputnode, [('out_file', 'anat_aseg')]),

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -176,6 +176,8 @@ white-matter (WM) and gray-matter (GM) was performed on """
     lut_anat_dseg.inputs.lut = _aseg_to_three()
     split_seg = pe.Node(niu.Function(function=_split_segments), name="split_seg")
     out_aseg = validate_aseg if precomp_aseg else jf_label
+    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
+    
     # fmt: off
     wf.connect([
         (out_aseg, outputnode, [('out_file', 'anat_aseg')]),
@@ -183,6 +185,8 @@ white-matter (WM) and gray-matter (GM) was performed on """
         (lut_anat_dseg, outputnode, [('out', 'anat_dseg')]),
         (lut_anat_dseg, split_seg, [('out', 'in_file')]),
         (split_seg, outputnode, [('out', 'anat_tpms')]),
+        (out_aseg, map_labels, [("out_file", "in_file")]),
+        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
     ])
     # fmt: on
 
@@ -226,15 +230,6 @@ white-matter (WM) and gray-matter (GM) was performed on """
         63: 50,
         253: 48,
     }
-
-    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
-
-    # fmt:off
-    wf.connect([
-        (out_aseg, map_labels, [("out_file", "in_file")]),
-        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
-    ])
-    # fmt: on
 
     return wf
 


### PR DESCRIPTION
- Use MapLabels interface to remap FreeSurfer aseg labels to MCRIB format
- "anat_mcrib" volume added to outputnode of anat_segmentations_wf