### PR TITLE
FEAT: Add `auto` option to `--hmc-bold-frame` to find a low-motion BOLD reference

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -762,8 +762,8 @@ discourage its usage.""",
     g_baby.add_argument(
         '--estimate-good-refframe',
         action='store_true',
-        help='Estimate and find a low-motion BOLD reference frame out of each timeseries instead of '
-        'running RobustAverage over all frames after ``hmc_bold_frame.``'
+        help='Use a heuristic to estimate a low-motion BOLD reference frame out '
+        'of each timeseries instead of running RobustAverage over all frames after ``hmc_bold_frame.``'
     )
     g_baby.add_argument(
         '--norm-csf',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -142,7 +142,10 @@ def _build_parser():
         if value.lower() == 'auto':
             return 'auto'
         try:
-            return int(value)
+            value = int(value)
+            if value < 0:
+                raise ValueError()
+            return value
         except ValueError:
             raise parser.error(
                 f"--hmc-bold-frame must be either 'auto' or a positive integer. Received {value}."

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -139,14 +139,14 @@ def _build_parser():
                 raise parser.error(f'Path does not exist: <{value}>.')
 
     def _pos_int_or_auto(value, parser):
-        import re
-        if re.fullmatch(r'\+?\d+', value):  # positive int
-            value = int(value)
-        elif value != "auto":
+        if value.lower() == 'auto':
+            return 'auto'
+        try:
+            return int(value)
+        except ValueError:
             raise parser.error(
                 f"--hmc-bold-frame must be either 'auto' or a positive integer. Received {value}."
             )
-        return value
 
     def _slice_time_ref(value, parser):
         if value == 'start':

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -757,13 +757,13 @@ discourage its usage.""",
         '--hmc-bold-frame',
         type=int,
         default=16,
-        help='Frame to start head motion estimation on BOLD.',
+        help='Frame to start head motion estimation on BOLD',
     )
     g_baby.add_argument(
-        '--find-good-hmc-refframe',
+        '--estimate-good-refframe',
         action='store_true',
-        help='Find a low-motion BOLD reference frame out of each timeseries instead of '
-        'running RobustAverage over all frames after hmc_bold_frame.'
+        help='Estimate and find a low-motion BOLD reference frame out of each timeseries instead of '
+        'running RobustAverage over all frames after ``hmc_bold_frame.``'
     )
     g_baby.add_argument(
         '--norm-csf',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -464,6 +464,15 @@ Useful for further Tedana processing post-NiBabies.""",
         help='Number of non steady state volumes.',
     )
     g_conf.add_argument(
+        '--sdc-boldref-fd-threshold',
+        required=False,
+        action='store',
+        default=None,
+        type=float,
+        help='A framewise displacement (FD) threshold which masks high-motion frames '
+        'before creating an average BOLD reference image for use in SDC correction. '
+    )
+    g_conf.add_argument(
         '--random-seed',
         dest='_random_seed',
         action='store',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -146,10 +146,10 @@ def _build_parser():
             if value < 0:
                 raise ValueError()
             return value
-        except ValueError:
+        except ValueError as err:
             raise parser.error(
                 f"--hmc-bold-frame must be either 'auto' or a positive integer. Received {value}."
-            )
+            ) from err
 
     def _slice_time_ref(value, parser):
         if value == 'start':

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -98,7 +98,7 @@ def _build_parser():
     def _to_gb(value):
         scale = {'G': 1, 'T': 10**3, 'M': 1e-3, 'K': 1e-6, 'B': 1e-9}
         digits = ''.join([c for c in value if c.isdigit()])
-        units = value[len(digits):] or 'M'
+        units = value[len(digits) :] or 'M'
         return int(digits) * scale[units[0]]
 
     def _drop_sub(value):
@@ -770,7 +770,7 @@ discourage its usage.""",
         metavar='{auto,FRAME_NUMBER}',
         help='Frame to start head motion estimation on BOLD. '
         '``auto`` chooses this frame based on a sum-of-least-squares '
-        'heuristic.'
+        'heuristic.',
     )
     g_baby.add_argument(
         '--norm-csf',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -769,6 +769,12 @@ discourage its usage.""",
         help='Frame to start head motion estimation on BOLD.',
     )
     g_baby.add_argument(
+        '--find-good-hmc-refframe',
+        action='store_true',
+        help='Find a low-motion BOLD reference frame out of each timeseries instead of '
+        'running RobustAverage over all frames after hmc_bold_frame.'
+    )
+    g_baby.add_argument(
         '--norm-csf',
         action='store_true',
         help='Replace low intensity voxels in CSF mask with average',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -766,7 +766,7 @@ discourage its usage.""",
     g_baby.add_argument(
         '--hmc-bold-frame',
         type=_pos_int_or_auto,
-        default='auto',
+        default=16,
         metavar='{auto,FRAME_NUMBER}',
         help='Frame to start head motion estimation on BOLD. '
         '``auto`` chooses this frame based on a sum-of-least-squares '

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -464,15 +464,6 @@ Useful for further Tedana processing post-NiBabies.""",
         help='Number of non steady state volumes.',
     )
     g_conf.add_argument(
-        '--sdc-boldref-fd-threshold',
-        required=False,
-        action='store',
-        default=None,
-        type=float,
-        help='A framewise displacement (FD) threshold which masks high-motion frames '
-        'before creating an average BOLD reference image for use in SDC correction. '
-    )
-    g_conf.add_argument(
         '--random-seed',
         dest='_random_seed',
         action='store',

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -766,8 +766,8 @@ discourage its usage.""",
     g_baby.add_argument(
         '--hmc-bold-frame',
         type=_pos_int_or_auto,
-        default=16,
-        metavar="{auto,FRAME_NUMBER}",
+        default='auto',
+        metavar='{auto,FRAME_NUMBER}',
         help='Frame to start head motion estimation on BOLD. '
         '``auto`` chooses this frame based on a sum-of-least-squares '
         'heuristic.'

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -19,6 +19,7 @@ def _build_parser():
         Action,
         ArgumentDefaultsHelpFormatter,
         ArgumentParser,
+        ArgumentTypeError,
         BooleanOptionalAction,
     )
     from functools import partial
@@ -138,7 +139,7 @@ def _build_parser():
             else:
                 raise parser.error(f'Path does not exist: <{value}>.')
 
-    def _pos_int_or_auto(value, parser):
+    def _pos_int_or_auto(value):
         if value.lower() == 'auto':
             return 'auto'
         try:
@@ -147,7 +148,7 @@ def _build_parser():
                 raise ValueError()
             return value
         except ValueError as err:
-            raise parser.error(
+            raise ArgumentTypeError(
                 f"--hmc-bold-frame must be either 'auto' or a positive integer. Received {value}."
             ) from err
 

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -596,6 +596,9 @@ class workflow(_Config):
     """Threshold for :abbr:`FD (frame-wise displacement)`."""
     run_reconall = True
     """Run FreeSurfer's surface reconstruction."""
+    sdc_boldref_fd_threshold = None
+    """A framewise displacement (FD) threshold which masks high-motion frames
+    before creating an average BOLD reference image for use in SDC correction."""
     skull_strip_fixed_seed = False
     """Fix a seed for skull-stripping."""
     skull_strip_template = 'UNCInfant:cohort-1'

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -563,6 +563,9 @@ class workflow(_Config):
     """Set a number of initial scans to be considered nonsteady states."""
     fd_radius = 45
     """Head radius in mm for framewise displacement calculation"""
+    find_good_hmc_refframe = False
+    """Find a single BOLD reference frame out of each timeseries instead of
+    running RobustAverage over all frames after hmc_bold_frame."""
     fmap_bspline = None
     """Regularize fieldmaps with a field of B-Spline basis."""
     fmap_demean = None
@@ -572,7 +575,8 @@ class workflow(_Config):
     hires = None
     """Run FreeSurfer ``recon-all`` with the ``-hires`` flag."""
     hmc_bold_frame = 16
-    """Frame to start head motion correction estimation on BOLD"""
+    """Frame to start head motion correction estimation on BOLD. Cannot be used
+    with --find-good-hmc-ref"""
     ignore = None
     """Ignore particular steps for *nibabies*."""
     level = None
@@ -596,9 +600,6 @@ class workflow(_Config):
     """Threshold for :abbr:`FD (frame-wise displacement)`."""
     run_reconall = True
     """Run FreeSurfer's surface reconstruction."""
-    sdc_boldref_fd_threshold = None
-    """A framewise displacement (FD) threshold which masks high-motion frames
-    before creating an average BOLD reference image for use in SDC correction."""
     skull_strip_fixed_seed = False
     """Fix a seed for skull-stripping."""
     skull_strip_template = 'UNCInfant:cohort-1'

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -561,9 +561,6 @@ class workflow(_Config):
     """Generate HCP Grayordinates, accepts either ``'91k'`` (default) or ``'170k'``."""
     dummy_scans = None
     """Set a number of initial scans to be considered nonsteady states."""
-    estimate_good_refframe = False
-    """Use a heuristic to estimate a good BOLD reference frame in each timeseries, instead of
-    running RobustAverage over all frames after ``hmc_bold_frame``."""
     fd_radius = 45
     """Head radius in mm for framewise displacement calculation"""
     fmap_bspline = None

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -561,11 +561,11 @@ class workflow(_Config):
     """Generate HCP Grayordinates, accepts either ``'91k'`` (default) or ``'170k'``."""
     dummy_scans = None
     """Set a number of initial scans to be considered nonsteady states."""
+    estimate_good_refframe = False
+    """Find a single BOLD reference frame out of each timeseries instead of
+    running RobustAverage over all frames after ``hmc_bold_frame``."""
     fd_radius = 45
     """Head radius in mm for framewise displacement calculation"""
-    find_good_hmc_refframe = False
-    """Find a single BOLD reference frame out of each timeseries instead of
-    running RobustAverage over all frames after hmc_bold_frame."""
     fmap_bspline = None
     """Regularize fieldmaps with a field of B-Spline basis."""
     fmap_demean = None

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -572,7 +572,7 @@ class workflow(_Config):
     hires = None
     """Run FreeSurfer ``recon-all`` with the ``-hires`` flag."""
     hmc_bold_frame = 16
-    """Frame to start head motion correction estimation on BOLD."""
+    """Frame to start head motion correction estimation on BOLD. If 'auto', use heuristic to estimate reference in each timeseries"""
     ignore = None
     """Ignore particular steps for *nibabies*."""
     level = None

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -575,8 +575,7 @@ class workflow(_Config):
     hires = None
     """Run FreeSurfer ``recon-all`` with the ``-hires`` flag."""
     hmc_bold_frame = 16
-    """Frame to start head motion correction estimation on BOLD. Cannot be used
-    with --find-good-hmc-ref"""
+    """Frame to start head motion correction estimation on BOLD."""
     ignore = None
     """Ignore particular steps for *nibabies*."""
     level = None

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -562,7 +562,7 @@ class workflow(_Config):
     dummy_scans = None
     """Set a number of initial scans to be considered nonsteady states."""
     estimate_good_refframe = False
-    """Find a single BOLD reference frame out of each timeseries instead of
+    """Use a heuristic to estimate a good BOLD reference frame in each timeseries, instead of
     running RobustAverage over all frames after ``hmc_bold_frame``."""
     fd_radius = 45
     """Head radius in mm for framewise displacement calculation"""

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -38,7 +38,7 @@ class DetectReferenceFrame(SimpleInterface):
 
     def _run_interface(self, runtime):
         out_path = fname_presuffix(self.inputs.in_file, suffix='_refframe', newpath=runtime.cwd)
-        _detect_reference_frame(
+        out_file, frame_idx = _detect_reference_frame(
             in_file=self.inputs.in_file,
             ref_frame_start=self.inputs.ref_frame_start,
             out_file=out_path,

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -8,7 +8,7 @@ from nipype.interfaces.base import (
 from nipype.utils.filemanip import fname_presuffix
 
 
-class _SelectOneFrameInputSpec(BaseInterfaceInputSpec):
+class _DetectReferenceFrameInputSpec(BaseInterfaceInputSpec):
     in_file = File(
         exists=True,
         mandatory=True,
@@ -25,19 +25,19 @@ class _SelectOneFrameInputSpec(BaseInterfaceInputSpec):
     )
 
 
-class _SelectOneFrameOutputSpec(TraitedSpec):
+class _DetectReferenceFrameOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="Single reference frame")
 
 
 class DetectReferenceFrame(SimpleInterface):
     """Select one reference frame for HMC and SDC correction"""
 
-    input_spec = _SelectOneFrameInputSpec
-    output_spec = _SelectOneFrameOutputSpec
+    input_spec = _DetectReferenceFrameInputSpec
+    output_spec = _DetectReferenceFrameOutputSpec
 
     def _run_interface(self, runtime):
         out_path = fname_presuffix(self.inputs.in_file, suffix='_refframe', newpath=runtime.cwd)
-        _select_one_frame(
+        _detect_reference_frame(
             in_file=self.inputs.in_file,
             ref_frame_start=self.inputs.ref_frame_start,
             out_file=out_path,

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -78,4 +78,4 @@ def _detect_reference_frame(
         affine=img.affine
     )
     nb.save(chosen_frame_img, out_file)
-    return out_file
+    return out_file, chosen_frame

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -9,24 +9,17 @@ from nipype.utils.filemanip import fname_presuffix
 
 
 class _DetectReferenceFrameInputSpec(BaseInterfaceInputSpec):
-    in_file = File(
-        exists=True,
-        mandatory=True,
-        desc="BOLD timeseries"
-    )
+    in_file = File(exists=True, mandatory=True, desc='BOLD timeseries')
     ref_frame_start = traits.Int(
-        mandatory=True,
-        desc="Frame to start looking for a low-motion reference frame"
+        mandatory=True, desc='Frame to start looking for a low-motion reference frame'
     )
     dummy_scans = traits.Either(
-        None, traits.Int,
-        usedefault=True,
-        desc="Number of non-steady-state scans at the start."
+        None, traits.Int, usedefault=True, desc='Number of non-steady-state scans at the start.'
     )
 
 
 class _DetectReferenceFrameOutputSpec(TraitedSpec):
-    out_file = File(exists=True, desc="Single reference frame")
+    out_file = File(exists=True, desc='Single reference frame')
     frame_idx = traits.Int(desc='Frame index used')
 
 
@@ -42,7 +35,7 @@ class DetectReferenceFrame(SimpleInterface):
             in_file=self.inputs.in_file,
             ref_frame_start=self.inputs.ref_frame_start,
             out_file=out_path,
-            dummy_scans=self.inputs.dummy_scans
+            dummy_scans=self.inputs.dummy_scans,
         )
         self._results['out_file'] = out_file
         self._results['frame_idx'] = frame_idx
@@ -50,14 +43,12 @@ class DetectReferenceFrame(SimpleInterface):
 
 
 def _detect_reference_frame(
-    in_file: str,
-    ref_frame_start: int,
-    out_file: str,
-    dummy_scans: int | None = None
+    in_file: str, ref_frame_start: int, out_file: str, dummy_scans: int | None = None
 ) -> tuple[str, int]:
     import warnings
     import nibabel as nb
     import numpy as np
+
     start_frame = max(ref_frame_start, dummy_scans) if dummy_scans else ref_frame_start
 
     img = nb.load(in_file)
@@ -74,10 +65,7 @@ def _detect_reference_frame(
     ts = ts[..., start_frame:]
     ts /= np.max(ts)
     ts_mean = np.nanmean(ts, axis=3)
-    chosen_frame = np.argmin(np.sum((ts - ts_mean[..., np.newaxis])**2, axis=(0,1,2)))
-    chosen_frame_img = nb.Nifti1Image(
-        np.squeeze(ts[..., chosen_frame]),
-        affine=img.affine
-    )
+    chosen_frame = np.argmin(np.sum((ts - ts_mean[..., np.newaxis]) ** 2, axis=(0, 1, 2)))
+    chosen_frame_img = nb.Nifti1Image(np.squeeze(ts[..., chosen_frame]), affine=img.affine)
     nb.save(chosen_frame_img, out_file)
     return out_file, chosen_frame

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -64,7 +64,7 @@ def _detect_reference_frame(
         start_frame = img_len - 1
 
     ts = ts[..., start_frame:]
-    ts /= np.max(ts)
+    ts = np.clip(ts, a_min=np.percentile(0.2), a_max=np.percentile(99.8))
     ts_mean = np.nanmean(ts, axis=3)
     chosen_frame = np.argmin(np.sum((ts - ts_mean[..., np.newaxis]) ** 2, axis=(0, 1, 2)))
     chosen_frame_img = nb.Nifti1Image(np.squeeze(ts[..., chosen_frame]), affine=img.affine)

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -47,7 +47,7 @@ class SelectOneFrame(SimpleInterface):
         return runtime
 
 
-def _select_one_frame(
+def _detect_reference_frame(
     in_file: str,
     ref_frame_start: int,
     out_file: str,

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -10,8 +10,8 @@ from nipype.utils.filemanip import fname_presuffix
 
 class _DetectReferenceFrameInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='BOLD timeseries')
-    ref_frame_start = traits.Int(0,
-        usedefault=True, desc='Frame to start looking for a low-motion reference frame'
+    ref_frame_start = traits.Int(
+        0, usedefault=True, desc='Frame to start looking for a low-motion reference frame'
     )
     dummy_scans = traits.Either(
         None, traits.Int, usedefault=True, desc='Number of non-steady-state scans at the start.'

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -1,0 +1,81 @@
+from nipype.interfaces.base import (
+    File,
+    SimpleInterface,
+    BaseInterfaceInputSpec,
+    TraitedSpec,
+    traits,
+)
+from nipype.utils.filemanip import fname_presuffix
+
+
+class _SelectOneFrameInputSpec(BaseInterfaceInputSpec):
+    in_file = File(
+        exists=True,
+        mandatory=True,
+        desc="BOLD timeseries"
+    )
+    ref_frame_start = traits.Int(
+        mandatory=True,
+        desc="Frame to start looking for a low-motion reference frame"
+    )
+    dummy_scans = traits.Either(
+        None, traits.Int,
+        usedefault=True,
+        desc="Number of non-steady-state scans at the start."
+    )
+
+
+class _SelectOneFrameOutputSpec(TraitedSpec):
+    out_file = File(desc="Single reference frame")
+
+
+class SelectOneFrame(SimpleInterface):
+    """Select one reference frame for HMC and SDC correction"""
+
+    input_spec = _SelectOneFrameInputSpec
+    output_spec = _SelectOneFrameOutputSpec
+
+    def _run_interface(self, runtime):
+        out_path = fname_presuffix(self.inputs.in_file, suffix='_refframe', newpath=runtime.cwd)
+        _select_one_frame(
+            in_file=self.inputs.in_file,
+            ref_frame_start=self.inputs.ref_frame_start,
+            out_file=out_path,
+            dummy_scans=self.inputs.dummy_scans
+        )
+        self._results['out_file'] = out_path
+        return runtime
+
+
+def _select_one_frame(
+    in_file: str,
+    ref_frame_start: int,
+    out_file: str,
+    dummy_scans: int | None = None
+) -> int:
+    import warnings
+    import nibabel as nb
+    import numpy as np
+    start_frame = max(ref_frame_start, dummy_scans) if dummy_scans else ref_frame_start
+
+    img = nb.load(in_file)
+    ts = img.get_fdata()
+    img_len = ts.shape[3]
+    if start_frame >= img_len:
+        warnings.warn(
+            f'Caculating the BOLD reference starting on frame {start_frame} but only {img_len} '
+            'volumes in BOLD file, so using last volume.',
+            stacklevel=1,
+        )
+        start_frame = img_len - 1
+
+    ts = ts[..., start_frame:]
+    ts /= np.max(ts)
+    ts_mean = np.nanmean(ts, axis=(0,1,2))
+    chosen_frame = np.argmin(np.sum((ts - ts_mean)**2, axis=(0,1,2)))
+    chosen_frame_img = nb.Nifti1Image(
+        np.squeeze(ts[..., chosen_frame]),
+        affine=img.affine
+    )
+    nb.save(chosen_frame_img, out_file)
+    return out_file

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -26,7 +26,7 @@ class _SelectOneFrameInputSpec(BaseInterfaceInputSpec):
 
 
 class _SelectOneFrameOutputSpec(TraitedSpec):
-    out_file = File(desc="Single reference frame")
+    out_file = File(exists=True, desc="Single reference frame")
 
 
 class SelectOneFrame(SimpleInterface):

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -44,7 +44,8 @@ class DetectReferenceFrame(SimpleInterface):
             out_file=out_path,
             dummy_scans=self.inputs.dummy_scans
         )
-        self._results['out_file'] = out_path
+        self._results['out_file'] = out_file
+        self._results['frame_idx'] = frame_idx
         return runtime
 
 

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -52,7 +52,7 @@ def _detect_reference_frame(
     ref_frame_start: int,
     out_file: str,
     dummy_scans: int | None = None
-) -> int:
+) -> str:
     import warnings
     import nibabel as nb
     import numpy as np

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -10,8 +10,8 @@ from nipype.utils.filemanip import fname_presuffix
 
 class _DetectReferenceFrameInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='BOLD timeseries')
-    ref_frame_start = traits.Int(
-        mandatory=True, desc='Frame to start looking for a low-motion reference frame'
+    ref_frame_start = traits.Int(0,
+        usedefault=True, desc='Frame to start looking for a low-motion reference frame'
     )
     dummy_scans = traits.Either(
         None, traits.Int, usedefault=True, desc='Number of non-steady-state scans at the start.'

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -27,6 +27,7 @@ class _DetectReferenceFrameInputSpec(BaseInterfaceInputSpec):
 
 class _DetectReferenceFrameOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="Single reference frame")
+    frame_idx = traits.Int(desc='Frame index used')
 
 
 class DetectReferenceFrame(SimpleInterface):

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -59,7 +59,7 @@ def _detect_reference_frame(
     start_frame = max(ref_frame_start, dummy_scans) if dummy_scans else ref_frame_start
 
     img = nb.load(in_file)
-    ts = img.get_fdata()
+    ts = img.get_fdata(dtype='float32')
     img_len = ts.shape[3]
     if start_frame >= img_len:
         warnings.warn(

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -1,7 +1,7 @@
 from nipype.interfaces.base import (
+    BaseInterfaceInputSpec,
     File,
     SimpleInterface,
-    BaseInterfaceInputSpec,
     TraitedSpec,
     traits,
 )
@@ -46,6 +46,7 @@ def _detect_reference_frame(
     in_file: str, ref_frame_start: int, out_file: str, dummy_scans: int | None = None
 ) -> tuple[str, int]:
     import warnings
+
     import nibabel as nb
     import numpy as np
 

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -64,7 +64,7 @@ def _detect_reference_frame(
         start_frame = img_len - 1
 
     ts = ts[..., start_frame:]
-    ts = np.clip(ts, a_min=np.percentile(0.2), a_max=np.percentile(99.8))
+    ts = np.clip(ts, a_min=np.percentile(ts, 0.2), a_max=np.percentile(ts, 99.8))
     ts_mean = np.nanmean(ts, axis=3)
     chosen_frame = np.argmin(np.sum((ts - ts_mean[..., np.newaxis]) ** 2, axis=(0, 1, 2)))
     chosen_frame_img = nb.Nifti1Image(np.squeeze(ts[..., chosen_frame]), affine=img.affine)

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -29,7 +29,7 @@ class _SelectOneFrameOutputSpec(TraitedSpec):
     out_file = File(exists=True, desc="Single reference frame")
 
 
-class SelectOneFrame(SimpleInterface):
+class DetectReferenceFrame(SimpleInterface):
     """Select one reference frame for HMC and SDC correction"""
 
     input_spec = _SelectOneFrameInputSpec

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -53,7 +53,7 @@ def _detect_reference_frame(
     ref_frame_start: int,
     out_file: str,
     dummy_scans: int | None = None
-) -> str:
+) -> tuple[str, int]:
     import warnings
     import nibabel as nb
     import numpy as np

--- a/nibabies/interfaces/reference.py
+++ b/nibabies/interfaces/reference.py
@@ -71,8 +71,8 @@ def _select_one_frame(
 
     ts = ts[..., start_frame:]
     ts /= np.max(ts)
-    ts_mean = np.nanmean(ts, axis=(0,1,2))
-    chosen_frame = np.argmin(np.sum((ts - ts_mean)**2, axis=(0,1,2)))
+    ts_mean = np.nanmean(ts, axis=3)
+    chosen_frame = np.argmin(np.sum((ts - ts_mean[..., np.newaxis])**2, axis=(0,1,2)))
     chosen_frame_img = nb.Nifti1Image(
         np.squeeze(ts[..., chosen_frame]),
         affine=img.affine

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -396,7 +396,7 @@ def init_bold_fit_wf(
             bold_file=bold_file,
             multiecho=multiecho,
             ref_frame_start=config.workflow.hmc_bold_frame,
-            find_good_refframe=config.workflow.estimate_good_refframe
+            estimate_good_refframe=config.workflow.estimate_good_refframe
         )
         hmc_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -396,6 +396,7 @@ def init_bold_fit_wf(
             bold_file=bold_file,
             multiecho=multiecho,
             ref_frame_start=config.workflow.hmc_bold_frame,
+            find_good_refframe=config.workflow.find_good_hmc_refframe
         )
         hmc_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -391,22 +391,12 @@ def init_bold_fit_wf(
     )
     if not hmc_boldref:
         config.loggers.workflow.info('Stage 1: Adding HMC boldref workflow')
-        if config.workflow.hmc_bold_frame == "auto":
-            hmc_boldref_wf = init_raw_boldref_wf(
-                name='hmc_boldref_wf',
-                bold_file=bold_file,
-                multiecho=multiecho,
-                ref_frame_start=16,
-                estimate_good_refframe=True
-            )
-        else:
-            hmc_boldref_wf = init_raw_boldref_wf(
-                name='hmc_boldref_wf',
-                bold_file=bold_file,
-                multiecho=multiecho,
-                ref_frame_start=config.workflow.hmc_bold_frame,
-                estimate_good_refframe=False
-            )
+        hmc_boldref_wf = init_raw_boldref_wf(
+            name='hmc_boldref_wf',
+            bold_file=bold_file,
+            multiecho=multiecho,
+            ref_frame_start=config.workflow.hmc_bold_frame,
+        )
         hmc_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 
         ds_hmc_boldref_wf = init_ds_boldref_wf(

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -396,7 +396,7 @@ def init_bold_fit_wf(
             bold_file=bold_file,
             multiecho=multiecho,
             ref_frame_start=config.workflow.hmc_bold_frame,
-            find_good_refframe=config.workflow.find_good_hmc_refframe
+            find_good_refframe=config.workflow.estimate_good_refframe
         )
         hmc_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -391,13 +391,22 @@ def init_bold_fit_wf(
     )
     if not hmc_boldref:
         config.loggers.workflow.info('Stage 1: Adding HMC boldref workflow')
-        hmc_boldref_wf = init_raw_boldref_wf(
-            name='hmc_boldref_wf',
-            bold_file=bold_file,
-            multiecho=multiecho,
-            ref_frame_start=config.workflow.hmc_bold_frame,
-            estimate_good_refframe=config.workflow.estimate_good_refframe
-        )
+        if config.workflow.hmc_bold_frame == "auto":
+            hmc_boldref_wf = init_raw_boldref_wf(
+                name='hmc_boldref_wf',
+                bold_file=bold_file,
+                multiecho=multiecho,
+                ref_frame_start=16,
+                estimate_good_refframe=True
+            )
+        else:
+            hmc_boldref_wf = init_raw_boldref_wf(
+                name='hmc_boldref_wf',
+                bold_file=bold_file,
+                multiecho=multiecho,
+                ref_frame_start=config.workflow.hmc_bold_frame,
+                estimate_good_refframe=False
+            )
         hmc_boldref_wf.inputs.inputnode.dummy_scans = config.workflow.dummy_scans
 
         ds_hmc_boldref_wf = init_ds_boldref_wf(

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -144,8 +144,8 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
             ]),
             (validation_and_dummies_wf, select_frames, [
                 ('outputnode.bold_file', 'in_file'),
+                ('outputnode.skip_vols', 'dummy_scans'),
             ]),
-            (inputnode, select_frames, [('dummy_scans', 'dummy_scans')]),
             (select_frames, gen_avg, [('t_mask', 't_mask')]),
             (gen_avg, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -150,7 +150,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
             (gen_avg, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip
     else:  # Select a single low-motion frame
-        detect_referenece_frame = pe.Node(DetectReferenceFrame(), name='detect_referenece_frame')
+        detect_reference_frame = pe.Node(DetectReferenceFrame(), name='detect_reference_frame')
         workflow.connect([
             (validation_and_dummies_wf, detect_referenece_frame, [
                 ('outputnode.bold_file', 'in_file'),

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -151,7 +151,10 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         ])  # fmt:skip
     else:  # Select a single low-motion frame
         detect_referenece_frame = pe.Node(DetectReferenceFrame(), name='detect_referenece_frame')
-        detect_referenece_frame.inputs.ref_frame_start = 16
+        if inputnode.dummy_scans is not None:
+            detect_referenece_frame.inputs.ref_frame_start = inputnode.dummy_scans
+        else:
+            detect_referenece_frame.inputs.ref_frame_start = 0
         workflow.connect([
             (validation_and_dummies_wf, detect_referenece_frame, [
                 ('outputnode.bold_file', 'in_file'),

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -34,7 +34,6 @@ def init_raw_boldref_wf(
     bold_file: str | None = None,
     multiecho: bool = False,
     ref_frame_start: int = 16,
-    estimate_good_refframe: bool = False,
     name: str = 'raw_boldref_wf',
 ):
     """

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -34,7 +34,7 @@ def init_raw_boldref_wf(
     bold_file: str | None = None,
     multiecho: bool = False,
     ref_frame_start: int = 16,
-    find_good_refframe: bool = False,
+    estimate_good_refframe: bool = False,
     name: str = 'raw_boldref_wf',
 ):
     """
@@ -62,9 +62,9 @@ def init_raw_boldref_wf(
         If multiecho data was supplied, data from the first echo will be selected
     ref_frame_start: :obj:`int`
         BOLD frame to start creating the reference map from.
-    find_good_refframe: :obj:`bool`
-        If True, find a single BOLD reference frame out of each timeseries instead of
-        running RobustAverage over all frames after ref_frame_start.
+    estimate_good_refframe: :obj:`bool`
+        If True, use a heuristic to find a single low-motion BOLD reference frame out of each timeseries
+        instead of running RobustAverage over all frames after ref_frame_start.
     name : :obj:`str`
         Name of workflow (default: ``raw_boldref_wf``)
 
@@ -120,7 +120,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
     validation_and_dummies_wf = init_validation_and_dummies_wf()
 
     # Drop frames to avoid startle when MRI begins acquiring
-    if not find_good_refframe:
+    if not estimate_good_refframe:
         select_frames = pe.Node(
             niu.Function(function=_select_frames, output_names=['start_frame', 't_mask']),
             name='select_frames',

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -152,11 +152,11 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
     else:  # Select a single low-motion frame
         detect_reference_frame = pe.Node(DetectReferenceFrame(), name='detect_reference_frame')
         workflow.connect([
-            (validation_and_dummies_wf, detect_referenece_frame, [
+            (validation_and_dummies_wf, detect_reference_frame, [
                 ('outputnode.bold_file', 'in_file'),
                 ('outputnode.skip_vols', 'dummy_scans'),
             ]),
-            (detect_referenece_frame, outputnode, [('out_file', 'boldref')]),
+            (detect_reference_frame, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip
     return workflow
 

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -59,10 +59,8 @@ def init_raw_boldref_wf(
         BOLD series NIfTI file
     multiecho : :obj:`bool`
         If multiecho data was supplied, data from the first echo will be selected
-    ref_frame_start: :obj:`int`
-        BOLD frame to start creating the reference map from.
-    estimate_good_refframe: :obj:`bool`
-        If True, use a heuristic to find a single low-motion BOLD reference frame out of each timeseries
+    ref_frame_start: :obj:`int` or :obj:`str`
+        BOLD frame to start creating the reference map from. If 'auto', use a heuristic to find a single low-motion BOLD reference frame out of each timeseries.
         instead of running RobustAverage over all frames after ref_frame_start.
     name : :obj:`str`
         Name of workflow (default: ``raw_boldref_wf``)

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -151,10 +151,6 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         ])  # fmt:skip
     else:  # Select a single low-motion frame
         detect_referenece_frame = pe.Node(DetectReferenceFrame(), name='detect_referenece_frame')
-        if inputnode.dummy_scans is not None:
-            detect_referenece_frame.inputs.ref_frame_start = inputnode.inputs.dummy_scans
-        else:
-            detect_referenece_frame.inputs.ref_frame_start = 0
         workflow.connect([
             (validation_and_dummies_wf, detect_referenece_frame, [
                 ('outputnode.bold_file', 'in_file'),

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -155,8 +155,8 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         workflow.connect([
             (validation_and_dummies_wf, detect_referenece_frame, [
                 ('outputnode.bold_file', 'in_file'),
+                ('outputnode.skip_vols', 'dummy_scans'),
             ]),
-            (inputnode, detect_referenece_frame, [('dummy_scans', 'dummy_scans')]),
             (detect_referenece_frame, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip
     return workflow

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -129,7 +129,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         ])
     ])  # fmt:skip
     # Drop frames to avoid startle when MRI begins acquiring
-    if ref_frame_start != "auto":
+    if ref_frame_start != 'auto':
         select_frames = pe.Node(
             niu.Function(function=_select_frames, output_names=['start_frame', 't_mask']),
             name='select_frames',

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -152,7 +152,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
     else:  # Select a single low-motion frame
         detect_referenece_frame = pe.Node(DetectReferenceFrame(), name='detect_referenece_frame')
         if inputnode.dummy_scans is not None:
-            detect_referenece_frame.inputs.ref_frame_start = inputnode.dummy_scans
+            detect_referenece_frame.inputs.ref_frame_start = inputnode.inputs.dummy_scans
         else:
             detect_referenece_frame.inputs.ref_frame_start = 0
         workflow.connect([

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -129,7 +129,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         ])
     ])  # fmt:skip
     # Drop frames to avoid startle when MRI begins acquiring
-    if not estimate_good_refframe:
+    if ref_frame_start != "auto":
         select_frames = pe.Node(
             niu.Function(function=_select_frames, output_names=['start_frame', 't_mask']),
             name='select_frames',
@@ -150,7 +150,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
         ])  # fmt:skip
     else:  # Select a single low-motion frame
         detect_referenece_frame = pe.Node(DetectReferenceFrame(), name='detect_referenece_frame')
-        detect_referenece_frame.inputs.ref_frame_start = ref_frame_start
+        detect_referenece_frame.inputs.ref_frame_start = 16
         workflow.connect([
             (validation_and_dummies_wf, detect_referenece_frame, [
                 ('outputnode.bold_file', 'in_file'),
@@ -187,9 +187,6 @@ def _select_frames(
     t_mask = np.array([False] * img_len, dtype=bool)
     t_mask[start_frame:] = True
     return start_frame, list(t_mask)
-
-
-
 
 
 def init_validation_and_dummies_wf(

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -25,6 +25,7 @@ from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.interfaces.header import ValidateImage
 from niworkflows.utils.misc import pass_dummy_scans
+
 from nibabies.interfaces.reference import DetectReferenceFrame
 
 DEFAULT_MEMORY_MIN_GB = 0.01

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -150,7 +150,6 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
             (select_frames, gen_avg, [('t_mask', 't_mask')]),
             (gen_avg, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip
-        return workflow
     else:  # Select a single low-motion frame
         select_one_frame = pe.Node(SelectOneFrame(), name='select_one_frame')
         select_one_frame.inputs.ref_frame_start = ref_frame_start
@@ -171,7 +170,7 @@ using a custom methodology of *NiBabies*, for use in head motion correction.
             (inputnode, select_one_frame, [('dummy_scans', 'dummy_scans')]),
             (select_one_frame, outputnode, [('out_file', 'boldref')]),
         ])  # fmt:skip
-        return workflow
+    return workflow
 
 
 def _select_frames(

--- a/nibabies/workflows/bold/reference.py
+++ b/nibabies/workflows/bold/reference.py
@@ -33,7 +33,7 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_raw_boldref_wf(
     bold_file: str | None = None,
     multiecho: bool = False,
-    ref_frame_start: int = 16,
+    ref_frame_start: int | str = 16,
     name: str = 'raw_boldref_wf',
 ):
     """

--- a/nibabies/workflows/tests/test_base.py
+++ b/nibabies/workflows/tests/test_base.py
@@ -139,6 +139,7 @@ def _make_params(
     bids_filters: dict | None = None,
     norm_csf: bool = False,
     multi_step_reg: bool = True,
+    hmc_bold_frame: int | str = 0,
 ):
     if ignore is None:
         ignore = []
@@ -161,6 +162,7 @@ def _make_params(
         bids_filters,
         norm_csf,
         multi_step_reg,
+        hmc_bold_frame,
     )
 
 
@@ -184,6 +186,7 @@ def _make_params(
         'bids_filters',
         'norm_csf',
         'multi_step_reg',
+        'hmc_bold_frame',
     ),
     [
         _make_params(),
@@ -220,6 +223,7 @@ def _make_params(
         _make_params(norm_csf=True),
         _make_params(multi_step_reg=True),
         _make_params(multi_step_reg=False),
+        _make_params(hmc_bold_frame='auto'),
     ],
 )
 def test_init_nibabies_wf(
@@ -244,6 +248,7 @@ def test_init_nibabies_wf(
     bids_filters: dict,
     norm_csf: bool,
     multi_step_reg: bool,
+    hmc_bold_frame: int | str,
 ):
     monkeypatch.setenv('SUBJECTS_DIR', '/opt/freesurfer/subjects')
     with mock_config(bids_dir=bids_root):
@@ -262,6 +267,7 @@ def test_init_nibabies_wf(
         config.workflow.cifti_output = cifti_output
         config.workflow.surface_recon_method = surface_recon_method
         config.workflow.ignore = ignore
+        config.workflow.hmc_bold_frame = hmc_bold_frame
         with patch.dict('nibabies.config.execution.bids_filters', bids_filters):
             wf = init_nibabies_wf(
                 [

--- a/nibabies/workflows/tests/test_base.py
+++ b/nibabies/workflows/tests/test_base.py
@@ -139,7 +139,7 @@ def _make_params(
     bids_filters: dict | None = None,
     norm_csf: bool = False,
     multi_step_reg: bool = True,
-    hmc_bold_frame: int | str = 0,
+    hmc_bold_frame: int | str = 16,
 ):
     if ignore is None:
         ignore = []


### PR DESCRIPTION
`--hmc-bold-frame` can now be set to `auto` to use a heuristic (pick the frame with the lowest sum-of-squared-differences between each voxel and the average over time at that voxel) to find a low-motion frame for use in HMC and SDC workflows, instead of running RobustAverage over frames 16 and after if no SBRef is present.