### PR TITLE
DOC: Changed "B0Identifier" -> "B0FieldIdentifier"

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -284,7 +284,7 @@ Coregistration outputs are part of the *minimal* processing level.
 
 If a fieldmap is used for the correction of a BOLD series, then a registration
 is calculated between the BOLD series and the fieldmap. If, for example, the fieldmap
-is identified with `"B0Identifier": "TOPUP"`, the generated transform will be named
+is identified with `"B0FieldIdentifier": "TOPUP"`, the generated transform will be named
 
 ```
 sub-<subject_label>/[ses-<session_label>/]


### PR DESCRIPTION
The outputs page on the docs specifies that topup should be identified with the ["B0Identifier"](https://nibabies.readthedocs.io/en/latest/outputs.html#fieldmap-registration) field, when the BIDS spec specifies [the "B0FieldIdentifier" field should be used instead](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#using-b0fieldidentifier-metadata)