### PR TITLE
ENH: Minimize clipping prior to surface reconstruction with MCRIBS

### DIFF
--- a/nibabies/interfaces/tests/test_mcribs.py
+++ b/nibabies/interfaces/tests/test_mcribs.py
@@ -1,0 +1,65 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nibabies.interfaces.mcribs import MCRIBReconAll
+
+SUBJECT_ID = 'X'
+
+
+@pytest.fixture
+def mcribs_directory(tmp_path):
+    def make_tree(path, tree):
+        for d, fls in tree.items():
+            (path / d).mkdir(exist_ok=True)
+            for f in fls:
+                (path / d / f).touch()
+
+    root = tmp_path / 'mcribs'
+    surfrecon = root / SUBJECT_ID / 'SurfReconDeformable' / SUBJECT_ID
+    surfrecon.mkdir(parents=True, exist_ok=True)
+    make_tree(surfrecon, MCRIBReconAll._expected_files['surfrecon'])
+    autorecon = root / SUBJECT_ID / 'freesurfer' / SUBJECT_ID
+    autorecon.mkdir(parents=True, exist_ok=True)
+    make_tree(autorecon, MCRIBReconAll._expected_files['autorecon'])
+
+    yield root
+
+    shutil.rmtree(root)
+
+
+def test_MCRIBReconAll(mcribs_directory):
+    t2w = Path('T2w.nii.gz')
+    t2w.touch()
+
+    surfrecon = MCRIBReconAll(
+        subject_id=SUBJECT_ID,
+        surfrecon=True,
+        surfrecon_method='Deformable',
+        join_thresh=1.0,
+        fast_collision=True,
+    )
+
+    # Requires T2w input
+    with pytest.raises(AttributeError):
+        surfrecon.cmdline  # noqa
+
+    surfrecon.inputs.t2w_file = t2w
+    # Since no existing directory is found, will run fresh
+    assert 'MCRIBReconAll --deformablefastcollision --deformablejointhresh' in surfrecon.cmdline
+
+    # But should not need to run again
+    surfrecon.inputs.outdir = mcribs_directory
+    assert surfrecon.cmdline == 'echo MCRIBReconAll: nothing to do'
+
+    t2w.unlink()
+
+    autorecon = MCRIBReconAll(
+        subject_id=SUBJECT_ID,
+        autorecon_after_surf=True,
+    )
+    # No need for T2w here
+    assert autorecon.cmdline == 'MCRIBReconAll --autoreconaftersurf X'
+    autorecon.inputs.outdir = mcribs_directory
+    assert autorecon.cmdline == 'echo MCRIBReconAll: nothing to do'

--- a/nibabies/workflows/anatomical/fit.py
+++ b/nibabies/workflows/anatomical/fit.py
@@ -1030,7 +1030,6 @@ def init_infant_anat_fit_wf(
         surface_recon_wf = init_mcribs_surface_recon_wf(
             omp_nthreads=omp_nthreads,
             use_aseg=bool(anat_aseg),
-            use_mask=True,
             precomputed=precomputed,
             mcribs_dir=str(config.execution.mcribs_dir),
         )
@@ -1040,10 +1039,8 @@ def init_infant_anat_fit_wf(
                 ('subject_id', 'inputnode.subject_id'),
                 ('subjects_dir', 'inputnode.subjects_dir'),
             ]),
-            (t2w_buffer, surface_recon_wf, [
-                ('t2w_preproc', 'inputnode.t2w'),
-                ('t2w_mask', 'inputnode.in_mask'),
-            ]),
+            (t2w_validate, surface_recon_wf, [('out_file', 'inputnode.t2w')]),
+            (t2w_buffer, surface_recon_wf, [('t2w_mask', 'inputnode.in_mask'),]),
             (aseg_buffer, surface_recon_wf, [
                 ('anat_aseg', 'inputnode.in_aseg'),
             ]),
@@ -1950,7 +1947,6 @@ def init_infant_single_anat_fit_wf(
         surface_recon_wf = init_mcribs_surface_recon_wf(
             omp_nthreads=omp_nthreads,
             use_aseg=bool(anat_aseg),
-            use_mask=True,
             precomputed=precomputed,
             mcribs_dir=str(config.execution.mcribs_dir),
         )
@@ -1960,10 +1956,8 @@ def init_infant_single_anat_fit_wf(
                 ('subject_id', 'inputnode.subject_id'),
                 ('subjects_dir', 'inputnode.subjects_dir'),
             ]),
-            (anat_buffer, surface_recon_wf, [
-                ('anat_preproc', 'inputnode.t2w'),
-                ('anat_mask', 'inputnode.in_mask'),
-            ]),
+            (anat_validate, surface_recon_wf, [('out_file', 'inputnode.t2w')]),
+            (anat_buffer, surface_recon_wf, [('anat_mask', 'inputnode.in_mask')]),
             (aseg_buffer, surface_recon_wf, [
                 ('anat_aseg', 'inputnode.in_aseg'),
             ]),

--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -122,21 +122,6 @@ def init_mcribs_surface_recon_wf(
     t2w_las = pe.Node(ReorientImage(target_orientation='LAS'), name='t2w_las')
     seg_las = pe.Node(ReorientImage(target_orientation='LAS'), name='seg_las')
 
-    mcribs_recon = pe.Node(
-        MCRIBReconAll(
-            surfrecon=True,
-            surfrecon_method='Deformable',
-            join_thresh=1.0,
-            fast_collision=True,
-            nthreads=omp_nthreads,
-        ),
-        name='mcribs_recon',
-        mem_gb=5,
-    )
-    if mcribs_dir:
-        mcribs_recon.inputs.outdir = mcribs_dir
-        mcribs_recon.config = {'execution': {'remove_unnecessary_outputs': False}}
-
     # dilated mask and use in recon-neonatal-cortex
     mask_dil = pe.Node(BinaryDilation(radius=3), name='mask_dil')
     mask_las = pe.Node(ReorientImage(target_orientation='LAS'), name='mask_las')
@@ -157,11 +142,26 @@ def init_mcribs_surface_recon_wf(
         name='n4_mcribs',
     )
 
+    mcribs_recon = pe.Node(
+        MCRIBReconAll(
+            surfrecon=True,
+            surfrecon_method='Deformable',
+            join_thresh=1.0,
+            fast_collision=True,
+            nthreads=omp_nthreads,
+            outdir=mcribs_dir,
+        ),
+        name='mcribs_recon',
+        mem_gb=5,
+    )
+    mcribs_recon.config = {'execution': {'remove_unnecessary_outputs': False}}
+
     mcribs_postrecon = pe.Node(
         MCRIBReconAll(autorecon_after_surf=True, nthreads=omp_nthreads),
         name='mcribs_postrecon',
         mem_gb=5,
     )
+    mcribs_postrecon.config = {'execution': {'remove_unnecessary_outputs': False}}
 
     fssource = pe.Node(FreeSurferSource(), name='fssource', run_without_submitting=True)
     midthickness_wf = init_make_midthickness_wf(omp_nthreads=omp_nthreads)


### PR DESCRIPTION
For FreeSurfer / InfantFS, we have passed in the anatomical template - not the preprocessed anatomical - as the input. However, MCRIBS is different, since we are bypassing some of the early preprocessing in the pipeline (conforming, n4, etc). However, due to the intensity clipping, it was reported that the white matter white surface may have been hitting the upper bounds, potentially leading to a decrease in cortical thickness.

This PR restructures the MCRIBS pipeline in the following ways:
- Pass in the anatomical template T2w (a single volume that has gone through DenoiseImage)
- Run N4BiasCorrection prior to MCRIBS injection, making sure to pass in a mask to enable `rescale_intensities` to actually run (it is disabled without a mask present).