### PR TITLE
fix: incorrect number of found t2w scans

### DIFF
--- a/nibabies/workflows/anatomical/fit.py
+++ b/nibabies/workflows/anatomical/fit.py
@@ -406,7 +406,7 @@ def init_infant_anat_fit_wf(
 
         t2w_template_wf = init_anat_template_wf(
             image_type='T2w',
-            num_files=num_t1w,
+            num_files=num_t2w,
             longitudinal=longitudinal,
             omp_nthreads=omp_nthreads,
             name='t2w_template_wf',


### PR DESCRIPTION
Fixes #496 

In cases where T1w and T2w anatomical images were present, there was a potential incorrect count of T2w images - leading to downstream crashes.