### PR TITLE
[ENH] Age float change + handling of sessions.tsv ages

### DIFF
--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -244,7 +244,7 @@ def parse_bids_for_age_months(
 
     scans_tsv = session_level / f'{prefix}_scans.tsv'
     if scans_tsv.exists():
-        age = _get_age_from_tsv(scans_tsv)
+        age = _get_age_from_tsv(scans_tsv, is_scans_tsv = True)
 
     if age is not None:
         return age
@@ -264,8 +264,8 @@ def parse_bids_for_age_months(
 
 
 def _get_age_from_tsv(
-    bids_tsv: Path, index_column: str | None = None, index_val: str | None = None
-) -> float | None:
+    bids_tsv: Path, index_column: str | None = None, index_val: str | None = None,
+    is_scans_tsv: bool = False) -> float | None:
     import pandas as pd
 
     df = pd.read_csv(str(bids_tsv), sep='\t')
@@ -277,6 +277,14 @@ def _get_age_from_tsv(
             break
     if age_col is None:
         return
+    
+    if is_scans_tsv: #If it is a scans.tsv, grab try to grab age from first anat file
+        try:
+            index_column = 'filename'
+            index_val = df.loc[df['filename'].str.startswith('anat'), 'filename'].iloc[0]
+        except:
+            index_column = None
+            index_val = None
 
     if not index_column or not index_val:  # Just grab first value
         idx = df.index[0]

--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -265,7 +265,7 @@ def parse_bids_for_age_months(
 
 def _get_age_from_tsv(
     bids_tsv: Path, index_column: str | None = None, index_val: str | None = None
-) -> int | None:
+) -> float | None:
     import pandas as pd
 
     df = pd.read_csv(str(bids_tsv), sep='\t')
@@ -285,7 +285,7 @@ def _get_age_from_tsv(
 
     try:
         # extract age value from row
-        age = int(df.loc[idx, age_col].item())
+        age = float(df.loc[idx, age_col].item())
     except Exception:  # noqa: BLE001
         return
 
@@ -318,12 +318,14 @@ def _get_age_units(bids_json: Path) -> ty.Literal['weeks', 'months', 'years', Fa
     return False
 
 
-def age_to_months(age: int, units: ty.Literal['weeks', 'months', 'years']) -> int:
+def age_to_months(age: float, units: ty.Literal['weeks', 'months', 'years']) -> int:
     """
     Convert a given age, in either "weeks", "months", or "years", into months.
 
     >>> age_to_months(1, 'years')
     12
+    >>> age_to_months(0.5, 'years')
+    6
     >>> age_to_months(2, 'weeks')
     0
     >>> age_to_months(3, 'weeks')
@@ -337,5 +339,7 @@ def age_to_months(age: int, units: ty.Literal['weeks', 'months', 'years']) -> in
     if units == 'weeks':
         age = round(age * WEEKS_TO_MONTH)
     elif units == 'years':
-        age *= YEARS_TO_MONTH
+        age = round(age * YEARS_TO_MONTH)
+    elif units == 'months':
+        age = round(age)
     return age


### PR DESCRIPTION
(1) Made adjustments to _get_age_from_tsv and age_to_months so that _get_age_from_tsv tries to pass a float (instead of an int) to age_to_months. The main goal behind this is to be able to give greater precision to age measures that are reported in years.
(2) Made adjustments to parse_bids_for_age_months and _get_age_from_tsv to have unique handling of age if a sessions.tsv is the source of age information. The previous functionality of _get_age_from_tsv when scans.tsv files were used was to try to grab age information from the first acquisition mentioned in the file. This current update instead has _get_age_from_tsv try to grab age from the first "anat" file in the scans.tsv. This change attempts to provide more precise age measures in the situation where many data elements (MRI, EEG, accelerometry, etc.) are collected at different times but still utilize the same scans.tsv file.