### PR TITLE
ENH: better repr for Derivatives class

### DIFF
--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -67,7 +67,10 @@ class Derivatives:
             setattr(self, name, None)
 
     def __repr__(self):
-        return '\n'.join([name for name in self.names if getattr(self, name)])
+        output = ["Derivatives |"]
+        output.extend([f"  {attr}: {getattr(self, attr)}" for attr in self.names])
+        return '\n'.join(output)
+        #return '\n'.join(f"{name}: {getattr(self, name)}" for name in self.names)
 
     def __contains__(self, val: str):
         return val in self.names

--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -70,7 +70,6 @@ class Derivatives:
         output = ["Derivatives |"]
         output.extend([f"  {attr}: {getattr(self, attr)}" for attr in self.names])
         return '\n'.join(output)
-        #return '\n'.join(f"{name}: {getattr(self, name)}" for name in self.names)
 
     def __contains__(self, val: str):
         return val in self.names

--- a/nibabies/utils/tests/test_bids.py
+++ b/nibabies/utils/tests/test_bids.py
@@ -99,6 +99,7 @@ def test_derivatives(
     assert derivatives.aseg is None
     assert derivatives.t1w_aseg is None
     assert derivatives.t2w_aseg is None
+    assert "t1w_mask" in repr(derivatives)
 
     derivatives.populate(deriv_dir, subject_id='01')
     if mask:
@@ -111,3 +112,5 @@ def test_derivatives(
         assert derivatives.references[aseg]
     else:
         assert derivatives.aseg == None
+    if t1w_mask:
+        assert "sub-01_space-T1w_desc-brain_mask.nii.gz" in repr(derivatives)


### PR DESCRIPTION
Close #348 

Sorry for the delay on getting to this. Now calling an instance of the `Derivatives` class will return something like below. WDYT? 

```
Derivatives |
  t2w_mask: None
  t1w_mask: None
  t1w_aseg: None
  t2w_aseg: None
``` 