### PR TITLE
FIX: Raise informative error if no t1w or t2w found

### DIFF
--- a/.maint/contributors.json
+++ b/.maint/contributors.json
@@ -1,1 +1,7 @@
-[]
+[
+  {
+    "affiliation": "Montreal Neurological Institute, McGill University",
+    "name": "Huberty, Scott",
+    "orcid": "0000-0003-2637-031X"
+  }
+]

--- a/nibabies/workflows/anatomical/base.py
+++ b/nibabies/workflows/anatomical/base.py
@@ -612,6 +612,9 @@ def init_infant_single_anat_wf(
             "This workflow uses only T1w or T2w inputs, but both contrasts are available."
         )
 
+    if not (t1w or t2w):
+        raise RuntimeError("This workflow requires either a T1w or T2w, but none were found.")
+
     anat_files = t1w or t2w
     num_files = len(anat_files)
     workflow = LiterateWorkflow(name=name)


### PR DESCRIPTION
Hello! 

I am doing some debugging of a script that runs `nibabies` and noticed I was getting the error shown below. This PR aims to add a more informative `RunTimeError` for users in the future.

```
Traceback (most recent call last):
  File "/opt/conda/envs/nibabies/bin/nibabies", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/cli/run.py", line 59, in main
    retval = build_workflow(config_file)
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/cli/workflow.py", line 76, in build_workflow
    retval["workflow"] = init_nibabies_wf(config.execution.unique_labels)
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/workflows/base.py", line 130, in init_nibabies_wf
    single_subject_wf = init_single_subject_wf(
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/workflows/base.py", line 371, in init_single_subject_wf
    else init_infant_single_anat_wf(**wf_args)
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/workflows/anatomical/base.py", line 661, in init_infant_single_anat_wf
    anat_derivatives_wf = init_anat_derivatives_wf(
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nibabies/workflows/anatomical/outputs.py", line 514, in init_anat_derivatives_wf
    (inputnode, raw_sources, [(source_files, 'in_files')]),
UnboundLocalError: local variable 'raw_sources' referenced before assignment
```


As far as I can tell `Nibabies` is looking for a T1w or T2w image, and in my case none were found. 

This means that the lines in the if clauses (`if num_t1w`, .... `if num_t2w`) in [init_anat_derivatives_wf](https://github.com/nipreps/nibabies/blob/3a25507cd26d6248797e8747e1067121910016e3/nibabies/workflows/anatomical/outputs.py#L263) were not being hit, and thus `raw_sources` was never assigned, ultimately causing an `UnboundLocalError` downstream when trying to pass `raw_sources` into another function.

So in this PR I explicitly raise an error if no T1w / T2w images are found, which will hopefully be more informative than the aforementioned `UnboundLocalError`.

Hopefully this can be helpful to someone else down the line, and feel free to let me know if I'm missing anything.
