### PR TITLE
chore: update to latest migas api

### DIFF
--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -101,7 +101,6 @@ def main():
             nibabies_wf.run(**_plugin)
         except Exception as e:
             config.loggers.workflow.critical("nibabies failed: %s", e)
-            EXITCODE = 1
             raise
         else:
             config.loggers.workflow.log(25, "nibabies finished successfully!")

--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -3,8 +3,6 @@
 """NiBabies runner."""
 from .. import config
 
-EXITCODE: int = -1
-
 
 def main():
     """Entry point."""
@@ -26,12 +24,10 @@ def main():
 
     # collect and submit telemetry information
     # if `--notrack` is specified, nothing is done.
-    global EXITCODE
     if not config.execution.notrack:
         from nibabies.utils.telemetry import setup_migas
 
-        setup_migas(init=True)
-        atexit.register(migas_exit)
+        setup_migas()
 
     if "participant" in config.workflow.analysis_level:
         _pool = None
@@ -61,7 +57,7 @@ def main():
         # build the workflow within the same process
         # it still needs to be saved / loaded to be properly initialized
         retval = build_workflow(config_file)
-        EXITCODE = retval['return_code']
+        exitcode = retval['return_code']
         nibabies_wf = retval['workflow']
 
         # exit conditions:
@@ -70,18 +66,18 @@ def main():
         # - boilerplate only
 
         if nibabies_wf is None and not config.execution.reports_only:
-            sys.exit(EXITCODE)
+            sys.exit(exitcode)
 
         if config.execution.write_graph:
             nibabies_wf.write_graph(graph2use="colored", format="svg", simple_form=True)
 
-        if EXITCODE != 0:
-            sys.exit(EXITCODE)
+        if exitcode != 0:
+            sys.exit(exitcode)
 
         # generate boilerplate
         build_boilerplate(nibabies_wf)
         if config.execution.boilerplate_only:
-            sys.exit(EXITCODE)
+            sys.exit(exitcode)
 
         gc.collect()
 
@@ -149,38 +145,6 @@ def main():
             )
             write_derivative_description(config.execution.bids_dir, config.execution.nibabies_dir)
             write_bidsignore(config.execution.nibabies_dir)
-
-
-def migas_exit() -> None:
-    """
-    Send a final crumb to the migas server signaling if the run successfully completed
-    This function should be registered with `atexit` to run at termination.
-    """
-    import sys
-
-    from nibabies.utils.telemetry import send_breadcrumb
-
-    global EXITCODE
-    migas_kwargs = {'status': 'C'}
-    # `sys` will not have these attributes unless an error has been handled
-    if hasattr(sys, 'last_type'):
-        migas_kwargs = {
-            'status': 'F',
-            'status_desc': 'Finished with error(s)',
-            'error_type': sys.last_type,
-            'error_desc': sys.last_value,
-        }
-    elif EXITCODE != 0:
-        migas_kwargs.update(
-            {
-                'status': 'F',
-                'status_desc': f'Completed with exitcode {EXITCODE}',
-            }
-        )
-    else:
-        migas_kwargs['status_desc'] = 'Success'
-
-    send_breadcrumb(**migas_kwargs)
 
 
 if __name__ == "__main__":

--- a/nibabies/utils/telemetry.py
+++ b/nibabies/utils/telemetry.py
@@ -5,7 +5,7 @@ from .. import __version__, config
 migas = optional_package("migas")[0]
 
 
-def setup_migas(init: bool = True) -> None:
+def setup_migas(init_ping: bool = True, exit_ping: bool = True) -> None:
     """
     Prepare the migas python client to communicate with a migas server.
     If ``init`` is ``True``, send an initial breadcrumb.
@@ -16,14 +16,21 @@ def setup_migas(init: bool = True) -> None:
         session_id = config.execution.run_uuid.split('_', 1)[-1]
 
     migas.setup(session_id=session_id)
-    if init:
+    if init_ping:
         # send initial status ping
-        send_breadcrumb(status='R', status_desc='workflow start')
+        send_crumb(status='R', status_desc='workflow start')
+    if exit_ping:
+        from migas.error.nipype import node_execution_error
+
+        migas.track_exit(
+            'nipreps/nibabies',
+            __version__,
+            {'NodeExecutionError': node_execution_error},
+        )
 
 
-def send_breadcrumb(**kwargs) -> dict:
+def send_crumb(**kwargs) -> dict:
     """
     Communicate with the migas telemetry server. This requires `migas.setup()` to be called.
     """
-    res = migas.add_project("nipreps/nibabies", __version__, **kwargs)
-    return res
+    return migas.add_breadcrumb("nipreps/nibabies", __version__, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "pytest-cov",
     "pytest-env",
 ]
-telemetry = ["migas"]
+telemetry = ["migas >= 0.4.0"]
 # Aliases
 docs = ["nibabies[doc]"]
 tests = ["nibabies[test]"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ matplotlib==3.7.1
     #   seaborn
     #   smriprep
     #   tedana
-migas==0.3.0
+migas==0.4.0
     # via nibabies (pyproject.toml)
 networkx==3.1
     # via


### PR DESCRIPTION
Strips away error handling logic, which has been ported to `migas.track_exit` and lightens the server load