### PR TITLE
If spherical registration not found, include the expected directory in the error message

### DIFF
--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -569,6 +569,8 @@ def _get_dhcp_spheres(subject_id: str, subjects_dir: str) -> list:
     for hemi in 'lr':
         sphere = Path(subjects_dir) / subject_id / 'surf' / f'{hemi}h.sphere.reg2'
         if not sphere.exists():
-            raise FileNotFoundError(f"MCRIBS spherical registration not found. Searched at {sphere}")
+            raise FileNotFoundError(
+                f"MCRIBS spherical registration not found. Searched at {sphere}"
+            )
         out.append(str(sphere))
     return out

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -569,6 +569,6 @@ def _get_dhcp_spheres(subject_id: str, subjects_dir: str) -> list:
     for hemi in 'lr':
         sphere = Path(subjects_dir) / subject_id / 'surf' / f'{hemi}h.sphere.reg2'
         if not sphere.exists():
-            raise OSError("MCRIBS spherical registration not found.")
+            raise FileNotFoundError(f"MCRIBS spherical registration not found. Searched at {sphere}")
         out.append(str(sphere))
     return out


### PR DESCRIPTION
I hit this  error during a nibabies run. Just making  the error message a tiny bit more verbose if you want it (knowing where Nibabies was searching for the spherical registration file was helpful to me).

EDIT: I also changed the error type from `OSError` to `FIleNotFoundError`. If you disagree with this, I can revert it back to `OSError`.