### PR TITLE
FIX: Add missing me-t2s-fit-method option

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -456,6 +456,19 @@ Useful for further Tedana processing post-NiBabies.""",
         default=None,
         help='Initialize the random seed for the workflow',
     )
+    g_conf.add_argument(
+        '--me-t2s-fit-method',
+        action='store',
+        default='curvefit',
+        choices=['curvefit', 'loglin'],
+        help=(
+            'The method by which to estimate T2* and S0 for multi-echo data. '
+            "'curvefit' uses nonlinear regression. "
+            "It is more memory intensive, but also may be more accurate, than 'loglin'. "
+            "'loglin' uses log-linear regression. "
+            'It is faster and less memory intensive, but may be less accurate.'
+        ),
+    )
 
     # Confounds options
     g_confounds = parser.add_argument_group('Specific options for estimating confounds')

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -630,6 +630,8 @@ class workflow(_Config):
     use_syn_sdc = None
     """Run *fieldmap-less* susceptibility-derived distortions estimation
     in the absence of any alternatives."""
+    me_t2s_fit_method = 'curvefit'
+    """The method by which to estimate T2*/S0 for multi-echo data"""
 
 
 class loggers:

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -882,6 +882,7 @@ def init_bold_native_wf(
             echo_times=echo_times,
             mem_gb=mem_gb['filesize'],
             omp_nthreads=config.nipype.omp_nthreads,
+            me_t2s_fit_method=config.workflow.me_t2s_fit_method,
             name='bold_t2smap_wf',
         )
 


### PR DESCRIPTION
Adds in method by which to estimate T2*/S0 for multi-echo data, which was already available within the T2* workflow.