### PR TITLE
ISC001 compatible with `ruff format` since ruff 0.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ skip_install = true
 commands =
   ruff check --fix
   ruff format
-  ruff check --select ISC001
 
 [testenv:spellcheck]
 description = Check spelling


### PR DESCRIPTION
https://astral.sh/blog/ruff-v0.9.0#fewer-single-line-implicitly-concatenated-strings