### PR TITLE
FIX: Avoid retrieving multiple templates from latest TF

### DIFF
--- a/nibabies/cli/run.py
+++ b/nibabies/cli/run.py
@@ -125,7 +125,16 @@ def main():
                 from niworkflows.utils.misc import _copy_any
                 from templateflow import api
 
-                dseg_tsv = str(api.get("fsaverage", suffix="dseg", extension=[".tsv"]))
+                dseg_tsv = str(
+                    api.get(
+                        'fsaverage',
+                        hemi=None,
+                        atlas=None,
+                        segmentation='aparc',
+                        suffix='dseg',
+                        extension=['.tsv'],
+                    )
+                )
                 _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aseg_dseg.tsv"))
                 _copy_any(dseg_tsv, str(config.execution.nibabies_dir / "desc-aparcaseg_dseg.tsv"))
         # errno = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "smriprep ~= 0.12.1",
 #    "smriprep @ git+https://github.com/nipreps/smriprep.git@master",
     "tedana >= 0.0.12",
-    "templateflow >= 0.6",
+    "templateflow >= 24.2.0",
     "toml",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Popping up in the latest tests - this increases the minimum templateflow version and adds additional entities when retrieving the aparc dseg.