### PR TITLE
ENH: Testing MCRIBS integration 

### DIFF
--- a/nibabies/cli/mcribs.py
+++ b/nibabies/cli/mcribs.py
@@ -1,0 +1,107 @@
+import os
+from argparse import ArgumentParser
+
+import nipype.pipeline.engine as pe
+from niworkflows.interfaces.nibabel import MapLabels
+
+from nibabies.interfaces.mcribs import MCRIBReconAll
+
+
+def _parser():
+    parser = ArgumentParser(description="Test script for MCRIBS surfaces")
+    parser.add_argument('subject', help='Subject ID')
+    parser.add_argument('t2w', type=os.path.abspath, help='Input T2w (radioisotropic)')
+    parser.add_argument(
+        'segmentation', type=os.path.abspath, help='Input anatomical segmentation in T2w space'
+    )
+    parser.add_argument(
+        '--outdir', type=os.path.abspath, help='Output directory to persist MCRIBS output'
+    )
+    parser.add_argument('--nthreads', type=int, help='Number of threads to parallelize tasks')
+    return parser
+
+
+def main(argv: list = None):
+    pargs = _parser().parse_args(argv)
+
+    t2w_file = _check_file(pargs.t2w)
+    seg_file = _check_file(pargs.segmentation)
+
+    aseg2mcrib = {
+        2: 51,
+        3: 21,
+        4: 49,
+        5: 0,
+        7: 17,
+        8: 17,
+        10: 43,
+        11: 41,
+        12: 47,
+        13: 47,
+        14: 0,
+        15: 0,
+        16: 19,
+        17: 1,
+        18: 3,
+        26: 41,
+        28: 45,
+        31: 49,
+        41: 52,
+        42: 20,
+        43: 50,
+        44: 0,
+        46: 18,
+        47: 18,
+        49: 42,
+        50: 40,
+        51: 46,
+        52: 46,
+        53: 2,
+        54: 4,
+        58: 40,
+        60: 44,
+        63: 50,
+        253: 48,
+    }
+    map_labels = pe.Node(MapLabels(in_file=seg_file, mappings=aseg2mcrib), name='map_labels')
+
+    recon = pe.Node(
+        MCRIBReconAll(subject_id=pargs.subject, t2w_file=t2w_file), name='mcribs_recon'
+    )
+    if pargs.outdir:
+        recon.inputs.outdir = pargs.outdir
+    if pargs.nthreads:
+        recon.inputs.nthreads = pargs.nthreads
+
+    wf = pe.Workflow(f'MRA_{pargs.subject}')
+    wf.connect(map_labels, 'out_file', recon, 'segmentation_file')
+    wf.run()
+
+
+def _check_file(fl: str) -> str:
+    import nibabel as nb
+    import numpy as np
+
+    img = nb.load(fl)
+    if len(img.shape) != 3:
+        raise ValueError('Image {fl} is not 3 dimensional.')
+
+    voxdims = img.header['pixdim'][1:4]
+    if not np.allclose(voxdims, voxdims[1]):
+        raise ValueError(f'Image {fl} is not isotropic: {voxdims}.')
+
+    ornt = nb.io_orientation(img.affine)
+    axcodes = nb.orientations.ornt2axcodes(ornt)
+    if ''.join(axcodes) != 'LAS':
+        las = nb.orientations.axcodes2ornt('LAS')
+        transform = nb.orientations.ornt_transform(ornt, las)
+        reornt = img.as_reoriented(transform)
+        outfl = os.path.abspath(f'LASornt_{os.path.basename(fl)}')
+        print(f'Creating reorientated image {outfl}')
+        reornt.to_filename(outfl)
+        return outfl
+    return fl
+
+
+if __name__ == '__main__':
+    main()

--- a/nibabies/interfaces/mcribs.py
+++ b/nibabies/interfaces/mcribs.py
@@ -21,14 +21,13 @@ class MCRIBReconAllInputSpec(CommandLineInputSpec):
     subjects_dir = Directory(
         exists=True,
         hash_files=False,
-        desc='path to subjects directory',
-        required=True,
+        desc='Path to FreeSurfer subjects directory',
     )
     subject_id = traits.Str(
-        # required=True,
+        required=True,
         argstr='%s',
         position=-1,
-        desc='subject name',
+        desc='Subject ID',
     )
     t1w_file = File(
         exists=True,
@@ -112,7 +111,7 @@ class MCRIBReconAll(CommandLine):
         # Avoid processing if valid
         if self.inputs.outdir:
             sid = self.inputs.subject_id
-            logf = self.inputs.outdir / sid / 'logs' / f'{sid}.log'
+            logf = Path(self.inputs.outdir) / sid / 'logs' / f'{sid}.log'
             if logf.exists():
                 logtxt = logf.read_text().splitlines()[-3:]
                 self._no_run = 'Finished without error' in logtxt
@@ -203,7 +202,7 @@ class MCRIBReconAll(CommandLine):
         # Copy freesurfer directory into FS subjects dir
         sid = self.inputs.subject_id
         mcribs_fs = self._mcribs_dir / sid / 'freesurfer' / sid
-        if mcribs_fs.exists():
+        if mcribs_fs.exists() and self.inputs.subjects_dir:
             dst = Path(self.inputs.subjects_dir) / self.inputs.subject_id
             if not dst.exists():
                 shutil.copytree(mcribs_fs, dst)

--- a/nibabies/interfaces/mcribs.py
+++ b/nibabies/interfaces/mcribs.py
@@ -1,0 +1,187 @@
+import os
+import shutil
+from pathlib import Path
+
+from nipype.interfaces.base import (
+    CommandLine,
+    CommandLineInputSpec,
+    Directory,
+    File,
+    TraitedSpec,
+    traits,
+)
+
+
+class MCRIBReconAllInputSpec(CommandLineInputSpec):
+    # Input structure massaging
+    subjects_dir = Directory(
+        exists=True,
+        hash_files=False,
+        desc='path to subjects directory',
+        required=True,
+    )
+    subject_id = traits.Str(
+        # required=True,
+        argstr='%s',
+        position=-1,
+        desc='subject name',
+    )
+    t1w_file = File(
+        exists=True,
+        copyfile=True,
+        desc='T1w to be used for deformable (must be registered to T2w image)',
+    )
+    t2w_file = File(
+        exists=True,
+        required=True,
+        copyfile=True,
+        desc='T2w (Isotropic + N4 corrected)',
+    )
+    segmentation_file = File(
+        desc='Segmentation file (skips tissue segmentation)',
+    )
+
+    # MCRIBS options
+    conform = traits.Bool(
+        argstr='--conform',
+        desc='Reorients to radiological, axial slice orientation. Resamples to isotropic voxels',
+    )
+    tissueseg = traits.Bool(
+        argstr='--tissueseg',
+        desc='Perform tissue type segmentation',
+    )
+    surfrecon = traits.Bool(
+        True,
+        usedefault=True,
+        argstr='--surfrecon',
+        desc='Reconstruct surfaces',
+    )
+    surfrecon_method = traits.Enum(
+        'Deformable',
+        argstr='--surfreconmethod %s',
+        usedefault=True,
+        desc='Surface reconstruction method',
+    )
+    join_thresh = traits.Float(
+        1.0,
+        argstr='--deformablejointhresh %f',
+        usedefault=True,
+        desc='Join threshold parameter for Deformable',
+    )
+    fast_collision = traits.Bool(
+        True,
+        argstr='--deformablefastcollision',
+        usedefault=True,
+        desc='Use Deformable fast collision test',
+    )
+    autorecon_after_surf = traits.Bool(
+        True,
+        argstr='--autoreconaftersurf',
+        usedefault=True,
+        desc='Do all steps after surface reconstruction',
+    )
+    segstats = traits.Bool(
+        True,
+        argstr='--segstats',
+        usedefault=True,
+        desc='Compute statistics on segmented volumes',
+    )
+    nthreads = traits.Int(
+        argstr='-nthreads %d',
+        desc='Number of threads for multithreading applications',
+    )
+
+
+class MCRIBReconAllOutputSpec(TraitedSpec):
+    mcribs_dir = Directory(desc='MCRIBS output directory')
+
+
+class MCRIBReconAll(CommandLine):
+    _cmd = 'MCRIBReconAll'
+    input_spec = MCRIBReconAllInputSpec
+    output_spec = MCRIBReconAllOutputSpec
+
+    def _setup_directory_structure(self, mcribs_dir: Path) -> None:
+        '''
+        Create the required structure for skipping steps.
+
+        The directory tree
+        ------------------
+
+        <subject_id>/
+        ├── RawT2
+        │   └── <subject_id>.nii.gz
+        ├── SurfReconDeformable
+        │   └── <subject_id>
+        │       └── temp
+        │           └── t2w-image.nii.gz
+        ├── TissueSeg
+        │   ├── <subject_id>_all_labels.nii.gz
+        │   └── <subject_id>_all_labels_manedit.nii.gz
+        └── TissueSegDrawEM
+            └── <subject_id>
+                └── N4
+                    └── <subject_id>.nii.gz
+        '''
+        sid = self.inputs.subject_id
+        mkdir_kw = {'parents': True, 'exist_ok': True}
+        root = mcribs_dir / sid
+        root.mkdir(**mkdir_kw)
+
+        # T2w operations
+        t2w = root / 'RawT2' / f'{sid}.nii.gz'
+        t2w.parent.mkdir(**mkdir_kw)
+        if not t2w.exists():
+            shutil.copy(self.inputs.t2w_file, str(t2w))
+
+        if not self.inputs.conform:
+            t2wiso = root / 'RawT2RadiologicalIsotropic' / f'{sid}.nii.gz'
+            t2wiso.parent.mkdir(**mkdir_kw)
+            if not t2wiso.exists():
+                t2wiso.symlink_to(f'../../RawT2/{sid}.nii.gz')
+
+            n4 = root / sid / 'N4' / f'{sid}.nii.gz'
+            n4.parent.mkdir(**mkdir_kw)
+            if not n4.exists():
+                n4.symlink_to(f'../../../RawT2/{sid}.nii.gz')
+
+        # Segmentation
+        if self.inputs.segmentation_file:
+            # TissueSeg directive disabled
+            tisseg = root / 'TissueSeg' / f'{sid}_all_labels.nii.gz'
+            tisseg.parent.mkdir(**mkdir_kw)
+            if not tisseg.exists():
+                shutil.copy(self.inputs.segmentation, str(tisseg))
+            manedit = tisseg.parent / f'{sid}_all_labels_manedit.nii.gz'
+            if not manedit.exists():
+                manedit.symlink_to(tisseg.name)
+
+            if self.inputs.surfrecon:
+                surfrec = root / 'SurfReconDeformable' / sid / 'temp' / 't2w-image.nii.gz'
+                surfrec.parent.mkdir(**mkdir_kw)
+                if not surfrec.exists():
+                    surfrec.symlink_to(f'../../../../RawT2/{sid}.nii.gz')
+
+        # TODO: T1w -> <subject_id>/RawT1RadiologicalIsotropic/<subjectid>.nii.gz
+        return
+
+    def _run_interface(self, runtime):
+        # if users wish to preserve their runs
+        mcribs_dir = os.getenv('MCRIBS_SUBJECTS')
+        if mcribs_dir is None or not Path(mcribs_dir).exists():
+            mcribs_dir = runtime.cwd / 'mcribs'
+        self._mcribs_dir = mcribs_dir
+        self._setup_directory_structure(mcribs_dir)
+        # runs in CWD
+        os.chdir(mcribs_dir / self.inputs.subject_id)
+        return super()._run_interface(runtime)
+
+    def _list_outputs(self):
+        outputs = self._outputs().get()
+        outputs['mcribs_dir'] = self._mcribs_dir
+
+        # TODO: Copy freesurfer directory into FS subjects dir
+        # fs_outputs = self._mcribs_dir / self.inputs.subject_id / 'freesurfer'
+        # if fs_outputs.exists():
+        #     pass
+        return outputs

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -147,6 +147,7 @@ BIDS dataset."""
                 "surfaces",
                 "morphometrics",
                 "anat_aseg",
+                "anat_mcrib",
                 "anat_aparc",
                 "template",
             ]

--- a/nibabies/workflows/anatomical/segmentation.py
+++ b/nibabies/workflows/anatomical/segmentation.py
@@ -6,6 +6,7 @@ from nipype.interfaces.ants.segmentation import JointFusion
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 from niworkflows.interfaces.fixes import FixHeaderRegistration as Registration
+from niworkflows.interfaces.nibabel import MapLabels
 from pkg_resources import resource_filename as pkgr_fn
 from smriprep.utils.misc import apply_lut as _apply_bids_lut
 from smriprep.workflows.anatomical import (
@@ -51,7 +52,7 @@ def init_anat_segmentations_wf(
         name="inputnode",
     )
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["anat_aseg", "anat_dseg", "anat_tpms"]),
+        niu.IdentityInterface(fields=["anat_aseg", "anat_mcrib_aseg", "anat_dseg", "anat_tpms"]),
         name="outputnode",
     )
 
@@ -175,6 +176,49 @@ white-matter (WM) and gray-matter (GM) was performed on """
     lut_anat_dseg.inputs.lut = _aseg_to_three()
     split_seg = pe.Node(niu.Function(function=_split_segments), name="split_seg")
     out_aseg = validate_aseg if precomp_aseg else jf_label
+
+    wf.__desc__ += """Segmentation volume label indices were remapped
+                     from FreeSurfer to M-CRIB-compatible format. """
+
+    # dictionary to map labels from aseg to mcrib
+    aseg2mcrib = {
+        2: 51,
+        3: 21,
+        4: 49,
+        5: 0,
+        7: 17,
+        8: 17,
+        10: 43,
+        11: 41,
+        12: 47,
+        13: 47,
+        14: 0,
+        15: 0,
+        16: 19,
+        17: 1,
+        18: 3,
+        26: 41,
+        28: 45,
+        31: 49,
+        41: 52,
+        42: 20,
+        43: 50,
+        44: 0,
+        46: 18,
+        47: 18,
+        49: 42,
+        50: 40,
+        51: 46,
+        52: 46,
+        53: 2,
+        54: 4,
+        58: 40,
+        60: 44,
+        63: 50,
+        253: 48,
+    }
+    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
+
     # fmt: off
     wf.connect([
         (out_aseg, outputnode, [('out_file', 'anat_aseg')]),
@@ -182,8 +226,11 @@ white-matter (WM) and gray-matter (GM) was performed on """
         (lut_anat_dseg, outputnode, [('out', 'anat_dseg')]),
         (lut_anat_dseg, split_seg, [('out', 'in_file')]),
         (split_seg, outputnode, [('out', 'anat_tpms')]),
+        (out_aseg, map_labels, [("out_file", "in_file")]),
+        (map_labels, outputnode, [("out_file", "anat_mcrib_aseg")]),
     ])
     # fmt: on
+
     return wf
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ all = ["nibabies[dev,doc,maint,telemetry,test]"]
 
 [project.scripts]
 nibabies = "nibabies.cli.run:main"
+nibabies-mcribs = "nibabies.cli.mcribs:main"
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
This replaces the original MIRTK integration (#269) with MCRIBS, which seems to do a better job handling intersection errors.

# TODO
- [x] Include standalone script to allow testing `MCRIBReconAll` with just T2w / segmentations
- [ ] Insert into surface workflow (separate PR)