### PR TITLE
FIX: Remove duplicated connections

### DIFF
--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -454,6 +454,12 @@ class execution(_Config):
     @classmethod
     def init(cls):
         """Create a new BIDS Layout accessible with :attr:`~execution.layout`."""
+        # Convert string literal None to NoneType
+        if cls.unique_labels:
+            cls.unique_labels = [
+                [sub, ses] if ses != 'None' else [sub, None] for sub, ses in cls.unique_labels
+            ]
+
         if cls.fs_license_file and Path(cls.fs_license_file).is_file():
             os.environ["FS_LICENSE"] = str(cls.fs_license_file)
 

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -365,10 +365,8 @@ as target template.
         )
         # fmt:off
         wf.connect([
-            (t1w_preproc_wf, brain_extraction_wf, [
-                ("outputnode.anat_preproc", "inputnode.in_t1w")]),
             (t2w_preproc_wf, brain_extraction_wf, [
-                ("outputnode.anat_preproc", "inputnode.in_t2w")]),
+                ("outputnode.anat_preproc", "inputnode.t2w_preproc")]),
             (brain_extraction_wf, coregistration_wf, [
                 ("outputnode.t2w_preproc", "inputnode.in_t2w"),
                 ("outputnode.out_mask", "inputnode.in_mask"),

--- a/nibabies/workflows/anatomical/brain_extraction.py
+++ b/nibabies/workflows/anatomical/brain_extraction.py
@@ -107,7 +107,7 @@ def init_infant_brain_extraction_wf(
 
     inputnode = pe.Node(niu.IdentityInterface(fields=["t2w_preproc"]), name="inputnode")
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=["t2w_brain", "out_mask", "out_probmap"]),
+        niu.IdentityInterface(fields=["t2w_preproc", "t2w_brain", "out_mask", "out_probmap"]),
         name="outputnode",
     )
 
@@ -182,9 +182,9 @@ def init_infant_brain_extraction_wf(
     workflow.connect([
         (inputnode, final_n4, [("t2w_preproc", "input_image")]),
         # 1. Massage T2w
-        (inputnode, mrg_t2w, [("in_t2w", "in1")]),
-        (inputnode, lap_t2w, [("in_t2w", "op1")]),
-        (inputnode, map_mask_t2w, [("in_t2w", "reference_image")]),
+        (inputnode, mrg_t2w, [("t2w_preproc", "in1")]),
+        (inputnode, lap_t2w, [("t2w_preproc", "op1")]),
+        (inputnode, map_mask_t2w, [("t2w_preproc", "reference_image")]),
         (bin_regmask, refine_mask, [("out_file", "in_file")]),
         (refine_mask, fixed_masks, [("out_file", "in4")]),
         (lap_t2w, norm_lap_t2w, [("output_image", "in_file")]),
@@ -241,7 +241,7 @@ def init_infant_brain_extraction_wf(
         # fmt:off
         workflow.connect([
             (clip_tmpl, init_aff, [("out_file", "fixed_image")]),
-            (inputnode, init_aff, [("in_t2w", "moving_image")]),
+            (inputnode, init_aff, [("t2w_preproc", "moving_image")]),
             (init_aff, norm, [("output_transform", "initial_moving_transform")]),
         ])
         # fmt:on

--- a/nibabies/workflows/anatomical/registration.py
+++ b/nibabies/workflows/anatomical/registration.py
@@ -203,8 +203,6 @@ def init_coregistration_wf(
                 ("reverse_invert_flags", "invert_transform_flags")]),
             (map_mask, thr_mask, [("output_image", "in_file")]),
             (map_mask, final_n4, [("output_image", "weight_image")]),
-            (final_n4, apply_mask, [("output_image", "in_file")]),
-            (final_n4, outputnode, [("output_image", "t1w_preproc")]),
             (thr_mask, outputnode, [("out_mask", "t1w_mask")]),
             (thr_mask, apply_mask, [("out_mask", "in_mask")]),
         ])


### PR DESCRIPTION
These mislabeled connections were not detected because CI is using precomputed derivatives.

This catches a bug where session-less data's `session_id: None` was being coerced into a string during configuration writing/reading.