### PR TITLE
ENH: Add M-CRIB-S surface processing

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -767,6 +767,11 @@ applied."""
             config.execution.nibabies_dir = output_dir
         elif output_layout == "legacy":
             config.execution.nibabies_dir = output_dir / "nibabies"
+    if config.workflow.surface_recon_method == "mcribs":
+        if output_layout == "bids":
+            config.execution.mcribs_dir = output_dir / "sourcedata" / "mcribs"
+        elif output_layout == "legacy":
+            config.execution.mcribs_dir = output_dir / "mcribs"
 
     # Wipe out existing work_dir
     if opts.clean_workdir and work_dir.exists():

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -759,9 +759,9 @@ applied."""
 
     if config.execution.fs_subjects_dir is None:
         if output_layout == "bids":
-            config.execution.fs_subjects_dir = output_dir / "sourcedata" / "infant-freesurfer"
+            config.execution.fs_subjects_dir = output_dir / "sourcedata" / "freesurfer"
         elif output_layout == "legacy":
-            config.execution.fs_subjects_dir = output_dir / "infant-freesurfer"
+            config.execution.fs_subjects_dir = output_dir / "freesurfer"
     if config.execution.nibabies_dir is None:
         if output_layout == "bids":
             config.execution.nibabies_dir = output_dir

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -772,6 +772,8 @@ applied."""
             config.execution.mcribs_dir = output_dir / "sourcedata" / "mcribs"
         elif output_layout == "legacy":
             config.execution.mcribs_dir = output_dir / "mcribs"
+        # Ensure the directory is created
+        config.execution.mcribs_dir.mkdir(exist_ok=True, parents=True)
 
     # Wipe out existing work_dir
     if opts.clean_workdir and work_dir.exists():

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -664,6 +664,12 @@ discourage its usage."""
         action="store_true",
         help="Force traditional FreeSurfer surface reconstruction.",
     )
+    g_baby.add_argument(
+        "--surface-recon-method",
+        choices=("infantfs", "freesurfer", "mcribs"),
+        default="infantfs",
+        help="Method to use for surface reconstruction",
+    )
     return parser
 
 
@@ -673,6 +679,14 @@ def parse_args(args=None, namespace=None):
 
     parser = _build_parser()
     opts = parser.parse_args(args, namespace)
+
+    # Deprecations
+    if opts.force_reconall:
+        config.loggers.cli.warning(
+            "--force-reconall is deprecated and will be removed in a future release."
+            "To run traditional `recon-all`, use `--surface-recon-method freesurfer` instead."
+        )
+        opts.surface_recon_method = "freesurfer"
 
     if opts.config_file:
         skip = {} if opts.reports_only else {"execution": ("run_uuid",)}

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -394,6 +394,8 @@ class execution(_Config):
     """Output verbosity."""
     low_mem = None
     """Utilize uncompressed NIfTIs and other tricks to minimize memory allocation."""
+    mcribs_dir = None
+    """M-CRIB-S processing and output directory."""
     md_only_boilerplate = False
     """Do not convert boilerplate from MarkDown to LaTex and HTML."""
     nibabies_dir = None
@@ -439,6 +441,7 @@ class execution(_Config):
         "fs_subjects_dir",
         "layout",
         "log_dir",
+        "mcribs_dir",
         "nibabies_dir",
         "output_dir",
         "segmentation_atlases_dir",

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -543,8 +543,6 @@ class workflow(_Config):
     """Remove the mean from fieldmaps."""
     force_syn = None
     """Run *fieldmap-less* susceptibility-derived distortions estimation."""
-    force_reconall = False
-    """Force traditional FreeSurfer surface reconstruction instead of infant version."""
     hires = None
     """Run FreeSurfer ``recon-all`` with the ``-hires`` flag."""
     ignore = None
@@ -578,6 +576,8 @@ class workflow(_Config):
     spaces = None
     """Keeps the :py:class:`~niworkflows.utils.spaces.SpatialReferences`
     instance keeping standard and nonstandard spaces."""
+    surface_recon_method = "infantfs"
+    """Method to use for surface reconstruction."""
     topup_max_vols = 5
     """Maximum number of volumes to use with TOPUP, per-series (EPI or BOLD)."""
     use_aroma = None

--- a/nibabies/data/boilerplate.bib
+++ b/nibabies/data/boilerplate.bib
@@ -392,3 +392,16 @@
 	title = {Infant {FreeSurfer}: An automated segmentation and surface extraction pipeline for T1-weighted neuroimaging data of infants 0{\textendash}2 years},
 	journal = {{NeuroImage}}
 }
+
+@article{mcribs,
+	doi = {10.1038/s41598-020-61326-2},
+	url = {https://doi.org/10.1038%2Fs41598-020-61326-2},
+	year = 2020,
+	month = {mar},
+	publisher = {Springer Science and Business Media {LLC}},
+	volume = {10},
+	number = {1},
+	author = {Chris L. Adamson and Bonnie Alexander and Gareth Ball and Richard Beare and Jeanie L. Y. Cheong and Alicia J. Spittle and Lex W. Doyle and Peter J. Anderson and Marc L. Seal and Deanne K. Thompson},
+	title = {Parcellation of the neonatal cortex using Surface-based Melbourne Children's Regional Infant Brain atlases (M-{CRIB}-S)},
+	journal = {Scientific Reports}
+}

--- a/nibabies/interfaces/mcribs.py
+++ b/nibabies/interfaces/mcribs.py
@@ -97,6 +97,7 @@ class MCRIBReconAllInputSpec(CommandLineInputSpec):
 
 class MCRIBReconAllOutputSpec(TraitedSpec):
     mcribs_dir = Directory(desc='MCRIBS output directory')
+    subjects_dir = Directory(desc='FreeSurfer output directory')
 
 
 class MCRIBReconAll(CommandLine):
@@ -212,5 +213,6 @@ class MCRIBReconAll(CommandLine):
             dst = Path(self.inputs.subjects_dir) / self.inputs.subject_id
             if not dst.exists():
                 shutil.copytree(mcribs_fs, dst)
+            outputs['subjects_dir'] = str(dst)
 
         return outputs

--- a/nibabies/interfaces/mcribs.py
+++ b/nibabies/interfaces/mcribs.py
@@ -43,6 +43,7 @@ class MCRIBReconAllInputSpec(CommandLineInputSpec):
     segmentation_file = File(
         desc='Segmentation file (skips tissue segmentation)',
     )
+    mask_file = File(desc='T2w mask')
 
     # MCRIBS options
     conform = traits.Bool(
@@ -184,6 +185,11 @@ class MCRIBReconAll(CommandLine):
                 surfrec.parent.mkdir(**mkdir_kw)
                 if not surfrec.exists():
                     surfrec.symlink_to(f'../../../RawT2/{sid}.nii.gz')
+
+                if self.inputs.mask_file:
+                    surfrec_mask = surfrec.parent / 'mask-image.nii.gz'
+                    if not surfrec_mask.exists():
+                        shutil.copy(self.inputs.mask_file, str(surfrec_mask))
 
         if self.inputs.surfrecon:
             # Create FreeSurfer layout to safeguard against cd-ing into missing directories

--- a/nibabies/interfaces/mcribs.py
+++ b/nibabies/interfaces/mcribs.py
@@ -213,6 +213,6 @@ class MCRIBReconAll(CommandLine):
             dst = Path(self.inputs.subjects_dir) / self.inputs.subject_id
             if not dst.exists():
                 shutil.copytree(mcribs_fs, dst)
-            outputs['subjects_dir'] = str(dst)
+            outputs['subjects_dir'] = self.inputs.subjects_dir
 
         return outputs

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -417,7 +417,9 @@ as target template.
         (inputnode, surface_recon_wf, [
             ("subject_id", "inputnode.subject_id"),
             ("subjects_dir", "inputnode.subjects_dir"),
-            ("t2w", "inputnode.t2w"),
+        ]),
+        (coregistration_wf, surface_recon_wf, [
+            ("outputnode.t2w_preproc", "inputnode.t2w"),
         ]),
         (anat_seg_wf, surface_recon_wf, [
             ("outputnode.anat_aseg", "inputnode.ants_segs"),

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -412,14 +412,20 @@ as target template.
             mcribs_dir=str(config.execution.mcribs_dir),  # Needed to preserve runs
         )
 
+    if precomp_mask:
+        wf.connect(
+            sdc_brain_extraction_wf, 'outputnode.out_file', surface_recon_wf, 'inputnode.t2w'
+        )
+    else:
+        wf.connect(
+            brain_extraction_wf, 'outputnode.t2w_preproc', surface_recon_wf, 'inputnode.t2w'
+        )
+
     # fmt:off
     wf.connect([
         (inputnode, surface_recon_wf, [
             ("subject_id", "inputnode.subject_id"),
             ("subjects_dir", "inputnode.subjects_dir"),
-        ]),
-        (coregistration_wf, surface_recon_wf, [
-            ("outputnode.t2w_preproc", "inputnode.t2w"),
         ]),
         (anat_seg_wf, surface_recon_wf, [
             ("outputnode.anat_aseg", "inputnode.ants_segs"),

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -417,7 +417,10 @@ as target template.
     elif config.workflow.surface_recon_method == 'mcribs':
         from .surfaces import init_mcribs_surface_recon_wf
 
-        surface_recon_wf = init_mcribs_surface_recon_wf(use_aseg=bool(precomp_aseg))
+        surface_recon_wf = init_mcribs_surface_recon_wf(
+            use_aseg=bool(precomp_aseg),
+            mcribs_dir=config.execution.mcribs_dir,  # Needed to preserve runs
+        )
 
     # fmt:off
     wf.connect([

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -267,6 +267,7 @@ as target template.
     # fmt:off
     wf.connect([
         (inputnode, t1w_template_wf, [("t1w", "inputnode.in_files")]),
+        (inputnode, t2w_template_wf, [("t2w", "inputnode.in_files")]),
         (t1w_template_wf, outputnode, [
             ("outputnode.realign_xfms", "anat_ref_xfms"),
         ]),
@@ -298,49 +299,6 @@ as target template.
             ("outputnode.t1w_mask", "inputnode.t1w_mask"),
             ("outputnode.t1w_preproc", "inputnode.t1w_preproc"),
         ]),
-        (coregistration_wf, anat_derivatives_wf, [
-            ("outputnode.t2w_preproc", "inputnode.t2w_preproc")
-         ]),
-        (t1w_preproc_wf, outputnode, [
-            ("outputnode.t1w_preproc", "anat_preproc"),
-            ("outputnode.t1w_brain", "anat_brain"),
-            ("outputnode.t1w_mask", "anat_mask"),
-        ]),
-    ])
-
-    if not precomp_aseg:
-        wf.connect([
-            (t1w_preproc_wf, anat_seg_wf, [("outputnode.t1w_brain", "inputnode.anat_brain")]),
-        ])
-    wf.connect([
-        (inputnode, t2w_template_wf, [("t2w", "inputnode.in_files")]),
-    ])
-    if precomp_mask:
-        wf.connect([
-            (t1w_template_wf, precomp_mask_wf, [
-                ("outputnode.out_file", "inputnode.t1w"),
-            ]),
-            (t2w_template_wf, sdc_brain_extraction_wf, [
-                ("outputnode.out_file", "inputnode.in_file"),
-            ]),
-            (sdc_brain_extraction_wf, coregistration_wf, [
-                ("outputnode.out_file", "inputnode.in_t2w_preproc"),
-                ("outputnode.out_mask", "inputnode.in_mask"),
-                ("outputnode.out_probseg", "inputnode.in_probmap"),
-            ]),
-        ])
-    else:
-        wf.connect([
-            (t2w_template_wf, brain_extraction_wf, [
-                ("outputnode.out_file", "inputnode.in_t2w"),
-            ]),
-            (brain_extraction_wf, coregistration_wf, [
-                ("outputnode.t2w_preproc", "inputnode.in_t2w_preproc"),
-                ("outputnode.out_mask", "inputnode.in_mask"),
-                ("outputnode.out_probmap", "inputnode.in_probmap"),
-            ]),
-        ])
-    wf.connect([
         (t1w_template_wf, coregistration_wf, [
             ("outputnode.out_file", "inputnode.in_t1w"),
         ]),
@@ -355,9 +313,14 @@ as target template.
         (coregistration_wf, coreg_report_wf, [
             ("outputnode.t2w_preproc", "inputnode.t2w_preproc")
         ]),
-    ])
-
-    wf.connect([
+        (coregistration_wf, anat_derivatives_wf, [
+            ("outputnode.t2w_preproc", "inputnode.t2w_preproc")
+         ]),
+        (t1w_preproc_wf, outputnode, [
+            ("outputnode.t1w_preproc", "anat_preproc"),
+            ("outputnode.t1w_brain", "anat_brain"),
+            ("outputnode.t1w_mask", "anat_mask"),
+        ]),
         # reports
         (inputnode, anat_reports_wf, [
             ("t1w", "inputnode.source_file"),
@@ -396,6 +359,33 @@ as target template.
             ("outputnode.anat_tpms", "inputnode.t1w_tpms"),
         ]),
     ])
+
+    if precomp_mask:
+        wf.connect([
+            (t1w_template_wf, precomp_mask_wf, [
+                ("outputnode.out_file", "inputnode.t1w"),
+            ]),
+            (t2w_template_wf, sdc_brain_extraction_wf, [
+                ("outputnode.out_file", "inputnode.in_file"),
+            ]),
+            (sdc_brain_extraction_wf, coregistration_wf, [
+                ("outputnode.out_file", "inputnode.in_t2w_preproc"),
+                ("outputnode.out_mask", "inputnode.in_mask"),
+                ("outputnode.out_probseg", "inputnode.in_probmap"),
+            ]),
+        ])
+    else:
+        wf.connect([
+            (t2w_template_wf, brain_extraction_wf, [
+                ("outputnode.out_file", "inputnode.in_t2w"),
+            ]),
+            (brain_extraction_wf, coregistration_wf, [
+                ("outputnode.t2w_preproc", "inputnode.in_t2w_preproc"),
+                ("outputnode.out_mask", "inputnode.in_mask"),
+                ("outputnode.out_probmap", "inputnode.in_probmap"),
+            ]),
+            (t1w_preproc_wf, anat_seg_wf, [("outputnode.t1w_brain", "inputnode.anat_brain")]),
+        ])
     # fmt:on
 
     if not freesurfer:

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -419,7 +419,7 @@ as target template.
 
         surface_recon_wf = init_mcribs_surface_recon_wf(
             use_aseg=bool(precomp_aseg),
-            mcribs_dir=config.execution.mcribs_dir,  # Needed to preserve runs
+            mcribs_dir=str(config.execution.mcribs_dir),  # Needed to preserve runs
         )
 
     # fmt:off

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -401,19 +401,23 @@ as target template.
     if not freesurfer:
         return wf
 
-    if config.workflow.force_reconall:
+    if config.workflow.surface_recon_method == 'freesurfer':
         from smriprep.workflows.surfaces import init_surface_recon_wf
 
         surface_recon_wf = init_surface_recon_wf(omp_nthreads=omp_nthreads, hires=hires)
-    else:
-        from .surfaces import init_infant_surface_recon_wf
+    elif config.workflow.surface_recon_method == 'infantfs':
+        from .surfaces import init_infantfs_surface_recon_wf
 
         # if running with precomputed aseg, or JLF, pass the aseg along to FreeSurfer
         use_aseg = bool(precomp_aseg or segmentation_atlases)
-        surface_recon_wf = init_infant_surface_recon_wf(
+        surface_recon_wf = init_infantfs_surface_recon_wf(
             age_months=age_months,
             use_aseg=use_aseg,
         )
+    elif config.workflow.surface_recon_method == 'mcribs':
+        from .surfaces import init_mcribs_surface_recon_wf
+
+        surface_recon_wf = init_mcribs_surface_recon_wf(use_aseg=bool(precomp_aseg))
 
     # fmt:off
     wf.connect([

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -1,4 +1,140 @@
-# Use infant_recon_all to generate subcortical segmentations and cortical parcellations
+"""Anatomical surface projections"""
+from nipype.interfaces import freesurfer as fs
+from nipype.interfaces import io as nio
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow
+from niworkflows.interfaces.freesurfer import PatchedLTAConvert as LTAConvert
+from niworkflows.interfaces.freesurfer import PatchedRobustRegister as RobustRegister
+from smriprep.workflows.surfaces import init_gifti_surface_wf
+
+SURFACE_INPUTS = [
+    "subjects_dir",
+    "subject_id",
+    "t1w",
+    "t2w",
+    "flair",
+    "skullstripped_t1",
+    "corrected_t1",
+    "ants_segs",
+]
+SURFACE_OUTPUTS = [
+    "subjects_dir",
+    "subject_id",
+    "t1w2fsnative_xfm",
+    "fsnative2t1w_xfm",
+    "surfaces",
+    "morphometrics",
+    "out_aseg",
+    "out_aparc",
+]
+
+
+def init_mcribs_surface_recon_wf(*, mcribs_dir=None, name="mcribs_surface_recon_wf"):
+    from niworkflows.interfaces.nibabel import MapLabels, ReorientImage
+
+    from ...interfaces.mcribs import MCRIBReconAll
+
+    inputnode = pe.Node(niu.IdentityInterface(fields=SURFACE_INPUTS), name='inputnode')
+    outputnode = pe.Node(niu.IdentityInterface(fields=SURFACE_OUTPUTS), name='outputnode')
+
+    wf = LiterateWorkflow(name=name)
+    wf.__desc__ = f"""\
+Brain surfaces were reconstructed using `MCRIBReconAll` [M-CRIB-S, @mcribs],
+leveraging the masked, preprocessed T2w and remapped anatomical segmentation.
+"""
+
+    # dictionary to map labels from FS to M-CRIB-S
+    aseg2mcrib = {
+        2: 51,
+        3: 21,
+        4: 49,
+        5: 0,
+        7: 17,
+        8: 17,
+        10: 43,
+        11: 41,
+        12: 47,
+        13: 47,
+        14: 0,
+        15: 0,
+        16: 19,
+        17: 1,
+        18: 3,
+        26: 41,
+        28: 45,
+        31: 49,
+        41: 52,
+        42: 20,
+        43: 50,
+        44: 0,
+        46: 18,
+        47: 18,
+        49: 42,
+        50: 40,
+        51: 46,
+        52: 46,
+        53: 2,
+        54: 4,
+        58: 40,
+        60: 44,
+        63: 50,
+        253: 48,
+    }
+    map_labels = pe.Node(MapLabels(mappings=aseg2mcrib), name="map_labels")
+
+    t2w_las = pe.Node(ReorientImage(target_orientation="LAS"), name="t2w_las")
+    seg_las = t2w_las.clone(name="seg_las")
+
+    mcribs_recon = pe.Node(
+        MCRIBReconAll(surfrecon=True, autorecon_after_surf=True), name="mcribs_recon"
+    )
+    if mcribs_dir:
+        mcribs_recon.inputs.outdir = mcribs_dir
+
+    fssource = pe.Node(nio.FreeSurferSource(), name='fssource', run_without_submitting=True)
+    norm2nii = pe.Node(fs.MRIConvert(out_type="niigz"), name="norm2nii")
+
+    fsnative2t1w_xfm = pe.Node(
+        RobustRegister(auto_sens=True, est_int_scale=True),
+        name='fsnative2t1w_xfm',
+    )
+
+    t1w2fsnative_xfm = pe.Node(
+        LTAConvert(out_lta=True, invert=True),
+        name="t1w2fsnative_xfm",
+    )
+    gifti_surface_wf = init_gifti_surface_wf()
+
+    # fmt:off
+    wf.connect([
+        (inputnode, t2w_las, [("t2w", "in_file")]),
+        (inputnode, map_labels, [("ants_segs", "in_file")])
+        (map_labels, seg_las, [("out_file", "in_file")]),
+        (inputnode, mcribs_recon, [
+            ("subjects_dir", "subjects_dir"),
+            ("subject_id", "subject_id")]),
+        (t2w_las, mcribs_recon, [("out_file", "t2w_file")]),
+        (seg_las, mcribs_recon, [("out_file", "segmentation_file")]),
+        (map_labels, outputnode, [("out_file", "out_aseg")]),
+
+        # copied from infantFS workflow
+        (inputnode, fsnative2t1w_xfm, [('skullstripped_t1', 'target_file')]),
+        (fssource, norm2nii, [('norm', 'in_file')]),
+        (norm2nii, fsnative2t1w_xfm, [('out_file', 'source_file')]),
+        (fsnative2t1w_xfm, t1w2fsnative_xfm, [('out_reg_file', 'in_lta')]),
+        (inputnode, gifti_surface_wf, [
+            ("subjects_dir", "subjects_dir"),
+            ("subject_id", "subject_id")]),
+        (fsnative2t1w_xfm, gifti_surface_wf, [
+            ('out_reg_file', 'inputnode.fsnative2t1w_xfm')]),
+        (gifti_surface_wf, outputnode, [
+            ('outputnode.surfaces', 'surfaces'),
+            ('outputnode.morphometrics', 'morphometrics'),
+        ]),
+    ])
+    # fmt:on
+    return wf
 
 from nipype.interfaces import fsl
 from nipype.interfaces import utility as niu
@@ -9,49 +145,12 @@ from ...interfaces.workbench import CreateSignedDistanceVolume
 
 
 def init_infant_surface_recon_wf(*, age_months, use_aseg=False, name="infant_surface_recon_wf"):
-    from nipype.interfaces import freesurfer as fs
-    from nipype.interfaces import io as nio
-    from niworkflows.engine.workflows import LiterateWorkflow
-    from niworkflows.interfaces.freesurfer import PatchedLTAConvert as LTAConvert
-    from niworkflows.interfaces.freesurfer import (
-        PatchedRobustRegister as RobustRegister,
-    )
-    from smriprep.workflows.surfaces import init_gifti_surface_wf
-
     from nibabies.interfaces.freesurfer import InfantReconAll
 
     # Synchronized inputs to smriprep.workflows.surfaces.init_surface_recon_wf
     wf = LiterateWorkflow(name=name)
-    inputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                "subjects_dir",
-                "subject_id",
-                "t1w",
-                "t2w",
-                "flair",
-                "skullstripped_t1",
-                "corrected_t1",
-                "ants_segs",
-            ],
-        ),
-        name="inputnode",
-    )
-    outputnode = pe.Node(
-        niu.IdentityInterface(
-            fields=[
-                "subjects_dir",
-                "subject_id",
-                "t1w2fsnative_xfm",
-                "fsnative2t1w_xfm",
-                "surfaces",
-                "morphometrics",
-                "out_aseg",
-                "out_aparc",
-            ]
-        ),
-        name="outputnode",
-    )
+    inputnode = pe.Node(niu.IdentityInterface(fields=SURFACE_INPUTS), name="inputnode")
+    outputnode = pe.Node(niu.IdentityInterface(fields=SURFACE_OUTPUTS), name="outputnode")
 
     wf.__desc__ = f"""\
 Brain surfaces were reconstructed using `infant_recon_all` [FreeSurfer

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -30,7 +30,13 @@ SURFACE_OUTPUTS = [
 ]
 
 
-def init_mcribs_surface_recon_wf(*, mcribs_dir=None, name="mcribs_surface_recon_wf"):
+def init_mcribs_surface_recon_wf(*, use_aseg, mcribs_dir=None, name="mcribs_surface_recon_wf"):
+    """
+    Reconstruct cortical surfaces using the M-CRIB-S pipeline.
+
+    This workflow injects a precomputed segmentation into the M-CRIB-S pipeline, bypassing the
+    DrawEM segmentation step that is normally performed.
+    """
     from niworkflows.interfaces.nibabel import MapLabels, ReorientImage
 
     from ...interfaces.mcribs import MCRIBReconAll
@@ -136,6 +142,7 @@ leveraging the masked, preprocessed T2w and remapped anatomical segmentation.
     # fmt:on
     return wf
 
+
 from nipype.interfaces import fsl
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
@@ -144,7 +151,9 @@ from ...config import DEFAULT_MEMORY_MIN_GB
 from ...interfaces.workbench import CreateSignedDistanceVolume
 
 
-def init_infant_surface_recon_wf(*, age_months, use_aseg=False, name="infant_surface_recon_wf"):
+def init_infantfs_surface_recon_wf(
+    *, age_months, use_aseg=False, name="infantfs_surface_recon_wf"
+):
     from nibabies.interfaces.freesurfer import InfantReconAll
 
     # Synchronized inputs to smriprep.workflows.surfaces.init_surface_recon_wf

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -145,9 +145,8 @@ leveraging the masked, preprocessed T2w and remapped anatomical segmentation.
         (aparc2nii, outputnode, [('out_file', 'out_aparc')]),
         (norm2nii, fsnative2t1w_xfm, [('out_file', 'source_file')]),
         (fsnative2t1w_xfm, t1w2fsnative_xfm, [('out_reg_file', 'in_lta')]),
-        (inputnode, gifti_surface_wf, [
-            ("subjects_dir", "inputnode.subjects_dir"),
-            ("subject_id", "inputnode.subject_id")]),
+        (inputnode, gifti_surface_wf, [("subject_id", "inputnode.subject_id")]),
+        (mcribs_recon, gifti_surface_wf, [("subjects_dir", "inputnode.subjects_dir")]),
         (fsnative2t1w_xfm, gifti_surface_wf, [
             ('out_reg_file', 'inputnode.fsnative2t1w_xfm')]),
         (fsnative2t1w_xfm, outputnode, [('out_reg_file', 'fsnative2t1w_xfm')]),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -931,6 +931,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
             surface_spaces=freesurfer_spaces,
             medial_surface_nan=config.workflow.medial_surface_nan,
             project_goodvoxels=project_goodvoxels,
+            surface_recon_method=config.workflow.surface_recon_method,
             name="bold_surf_wf",
         )
         # fmt:off


### PR DESCRIPTION
This PR adds a new workflow (`init_mcribs_surface_recon_wf`) that can be used as an alternative to `recon-all`/`infant_recon_all` to produce anatomical surfaces.

To use this workflow, the new flag `--surface-recon-method` needs to be used with the option `mcribs`.


With the addition of this new flag, the now redundant `--force-reconall` flag is deprecated.
Additionally, the infantFS surface workflow was renamed to better reflect which method is being used.

## To Do
- [x] Create `brain.mgz` in FreeSurfer directory (needed for `recon_report`)
- [x] Test with latest & greatest segmentations