### PR TITLE
FIX: Connect derivatives mask to mcribs recon

### DIFF
--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -848,6 +848,9 @@ def init_infant_single_anat_wf(
         else:
             # TODO: Use MCRIBS segmentation
             ...
+
+        if mask:
+            workflow.connect(mask_buffer, 'anat_mask', surface_recon_wf, 'inputnode.anat_mask')
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Running `--surface-recon mcribs` with a derivative mask would cause the process to hang indefinitely.