### PR TITLE
ENH: Add preprocessed T2w volume to outputs

### DIFF
--- a/.maint/update_zenodo.py
+++ b/.maint/update_zenodo.py
@@ -122,4 +122,4 @@ if __name__ == '__main__':
         if isinstance(creator['affiliation'], list):
             creator['affiliation'] = creator['affiliation'][0]
 
-    zenodo_file.write_text('%s\n' % json.dumps(zenodo, indent=2))
+    zenodo_file.write_text('%s\n' % json.dumps(zenodo, indent=2, ensure_ascii=False))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+22.2.0 (December 13, 2022)
+==========================
+The final *NiBabies* minor series of 2022!
+Some highlights of the new additions in this release series includes:
+- surface morphometrics outputs, including cortical thickness
+- T2star maps for multiecho data, projected to target output spaces
+
+This series will be the last to support Python 3.7.
+
+A full list of changes can be found below.
+
+## Full Changelog
+  * FIX: Remove cortex masking during vol2surf sampling (#258)
+  * ENH: Improve migas telemetry (#257)
+  * CI: GitHub actions update (#256)
+  * ENH: Add morphometric outputs (#255)
+  * ENH: Output T2star maps for multiecho data (#252)
+  * FIX: Use the binarized output from the brain extraction (#246)
+  * DOC: Add long description including background/significance (#243)
+  * CI: Fix docker credential error (#244)
+  * DOC: Advertise nipreps community pages, add section on contributions (#242)
+
 22.1.3 (September 12, 2022)
 ===========================
 This patch release includes a vital fix for susceptibility distortion correction on multi-echo data.

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -77,8 +77,9 @@ def init_infant_anat_wf(
     """
     from nipype.interfaces.ants.base import Info as ANTsInfo
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-
-    from sdcflows.workflows.ancillary import init_brainextraction_wf as init_sdc_brain_extraction_wf
+    from sdcflows.workflows.ancillary import (
+        init_brainextraction_wf as init_sdc_brain_extraction_wf,
+    )
 
     from ...utils.misc import fix_multi_source_name
     from .brain_extraction import (

--- a/nibabies/workflows/anatomical/outputs.py
+++ b/nibabies/workflows/anatomical/outputs.py
@@ -313,7 +313,7 @@ def init_anat_derivatives_wf(
     t2w_source_files
         List of input T2w images
     t2w_preproc
-        The T2w image in T1w space. 
+        The T2w image in T1w space.
     """
     from niworkflows.interfaces.nibabel import ApplyMask
     from niworkflows.interfaces.utility import KeySelect
@@ -376,7 +376,9 @@ def init_anat_derivatives_wf(
     )
 
     ds_t2w_preproc = pe.Node(
-        DerivativesDataSink(data_dtype="i2", base_directory=output_dir, space="T1w", desc="preproc", compress=True),
+        DerivativesDataSink(
+            data_dtype="i2", base_directory=output_dir, space="T1w", desc="preproc", compress=True
+        ),
         name="ds_t2w_preproc",
         run_without_submitting=True,
     )

--- a/nibabies/workflows/anatomical/outputs.py
+++ b/nibabies/workflows/anatomical/outputs.py
@@ -376,7 +376,7 @@ def init_anat_derivatives_wf(
     )
 
     ds_t2w_preproc = pe.Node(
-        DerivativesDataSink(base_directory=output_dir, space="T1w", desc="preproc", compress=True),
+        DerivativesDataSink(data_dtype="i2", base_directory=output_dir, space="T1w", desc="preproc", compress=True),
         name="ds_t2w_preproc",
         run_without_submitting=True,
     )


### PR DESCRIPTION
- output preprocessed T2w volume as "space-T1w_desc-preproc_T2w.nii.gz"
- If input includes T1w volume, T2w volume, and precomputed T1w mask, use SDCFlows brain extraction wf for T2w which avoids doing redundant brain extraction of T1w