### PR TITLE
FIX: Match mask header prior to n4 correction

### DIFF
--- a/nibabies/workflows/anatomical/surfaces.py
+++ b/nibabies/workflows/anatomical/surfaces.py
@@ -15,6 +15,7 @@ from niworkflows.interfaces.freesurfer import (
 from niworkflows.interfaces.freesurfer import (
     PatchedRobustRegister as RobustRegister,
 )
+from niworkflows.interfaces.header import MatchHeader
 from niworkflows.interfaces.morphology import BinaryDilation
 from niworkflows.interfaces.patches import FreeSurferSource
 from smriprep.interfaces.freesurfer import MakeMidthickness
@@ -126,6 +127,9 @@ def init_mcribs_surface_recon_wf(
     mask_dil = pe.Node(BinaryDilation(radius=3), name='mask_dil')
     mask_las = pe.Node(ReorientImage(target_orientation='LAS'), name='mask_las')
 
+    # N4 has low tolerance for mismatch between input / mask
+    match_header = pe.Node(MatchHeader(), name='match_header')
+
     # N4BiasCorrection occurs in MCRIBTissueSegMCRIBS (which is skipped)
     # Run it (with mask to rescale intensities) prior injection
     n4_mcribs = pe.Node(
@@ -177,7 +181,9 @@ def init_mcribs_surface_recon_wf(
             ('subjects_dir', 'subjects_dir'),
             ('subject_id', 'subject_id')]),
         (t2w_las, n4_mcribs, [('out_file', 'input_image')]),
-        (mask_las, n4_mcribs, [('out_file', 'mask_image')]),
+        (mask_las, match_header, [('out_file', 'in_file')]),
+        (t2w_las, match_header, [('out_file', 'reference')]),
+        (match_header, n4_mcribs, [('out_file', 'mask_image')]),
         (n4_mcribs, mcribs_recon, [('output_image', 't2w_file')]),
         (seg_las, mcribs_recon, [('out_file', 'segmentation_file')]),
         (inputnode, mcribs_postrecon, [


### PR DESCRIPTION
Closes #442 

Some affine skewing may occur after `DenoiseImage`, which can cause the t2w mask and template to differ enough to make `N4BiasCorrection` upset. This ensures the mask and template have the same header prior to N4 correction leveraging the mask to localize intensity rescaling.

As of niworkflows 1.12.2, `MatchHeader` will just emit a warning if a significant difference is found - opened https://github.com/nipreps/niworkflows/issues/924 with plans to restrict tolerance in a future release