### PR TITLE
FIX: Multi-step-reg / composite transform misformation

### DIFF
--- a/nibabies/utils/transforms.py
+++ b/nibabies/utils/transforms.py
@@ -21,9 +21,6 @@ def load_transforms(xfm_paths: list[Path], inverse: list[bool]) -> nt.base.Trans
         if path.suffix == '.h5':
             # Load as a TransformChain
             xfm = nt.manip.load(path)
-            if len(xfm.transforms) == 4:
-                # MG: This behavior should be ported to nitransforms
-                xfm = nt.manip.TransformChain(reverse_pairs(xfm.transforms))
         else:
             xfm = nt.linear.load(path)
         if inv:
@@ -35,19 +32,3 @@ def load_transforms(xfm_paths: list[Path], inverse: list[bool]) -> nt.base.Trans
     if chain is None:
         chain = nt.Affine()  # Identity
     return chain
-
-
-def reverse_pairs(arr: list) -> list:
-    """
-    Reverse the order of pairs in a list.
-
-    >>> reverse_pairs([1, 2, 3, 4])
-    [3, 4, 1, 2]
-
-    >>> reverse_pairs([1, 2, 3, 4, 5, 6])
-    [5, 6, 3, 4, 1, 2]
-    """
-    rev = []
-    for i in range(len(arr), 0, -2):
-        rev.extend(arr[i - 2 : i])
-    return rev

--- a/nibabies/workflows/anatomical/fit.py
+++ b/nibabies/workflows/anatomical/fit.py
@@ -988,8 +988,8 @@ def init_infant_anat_fit_wf(
             (concat_std2anat_buffer, select_infant_mni, [('out', 'std2anat_xfm')]),
             (select_infant_mni, concat_reg_wf, [
                 ('key', 'inputnode.intermediate'),
-                ('anat2std_xfm', 'inputnode.anat2std_xfm'),
-                ('std2anat_xfm', 'inputnode.std2anat_xfm'),
+                ('anat2std_xfm', 'inputnode.anat2int_xfm'),
+                ('std2anat_xfm', 'inputnode.int2anat_xfm'),
             ]),
             (sourcefile_buffer, ds_concat_reg_wf, [
                 ('anat_source_files', 'inputnode.source_files')
@@ -1905,8 +1905,8 @@ def init_infant_single_anat_fit_wf(
             (concat_std2anat_buffer, select_infant_mni, [('out', 'std2anat_xfm')]),
             (select_infant_mni, concat_reg_wf, [
                 ('key', 'inputnode.intermediate'),
-                ('anat2std_xfm', 'inputnode.anat2std_xfm'),
-                ('std2anat_xfm', 'inputnode.std2anat_xfm'),
+                ('anat2std_xfm', 'inputnode.anat2int_xfm'),
+                ('std2anat_xfm', 'inputnode.int2anat_xfm'),
             ]),
             (sourcefile_buffer, ds_concat_reg_wf, [
                 ('anat_source_files', 'inputnode.source_files')

--- a/nibabies/workflows/anatomical/registration.py
+++ b/nibabies/workflows/anatomical/registration.py
@@ -387,7 +387,7 @@ stored for reuse and accessed with *TemplateFlow* [{tf_ver}, @templateflow]:
                 'template',  # template identifier (name[+cohort])
                 'intermediate',  # intermediate space (name[+cohort])
                 'anat2int_xfm',  # anatomical -> intermediate
-                'int2anat_xfm',  # std -> intermediate
+                'int2anat_xfm',  # intermediate -> anatomical
             ]
         ),
         name='inputnode',
@@ -537,6 +537,22 @@ def _load_intermediate_xfms(intermediate, std):
 
 
 def _create_inverse_composite(in_file, out_file='inverse_composite.h5'):
+    """Build a composite transform with SimpleITK.
+
+    This serves as a workaround for a bug in ANTs's CompositeTransformUtil
+    where composite transforms cannot be created with a displacement field placed first.
+
+    Parameters
+    ----------
+    in_file : list of str
+        List of input transforms to concatenate into a composite transform.
+    out_file : str, optional
+        File to write the composite transform to.
+
+    Returns
+    -------
+    out_file : str
+        Absolute path to the composite transform.
     from pathlib import Path
 
     import SimpleITK as sitk

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -846,6 +846,13 @@ def init_workflow_spaces(execution_spaces: SpatialReferences, age_months: int):
     if not spaces.is_cached():
         spaces.checkpoint()
 
+    # Ensure one cohort of MNIInfant is always available as an internal space
+    if not any(
+        space.startswith('MNIInfant') for space in spaces.get_spaces(nonstandard=False, dim=(3,))
+    ):
+        cohort = cohort_by_months('MNIInfant', age_months)
+        spaces.add(Reference('MNIInfant', {'cohort': cohort}))
+
     if config.workflow.cifti_output:
         # CIFTI grayordinates to corresponding FSL-MNI resolutions.
         vol_res = '2' if config.workflow.cifti_output == '91k' else '1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "psutil >= 5.4",
     "pybids >= 0.15.0",
     "requests",
+    "SimpleITK",
     "sdcflows >= 2.10.0",
     "smriprep >= 0.17.0",
     "tedana >= 23.0.2",


### PR DESCRIPTION
Hopefully the end of this mini-saga - thanks to @tsalo @mattcieslak for taking a look.

Changes included in this:
- Fix ordering in multi-step-reg's anat2std_xfm and std2anat_xfm
- Disassemble transform components in standalone nodes for improved transparency
- Change inputnode fields to reflect intermediate are being used.
- Cache intermediate <-> std transforms to node working directories.
- Add SimpleITK as a dependency for assembling inverse std2anat xfm, until ants CompositeTransformUtil is addressed.