### PR TITLE
MNT: Update ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,8 +154,6 @@ extend-exclude = [
 
 [tool.ruff.lint]
 extend-select = [
-  "F",
-  "E",
   "W",
   "I",
   "UP",
@@ -176,9 +174,8 @@ extend-select = [
   "PT",
   "Q",
 ]
-extend-ignore = [
+ignore = [
   "S311",  # We are not using random for cryptographic purposes
-  "ISC001",
   "S603",
 ]
 


### PR DESCRIPTION
* No need to specify `E` and `F` rules with `extend-select`.
* Setting `extend-ignore` has been deprecated. Use plain `ignore` instead.
* Rule `ISC001` is now compatible with `ruff format`.