### PR TITLE
FEAT: Save CIFTI subcortical volumes

### DIFF
--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -366,6 +366,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
                 "bold_mask_native",
                 "bold_echos_native",
                 "bold_cifti",
+                "bold_rois",
                 "bold2anat_xfm",
                 "cifti_metadata",
                 "surfaces",
@@ -456,6 +457,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
             ('nonaggr_denoised_file', 'inputnode.nonaggr_denoised_file'),
             ('bold_cifti', 'inputnode.bold_cifti'),
             ('cifti_metadata', 'inputnode.cifti_metadata'),
+            ('bold_rois', 'inputnode.bold_rois'),
             ('t2star_bold', 'inputnode.t2star_bold'),
             ('t2star_t1', 'inputnode.t2star_t1'),
             ('t2star_std', 'inputnode.t2star_std'),
@@ -991,6 +993,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf` (FreeSurfe
             (subcortical_rois_wf, subcortical_mni_alignment_wf, [
                 ("outputnode.MNIInfant_rois", "inputnode.MNIInfant_rois"),
                 ("outputnode.MNI152_rois", "inputnode.MNI152_rois")]),
+            (subcortical_mni_alignment_wf, outputnode, [
+                ("outputnode.subcortical_volume", "bold_rois")]),
 
             # CIFTI surface sampling
             (inputnode, bold_fsLR_resampling_wf, [

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -209,6 +209,7 @@ def init_func_derivatives_wf(
                 "bold_mask_native",
                 "cifti_metadata",
                 "cifti_density",
+                "bold_rois",
                 "confounds",
                 "confounds_metadata",
                 "goodvoxels_mask",
@@ -823,12 +824,31 @@ def init_func_derivatives_wf(
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,
         )
 
+        ds_bold_subcortical = pe.Node(
+            DerivativesDataSink(
+                base_directory=output_dir,
+                suffix="bold",
+                compress=True,
+                TaskName=metadata.get("TaskName"),
+                space="fsLR",
+                desc="rois",
+                **timing_parameters,
+            ),
+            name="ds_bold_subcortical",
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
         # fmt: off
         workflow.connect([
             (inputnode, ds_bold_cifti, [(('bold_cifti', _unlist), 'in_file'),
                                         ('source_file', 'source_file'),
                                         ('cifti_density', 'density'),
-                                        (('cifti_metadata', _read_json), 'meta_dict')])
+                                        (('cifti_metadata', _read_json), 'meta_dict')]),
+            (inputnode, ds_bold_subcortical, [
+                ('bold_rois', 'in_file'),
+                ('source_file', 'source_file')]),
+
         ])
         # fmt: on
 


### PR DESCRIPTION
Address #251 

- My preference remains only outputting the CIFTI, and allowing users to derive this with `wb_command -cifti-separate <input-cifti> COLUMN -volume-all <output-file>`
- This will increase output size, as another copy of the BOLD series will now be present.
  - Perhaps we want to output a mask + xfm that can be applied instead (and fits better with the fit/apply approach we are moving towards)


Note: The ROI is not guaranteed to be in LAS orientation, as the reorienting happens directly in the dtseries creation workflow