### PR TITLE
FIX: Do not require mniinfant xfm if no cifti

### DIFF
--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -514,7 +514,7 @@ It is released under the [CC0]\
             ]),
         ])  # fmt:skip
 
-        if 'MNIInfant' in [ref.space for ref in spaces.references]:
+        if cifti_output and 'MNIInfant' in [ref.space for ref in spaces.references]:
             select_MNIInfant_xfm = pe.Node(
                 KeySelect(
                     fields=['anat2std_xfm', 'std2anat_xfm'],


### PR DESCRIPTION
Closes #375 

It's a simple fix so figured I'd just do it, will work on getting CI passing now