### PR TITLE
FIX: Remove unused ANTs parameter that was removed in 2.4.1

### DIFF
--- a/nibabies/data/t1_to_bold.json
+++ b/nibabies/data/t1_to_bold.json
@@ -31,7 +31,6 @@
       [ 0.1, 3.0, 0.0 ]
     ],
     "transforms": [ "Translation", "Rigid", "SyN" ],
-    "use_estimate_learning_rate_once": [ false, false, true ],
     "use_histogram_matching": [ true, true, true ],
     "verbose": true,
     "winsorize_lower_quantile": 0.0001,

--- a/nibabies/data/within_subject_t1t2.json
+++ b/nibabies/data/within_subject_t1t2.json
@@ -31,7 +31,6 @@
     [ 0.1, 3.0, 0.0 ]
   ],
   "transforms": [ "Translation", "Rigid", "SyN" ],
-  "use_estimate_learning_rate_once": [ false, false, true ],
   "use_histogram_matching": [ true, true, true ],
   "verbose": true,
   "winsorize_lower_quantile": 0.0001,


### PR DESCRIPTION
`--use-estimate-learning-rate-once` was removed in https://github.com/ANTsX/ANTs/pull/1411 (released v2.4.1). It seems it has had no effect for some time (I think since v2.0.0).

No effect for now, but this will allow us to eventually upgrade ANTs.