### PR TITLE
FIX: swap out remaining `load_resources` cruft with `acres` `load`

### DIFF
--- a/nibabies/workflows/bold/resampling.py
+++ b/nibabies/workflows/bold/resampling.py
@@ -647,7 +647,7 @@ The BOLD time-series were resampled onto the left/right-symmetric template
             extension='.surf.gii',
         )
     ]
-    atlases = smriprep_data.load_resource('atlases')
+    atlases = smriprep_data.load('atlases')
     select_surfaces.inputs.template_roi = [
         str(atlases / f'L.atlasroi.{fslr_density}_fs_LR.shape.gii'),
         str(atlases / f'R.atlasroi.{fslr_density}_fs_LR.shape.gii'),


### PR DESCRIPTION
If i'm understanding https://github.com/nipreps/smriprep/blob/master/smriprep/data/__init__.py

and

https://github.com/nipreps/smriprep/commit/7f4e0df4ddb9fd6cf3490171b74c9fb9d39ba7ee

correctly, I think you missed an instance of `load_resources` that needs to be changed to `load`.

When using nibabies dev with the 24.0.0rc release candidate image, this results in an error `smriprep has no attribute load_resources`