### PR TITLE
CI: Fix output order

### DIFF
--- a/.circleci/bcp_anat_outputs.txt
+++ b/.circleci/bcp_anat_outputs.txt
@@ -18,10 +18,10 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-preproc_T1w.json
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-preproc_T1w.nii.gz
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-ribbon_mask.nii.gz
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_dseg.nii.gz
-sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-fsnative_to-T1w_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-MNIInfant+1_to-T1w_mode-image_xfm.h5
-sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-fsnative_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-MNIInfant+1_mode-image_xfm.h5
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-fsnative_mode-image_xfm.txt
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-fsnative_to-T1w_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_curv.shape.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_inflated.surf.gii

--- a/.circleci/bcp_full_outputs.txt
+++ b/.circleci/bcp_full_outputs.txt
@@ -65,8 +65,8 @@ sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-confounds_times
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-confounds_timeseries.tsv
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_bold.json
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_bold.nii.gz
-sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-scanner_to-boldref_mode-image_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-scanner_to-T1w_mode-image_xfm.txt
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-scanner_to-boldref_mode-image_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-T1w_to-scanner_mode-image_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_boldref.nii.gz
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant_cohort-1_desc-aparcaseg_dseg.nii.gz

--- a/.circleci/bcp_full_outputs.txt
+++ b/.circleci/bcp_full_outputs.txt
@@ -18,10 +18,10 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-preproc_T1w.json
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-preproc_T1w.nii.gz
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_desc-ribbon_mask.nii.gz
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_dseg.nii.gz
-sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-fsnative_to-T1w_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-MNIInfant+1_to-T1w_mode-image_xfm.h5
-sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-fsnative_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-MNIInfant+1_mode-image_xfm.h5
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-T1w_to-fsnative_mode-image_xfm.txt
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_from-fsnative_to-T1w_mode-image_xfm.txt
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_curv.shape.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_inflated.surf.gii

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,6 +385,7 @@ jobs:
             mkdir -p /tmp/${DATASET}/test
             CHECK_OUTPUTS_FILE="${DATASET}_full_outputs.txt"
             cd /tmp/${DATASET}/derivatives/nibabies && tree -I 'figures|log' -lifa --noreport | sed s+^\./++ | sed '1d' | sort > /tmp/${DATASET}/test/outputs.out
+            cat /tmp/${DATASET}/test/outputs.out
             diff /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE} /tmp/${DATASET}/test/outputs.out
             rm -rf /tmp/${DATASET}/test
             exit $?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,6 +358,7 @@ jobs:
             mkdir -p /tmp/${DATASET}/test
             CHECK_OUTPUTS_FILE="${DATASET}_anat_outputs.txt"
             cd /tmp/${DATASET}/derivatives/nibabies && tree -I 'figures|log' -lifa --noreport | sed s+^\./++ | sed '1d' | sort > /tmp/${DATASET}/test/outputs.out
+            cat /tmp/${DATASET}/test/outputs.out
             diff /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE} /tmp/${DATASET}/test/outputs.out
             rm -rf /tmp/${DATASET}/test
             exit $?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,8 @@ jobs:
             CHECK_OUTPUTS_FILE="${DATASET}_anat_outputs.txt"
             cd /tmp/${DATASET}/derivatives/nibabies && tree -I 'figures|log' -lifa --noreport | sed s+^\./++ | sed '1d' | sort > /tmp/${DATASET}/test/outputs.out
             cat /tmp/${DATASET}/test/outputs.out
-            diff /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE} /tmp/${DATASET}/test/outputs.out
+            sort -o /tmp/${DATASET}/test/expected.out /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE}
+            diff /tmp/${DATASET}/test/expected.out /tmp/${DATASET}/test/outputs.out
             rm -rf /tmp/${DATASET}/test
             exit $?
       - run:
@@ -386,7 +387,8 @@ jobs:
             CHECK_OUTPUTS_FILE="${DATASET}_full_outputs.txt"
             cd /tmp/${DATASET}/derivatives/nibabies && tree -I 'figures|log' -lifa --noreport | sed s+^\./++ | sed '1d' | sort > /tmp/${DATASET}/test/outputs.out
             cat /tmp/${DATASET}/test/outputs.out
-            diff /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE} /tmp/${DATASET}/test/outputs.out
+            sort -o /tmp/${DATASET}/test/expected.out /tmp/src/nibabies/.circleci/${CHECK_OUTPUTS_FILE}
+            diff /tmp/${DATASET}/test/expected.out /tmp/${DATASET}/test/outputs.out
             rm -rf /tmp/${DATASET}/test
             exit $?
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,11 +173,11 @@ jobs:
     steps:
       - restore_cache:
           keys:
-            - data-v3-{{ .Branch }}-{{ .Revision }}
-            - data-v3--{{ .Revision }}
-            - data-v3-{{ .Branch }}-
-            - data-v3-master-
-            - data-v3-
+            - data-v0-{{ .Branch }}-{{ .Revision }}
+            - data-v0--{{ .Revision }}
+            - data-v0-{{ .Branch }}-
+            - data-v0-master-
+            - data-v0-
       - run:
           name: Install datalad + git-annex
           command: |
@@ -203,7 +203,7 @@ jobs:
               echo "Reusing cached data"
             fi
       - save_cache:
-         key: data-v3-{{ .Branch }}-{{ .Revision }}
+         key: data-v0-{{ .Branch }}-{{ .Revision }}
          paths:
             - /tmp/data
       - run:
@@ -243,7 +243,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v3-{{ .Branch }}-{{ .Revision }}
+            - data-v0-{{ .Branch }}-{{ .Revision }}
       - docker/install-docker-credential-helper
       - run: *docker_auth
       - run: *setup_docker_registry
@@ -314,7 +314,7 @@ jobs:
             - /tmp/images
       - restore_cache:
           keys:
-            - data-v3-{{ .Branch }}-{{ .Revision }}
+            - data-v0-{{ .Branch }}-{{ .Revision }}
       - restore_cache:
           keys:
             - bcp-anat-v0-{{ .Branch }}-{{ .Revision }}


### PR DESCRIPTION
- `sort` behavior seemingly changed with the newer circle images
- updated testing data derivatives formatting should now allow `--derivatives` pathway to be tested.

Continues #305 