### PR TITLE
FEAT: Option to normalize CSF prior to template registration

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -753,6 +753,11 @@ discourage its usage.""",
         default=16,
         help='Frame to start head motion estimation on BOLD.',
     )
+    g_baby.add_argument(
+        '--norm-csf',
+        action='store_true',
+        help='Replace low intensity voxels in CSF mask with average',
+    )
     return parser
 
 

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -578,6 +578,8 @@ class workflow(_Config):
     """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
+    norm_csf = False
+    """Replace low intensity voxels in CSF mask with average."""
     project_goodvoxels = False
     """Exclude voxels with locally high coefficient of variation from sampling."""
     regressors_all_comps = None

--- a/nibabies/workflows/anatomical/fit.py
+++ b/nibabies/workflows/anatomical/fit.py
@@ -184,6 +184,12 @@ def init_infant_anat_fit_wf(
         name='anat_buffer',
     )
 
+    # Additional CSF normalization, if necessary
+    anat_norm_buffer = pe.Node(
+        niu.IdentityInterface(fields=['anat_preproc']),
+        name='anat_norm_buffer',
+    )
+
     if reference_anat == 'T1w':
         LOGGER.info('ANAT: Using T1w as the reference anatomical')
         workflow.connect([
@@ -637,24 +643,6 @@ def init_infant_anat_fit_wf(
                     (binarize_t2w, t2w_buffer, [('out_file', 't2w_mask')]),
                 ])  # fmt:skip
         else:
-            # Check whether we can convert a previously computed T2w mask
-            # or need to run the atlas based brain extraction
-
-            # if t1w_mask:
-            #     LOGGER.info('ANAT T1w mask will be transformed into T2w space')
-            #     transform_t1w_mask = pe.Node(
-            #         ApplyTransforms(interpolation='MultiLabel'),
-            #         name='transform_t1w_mask',
-            #     )
-
-            #     workflow.connect([
-            #         (t1w_buffer, transform_t1w_mask, [('t1w_mask', 'input_image')]),
-            #         (coreg_buffer, transform_t1w_mask, [('t1w2t2w_xfm', 'transforms')]),
-            #         (transform_t1w_mask, apply_t2w_mask, [('output_image', 'in_mask')]),
-            #         (t2w_buffer, apply_t1w_mask, [('t2w_preproc', 'in_file')]),
-            #         # TODO: Unsure about this connection^
-            #     ])  # fmt:skip
-            # else:
             LOGGER.info('ANAT Atlas-based brain mask will be calculated on the T2w')
             brain_extraction_wf = init_infant_brain_extraction_wf(
                 omp_nthreads=omp_nthreads,

--- a/nibabies/workflows/anatomical/preproc.py
+++ b/nibabies/workflows/anatomical/preproc.py
@@ -68,27 +68,50 @@ def init_anat_preproc_wf(
     return wf
 
 
-def init_anat_csf_norm_wf(name='anat_csf_norm_wf') -> LiterateWorkflow:
+def init_csf_norm_wf(name: str = 'csf_norm_wf') -> LiterateWorkflow:
     """Replace low intensity voxels within the CSF mask with the median value."""
 
     workflow = LiterateWorkflow(name=name)
-    inputnode = niu.IdentityInterface(fields=['anat_preproc', 'anat_dseg'], name='inputnode')
+    workflow.__desc__ = (
+        'The CSF mask was used to normalize the anatomical template by the median of voxels '
+        'within the mask.'
+    )
+    inputnode = niu.IdentityInterface(fields=['anat_preproc', 'anat_tpms'], name='inputnode')
     outputnode = niu.IdentityInterface(fields=['anat_preproc'], name='outputnode')
 
-    applymask = pe.Node(ApplyMask(), name='applymask')
+    # select CSF from BIDS-ordered list (GM, WM, CSF)
+    select_csf = pe.Node(niu.Select(index=2), name='select_csf')
+    norm_csf = pe.Node(niu.Function(function=_normalize_roi), name='norm_csf')
 
-    norm2median = pe.Node(niu.Function(function=_normalize_csf), name='norm2median')
-    # 1. mask brain with CSF mask
-    # fslmaths input.nii.gz -mas aseg_label-CSF_mask.nii.gz input_CSF.nii.gz
-    # 2. get median intensity of nonzero voxels in mask
-    # fslstats input_CSF.nii.gz -P 50
-    # 3. normalize CSF-masked T2w to the median
-    # fslmaths input_CSF.nii.gz -bin -mul <median intensity from (> median_CSF.nii.gz
-    # 4. make the modified T2w, setting voxel intensity to be the max between the original T2w's,
-    # and the normalized mask from (3)'s:
-    # fslmaths input.nii.gz -max median_CSF.nii.gz input_floorCSF.nii.gz
+    workflow.connect([
+        (inputnode, select_csf, [('anat_tpms', 'in_list')]),
+        (select_csf, norm_csf, [('out', 'mask_file')]),
+        (inputnode, norm_csf, [('anat_preproc', 'in_file')]),
+        (norm_csf, outputnode, [('out', 'anat_preproc')]),
+    ])  # fmt:skip
 
     return workflow
 
 
-def _normalize_csf(in_file): ...
+def _normalize_roi(in_file, mask_file, threshold=0.2, out_file=None):
+    """Normalize low intensity voxels that fall within a given mask."""
+    import nibabel as nb
+    import numpy as np
+
+    img = nb.load(in_file)
+    img_data = img.get_fdata()
+    mask_img = nb.load(mask_file)
+    # binary mask
+    bin_mask = mask_img.get_fdata() > threshold
+    mask_data = bin_mask * img_data
+
+    median = np.median(mask_data[mask_data > 0])
+    normed_data = np.maximum(img_data, bin_mask * median)
+
+    oimg = img.__class__(normed_data, img.affine, img.header)
+    if not out_file:
+        from nipype.utils.filemanip import fname_presuffix
+
+        out_file = fname_presuffix(in_file, suffix='normed')
+    oimg.to_filename(out_file)
+    return out_file

--- a/nibabies/workflows/anatomical/tests/test_preproc.py
+++ b/nibabies/workflows/anatomical/tests/test_preproc.py
@@ -1,0 +1,55 @@
+import typing as ty
+from pathlib import Path
+
+import nibabel as nb
+import numpy as np
+import pytest
+
+from nibabies.workflows.anatomical.preproc import _normalize_roi, init_csf_norm_wf
+
+EXPECTED_CSF_NORM = np.array([[[10, 73], [73, 29]], [[77, 80], [6, 16]]], dtype='uint8')
+
+
+@pytest.fixture
+def csf_norm_data(tmp_path) -> ty.Generator[tuple[Path, list[Path]], None, None]:
+    np.random.seed(10)
+
+    in_file = tmp_path / 'input.nii.gz'
+    data = np.random.randint(1, 101, size=(2, 2, 2), dtype='uint8')
+    img = nb.Nifti1Image(data, np.eye(4))
+    img.to_filename(in_file)
+
+    masks = []
+    for tpm in ('gm', 'wm', 'csf'):
+        name = tmp_path / f'{tpm}.nii.gz'
+        binmask = data > np.random.randint(10, 90)
+        masked = (binmask * 1).astype('uint8')
+        mask = nb.Nifti1Image(masked, img.affine)
+        mask.to_filename(name)
+        masks.append(name)
+
+    yield in_file, masks
+
+    in_file.unlink()
+    for m in masks:
+        m.unlink()
+
+
+def test_csf_norm_wf(tmp_path, csf_norm_data):
+    anat, tpms = csf_norm_data
+    wf = init_csf_norm_wf()
+    wf.base_dir = tmp_path
+
+    wf.inputs.inputnode.anat_preproc = anat
+    wf.inputs.inputnode.anat_tpms = tpms
+
+    # verify workflow runs
+    wf.run()
+
+    # verify function works as expected
+    outfile = _normalize_roi(anat, tpms[2])
+    assert np.array_equal(
+        np.asanyarray(nb.load(outfile).dataobj),
+        EXPECTED_CSF_NORM,
+    )
+    Path(outfile).unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "requests",
     "sdcflows >= 2.10.0",
 #    "smriprep >= 0.16.1",
-    "smriprep @ git+https://github.com/nipreps/smriprep.git@master",
+    "smriprep @ git+https://github.com/nipreps/smriprep.git@dev-nibabies",
     "tedana >= 23.0.2",
     "templateflow >= 24.2.0",
     "toml",


### PR DESCRIPTION
Adds new parser option `--norm-csf`, which will normalize the voxels within the CSF mask (max of either the median value or original value) prior to template registration.

This is experimental and should only be used carefully.