### PR TITLE
FIX: Reverse transform order for multi-step

### DIFF
--- a/nibabies/utils/transforms.py
+++ b/nibabies/utils/transforms.py
@@ -21,6 +21,9 @@ def load_transforms(xfm_paths: list[Path], inverse: list[bool]) -> nt.base.Trans
         if path.suffix == '.h5':
             # Load as a TransformChain
             xfm = nt.manip.load(path)
+            if len(xfm.transforms) == 4:
+                # MG: This behavior should be ported to nitransforms
+                xfm = nt.manip.TransformChain(reverse_pairs(xfm.transforms))
         else:
             xfm = nt.linear.load(path)
         if inv:
@@ -32,3 +35,19 @@ def load_transforms(xfm_paths: list[Path], inverse: list[bool]) -> nt.base.Trans
     if chain is None:
         chain = nt.Affine()  # Identity
     return chain
+
+
+def reverse_pairs(arr: list) -> list:
+    """
+    Reverse the order of pairs in a list.
+
+    >>> reverse_pairs([1, 2, 3, 4])
+    [3, 4, 1, 2]
+
+    >>> reverse_pairs([1, 2, 3, 4, 5, 6])
+    [5, 6, 3, 4, 1, 2]
+    """
+    rev = []
+    for i in range(len(arr), 0, -2):
+        rev.extend(arr[i - 2 : i])
+    return rev


### PR DESCRIPTION
Fixes #429 

Alter the order when loading a composite transform that includes 2 composite transforms, like is generated if using `--multi-step-reg`. This is required when mapping from the target space to the source voxels.

https://github.com/nipreps/nibabies/blob/6599e40ab39c35e25b1e20e6ec501e21ae8776d4/nibabies/interfaces/resampling.py#L563-L576

It's not clear to me if this is something that needs to be accounted for in nitransforms, or if we should handle this unorthodox case internally here - would love hear any thoughts