### PR TITLE
FIX: nest pathlib import in fix_multi_source_name

### DIFF
--- a/nibabies/utils/misc.py
+++ b/nibabies/utils/misc.py
@@ -20,6 +20,7 @@ def fix_multi_source_name(in_files):
     '/path/to/sub-045_T1w.nii.gz'
     """
     import re
+    from pathlib import Path
 
     from nipype.utils.filemanip import filename_to_list
 


### PR DESCRIPTION
Per [nipype.pipeline.engine.utils.evaluate_connect_function](https://github.com/nipy/nipype/blob/4d1352ade7171fd5f55eff62cee4c99a4f9cfed1/nipype/pipeline/engine/utils.py#L687-L701):

```
def evaluate_connect_function(function_source, args, first_arg):
    func = create_function_from_source(function_source)
    try:
        output_value = func(first_arg, *list(args))
    except NameError as e:
        if e.args[0].startswith("global name") and e.args[0].endswith("is not defined"):
            e.args = (
                e.args[0],
                (
                    "Due to engine constraints all imports have to be done "
                    "inside each function definition"
                ),
            )
        raise e
    return output_value
```

If I'm understanding this right I think we need to nest the `pathlib.Path` import within [fix_multi_source_name](https://github.com/nipreps/nibabies/blob/7b1e91d5d84094129caa29e16803f842605eaa23/nibabies/utils/misc.py#L14).

<details><summary>Crash log that brought the issue to my attention</summary>

```
Node: nibabies_24_1_wf.single_subject_1011_sixmonth_wf.ds_report_about
Working directory: /scratch/nibabies_24_1_wf/single_subject_1011_sixmonth_wf/ds_report_about

Node inputs:

acquisition = <undefined>
atlas = <undefined>
base_directory = /out
ceagent = <undefined>
check_hdr = True
cohort = <undefined>
compress = <undefined>
data_dtype = <undefined>
datatype = figures
density = <undefined>
desc = about
direction = <undefined>
dismiss_entities = ['echo']
echo = <undefined>
extension = <undefined>
flip = <undefined>
fmap = <undefined>
fmapid = <undefined>
from = <undefined>
hemi = <undefined>
in_file = <undefined>
inv = <undefined>
label = <undefined>
meta_dict = <undefined>
modality = <undefined>
mode = <undefined>
model = <undefined>
mt = <undefined>
part = <undefined>
proc = <undefined>
reconstruction = <undefined>
recording = <undefined>
resolution = <undefined>
roi = <undefined>
run = <undefined>
scans = <undefined>
session = <undefined>
source_file = <undefined>
space = <undefined>
subject = <undefined>
subset = <undefined>
suffix = <undefined>
task = <undefined>
to = <undefined>

Traceback (most recent call last):
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/plugins/multiproc.py", line 344, in _send_procs_to_workers
    self.procs[jobid].run(updatehash=updatehash)
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 497, in run
    self._get_hashval()
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 548, in _get_hashval
    self._get_inputs()
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/engine/nodes.py", line 607, in _get_inputs
    output_value = evaluate_connect_function(
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/engine/utils.py", line 707, in evaluate_connect_function
    raise e
  File "/opt/conda/envs/nibabies/lib/python3.10/site-packages/nipype/pipeline/engine/utils.py", line 697, in evaluate_connect_function
    output_value = func(first_arg, *list(args))
  File "<string>", line 18, in fix_multi_source_name
NameError: name 'Path' is not defined


When creating this crashfile, the results file corresponding
to the node could not be found.
```

</details>

This PR fixed this issue on my side, but is there a unit test I can modify to check my understanding of the issue?



** FYI Looks like pathlib is still used by other functions in the `nibabies.utils.misc` module so I also kept the top level import of `Path`.. Let's see if that causes any flakes..
