### PR TITLE
ENH: Resample morphometrics to fsLR dscalar CIFTI-2 files if ``--cifti-output`` is used

### DIFF
--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -24,6 +24,7 @@ def init_infant_anat_wf(
     skull_strip_template,
     sloppy,
     spaces,
+    cifti_output=False,
     name="infant_anat_wf",
 ):
     """
@@ -193,6 +194,7 @@ as target template.
         num_t1w=num_t1w,
         output_dir=output_dir,
         spaces=spaces,
+        cifti_output=cifti_output,
     )
 
     # Multiple T1w files -> generate average reference
@@ -444,4 +446,21 @@ as target template.
         ]),
     ])
     # fmt: on
+
+    if cifti_output:
+        morph_grayords_wf = init_morph_grayords_wf(grayord_density=cifti_output)
+        anat_derivatives_wf.get_node('inputnode').inputs.cifti_density = cifti_output
+        # fmt:off
+        workflow.connect([
+            (surface_recon_wf, morph_grayords_wf, [
+                ('outputnode.subject_id', 'inputnode.subject_id'),
+                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+            ]),
+            (morph_grayords_wf, anat_derivatives_wf, [
+                ("outputnode.cifti_morph", "inputnode.cifti_morph"),
+                ("outputnode.cifti_metadata", "inputnode.cifti_metadata"),
+            ]),
+        ])
+        # fmt:on
+
     return wf

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -453,7 +453,7 @@ as target template.
         morph_grayords_wf = init_morph_grayords_wf(grayord_density=cifti_output)
         anat_derivatives_wf.get_node('inputnode').inputs.cifti_density = cifti_output
         # fmt:off
-        workflow.connect([
+        wf.connect([
             (surface_recon_wf, morph_grayords_wf, [
                 ('outputnode.subject_id', 'inputnode.subject_id'),
                 ('outputnode.subjects_dir', 'inputnode.subjects_dir'),

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -448,6 +448,8 @@ as target template.
     # fmt: on
 
     if cifti_output:
+        from smriprep.workflows.surfaces import init_morph_grayords_wf
+
         morph_grayords_wf = init_morph_grayords_wf(grayord_density=cifti_output)
         anat_derivatives_wf.get_node('inputnode').inputs.cifti_density = cifti_output
         # fmt:off

--- a/nibabies/workflows/anatomical/outputs.py
+++ b/nibabies/workflows/anatomical/outputs.py
@@ -249,6 +249,7 @@ def init_anat_derivatives_wf(
     num_t1w,
     output_dir,
     spaces,
+    cifti_output,
     name="anat_derivatives_wf",
     tpm_labels=BIDS_TISSUE_ORDER,
 ):
@@ -314,6 +315,12 @@ def init_anat_derivatives_wf(
         List of input T2w images
     t2w_preproc
         The T2w image in T1w space.
+    cifti_morph
+        Morphometric CIFTI-2 dscalar files
+    cifti_density
+        Grayordinate density
+    cifti_metadata
+        JSON files containing metadata dictionaries
     """
     from niworkflows.interfaces.nibabel import ApplyMask
     from niworkflows.interfaces.utility import KeySelect
@@ -347,6 +354,9 @@ def init_anat_derivatives_wf(
                 "t1w_fs_aparc",
                 "t2w_source_files",
                 "t2w_preproc",
+                "cifti_metadata",
+                "cifti_density",
+                "cifti_morph",
             ]
         ),
         name="inputnode",
@@ -706,6 +716,26 @@ def init_anat_derivatives_wf(
                                     ('source_files', 'source_file')]),
     ])
     # fmt: on
+    if cifti_output:
+        ds_cifti_morph = pe.MapNode(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                suffix=['curv', 'sulc', 'thickness'],
+                compress=False,
+                space='fsLR',
+            ),
+            name='ds_cifti_morph',
+            run_without_submitting=True,
+            iterfield=["in_file", "meta_dict", "suffix"],
+        )
+        # fmt:off
+        workflow.connect([
+            (inputnode, ds_cifti_morph, [('cifti_morph', 'in_file'),
+                                         ('source_files', 'source_file'),
+                                         ('cifti_density', 'density'),
+                                         (('cifti_metadata', _read_jsons), 'meta_dict')])
+        ])
+        # fmt:on
     return workflow
 
 
@@ -718,3 +748,10 @@ def _set_tpl_res(space, resolution):
         return int(resolution)
     except ValueError:
         return 1
+
+
+def _read_jsons(in_file):
+    from json import loads
+    from pathlib import Path
+
+    return [loads(Path(f).read_text()) for f in in_file]

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -331,6 +331,7 @@ It is released under the [CC0]\
         skull_strip_template=Reference.from_string(config.workflow.skull_strip_template)[0],
         sloppy=config.execution.sloppy,
         spaces=spaces,
+        cifti_output=config.workflow.cifti_output,
     )
 
     # fmt: off

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pybids >= 0.15.0",
     "requests",
     "sdcflows ~= 2.2.2",
-    "smriprep ~= 0.10.0",
+    "smriprep ~= 0.11.0",
     "tedana ~= 0.0.12",
     "templateflow >= 0.6",
     "toml",


### PR DESCRIPTION
Ports nipreps/smriprep#325 and nipreps/fmriprep#2959 to nibabies.

It doesn't look like we're resampling to fsLR in CircleCI, so this will require manual tests.