### PR TITLE
ENH: Expand BOLD coregistration targets

### DIFF
--- a/.circleci/bcp_full_outputs.txt
+++ b/.circleci/bcp_full_outputs.txt
@@ -79,8 +79,10 @@ sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_bold.js
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_desc-preproc_bold.nii.gz
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-T1w_mode-image_desc-coreg_xfm.json
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-T1w_mode-image_desc-coreg_xfm.txt
-sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-auto00000_mode-image_desc-fmap_xfm.json
-sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-auto00000_mode-image_desc-fmap_xfm.txt
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-run_to-auto00000_mode-image_desc-fmap_xfm.json
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-run_to-auto00000_mode-image_desc-fmap_xfm.txt
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-run_to-boldref_mode-image_desc-coreg_xfm.json
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-run_to-boldref_mode-image_desc-coreg_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-run_mode-image_desc-hmc_xfm.json
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-run_mode-image_desc-hmc_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant+1_boldref.json

--- a/.circleci/bcp_full_outputs.txt
+++ b/.circleci/bcp_full_outputs.txt
@@ -81,8 +81,8 @@ sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-T1w_
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-T1w_mode-image_desc-coreg_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-auto00000_mode-image_desc-fmap_xfm.json
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-boldref_to-auto00000_mode-image_desc-fmap_xfm.txt
-sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-boldref_mode-image_desc-hmc_xfm.json
-sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-boldref_mode-image_desc-hmc_xfm.txt
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-run_mode-image_desc-hmc_xfm.json
+sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_from-orig_to-run_mode-image_desc-hmc_xfm.txt
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant+1_boldref.json
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant+1_boldref.nii.gz
 sub-01/ses-1mo/func/sub-01_ses-1mo_task-rest_acq-PA_run-001_space-MNIInfant+1_desc-brain_mask.json

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -305,8 +305,12 @@ for details.
 sub-<subject_label>/[ses-<session_label>/]
   func/
     sub-<subject_label>_[specifiers]_desc-coreg_boldref.nii.gz
+    sub-<subject_label>_[specifiers]_from-run_to-boldref_mode-image_desc-coreg_xfm.txt
     sub-<subject_label>_[specifiers]_from-boldref_to-<anat>_mode-image_desc-coreg_xfm.txt
 ```
+
+The `from-run_to-boldref` transform is written for every run regardless of `--bold-coreg-level`;
+it is an identity transform when `--bold-coreg-level run` (the default).
 
 :::{note}
 Coregistration outputs are part of the *minimal* processing level.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -249,17 +249,40 @@ The mask file is part of the *minimal* processing level. The BOLD series
 is only generated at the *full* processing level.
 :::
 
+#### BOLD reference spaces
+
+NiBabies defines a consistent hierarchy of BOLD reference spaces, reflected in
+the `space` and `from`/`to` entities of functional outputs:
+
+- **`orig`** — the native BOLD acquisition space.
+- **`run`** — the per-run boldref space. This is the target of HMC and is derived
+  from the sbref or a robust average of the BOLD series.
+- **`boldref`** — the final coregistration reference space registered to anatomy.
+  When `--bold-coreg-level run` (default), `boldref` is identical to `run`.
+  When `--bold-coreg-level session`, `boldref` is a template image built from all
+  run-level boldrefs.
+- **`anat`** — the anatomical reference space (T1w or T2w).
+
+The full transform chain applied during resampling is therefore:
+
+```
+orig → run      (from-orig_to-run, HMC)
+run  → boldref  (from-run_to-boldref, identity when --bold-coreg-level run)
+boldref → anat  (from-boldref_to-anat)
+anat → std      (anat2std)
+```
+
 #### Motion correction outputs
 
 Head-motion correction (HMC) produces a reference image to which all volumes
 are aligned, and a corresponding transform that maps the original BOLD series
-to the reference image::
+to the run-level boldref:
 
 ```
 sub-<subject_label>/[ses-<session_label>/]
   func/
     sub-<subject_label>_[specifiers]_desc-hmc_boldref.nii.gz
-    sub-<subject_label>_[specifiers]_from-orig_to_boldref_mode-image_desc-hmc_xfm.nii.gz
+    sub-<subject_label>_[specifiers]_from-orig_to-run_mode-image_desc-hmc_xfm.txt
 ```
 
 :::{note}
@@ -268,8 +291,15 @@ Motion correction outputs are part of the *minimal* processing level.
 
 #### Coregistration outputs
 
-Registration of the BOLD series to the anatomical reference image generates a further reference
-image and affine transform
+Registration of the BOLD series to the anatomical image generates a further reference
+image and affine transform:
+
+:::{tip}
+The coregistration reference used for anatomy registration depends on
+`--bold-coreg-level`. See [BOLD coregistration level](usage.md#bold-coregistration-level---bold-coreg-level)
+for details.
+:::
+
 
 ```
 sub-<subject_label>/[ses-<session_label>/]
@@ -291,7 +321,7 @@ is identified with `"B0FieldIdentifier": "TOPUP"`, the generated transform will 
 ```
 sub-<subject_label>/[ses-<session_label>/]
   func/
-    sub-<subject_label>_[specifiers]_from-boldref_to-TOPUP_mode-image_xfm.nii.gz
+    sub-<subject_label>_[specifiers]_from-boldref_to-TOPUP_mode-image_xfm.txt
 ```
 
 If the association is discovered through the `IntendedFor` field of the

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -321,7 +321,7 @@ is identified with `"B0FieldIdentifier": "TOPUP"`, the generated transform will 
 ```
 sub-<subject_label>/[ses-<session_label>/]
   func/
-    sub-<subject_label>_[specifiers]_from-boldref_to-TOPUP_mode-image_xfm.txt
+    sub-<subject_label>_[specifiers]_from-run_to-TOPUP_mode-image_xfm.txt
 ```
 
 If the association is discovered through the `IntendedFor` field of the
@@ -330,7 +330,7 @@ fieldmap metadata, then the transform will be given an auto-generated name
 ```
 sub-<subject_label>/[ses-<session_label>/]
   func/
-    sub-<subject_label>_[specifiers]_from-boldref_to-auto000XX_mode-image_desc-fmap_xfm.txt
+    sub-<subject_label>_[specifiers]_from-run_to-auto000XX_mode-image_desc-fmap_xfm.txt
 ```
 
 :::{note}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,15 +102,15 @@ The session-level pipeline follows four steps:
 4. The session template is registered to the anatomical image.
 
 The full transform chain applied during resampling is therefore:
-`bold volume → orig boldref (HMC) → boldref template (orig2template) → T1w (boldref2anat) → standard space (anat2std)`.
+`bold volume → run boldref (HMC) → boldref (run2boldref) → T1w (boldref2anat) → standard space (anat2std)`.
 
 If `--bold-coreg-level session` is selected, NiBabies will first validate whether all runs can contribute to a common session template. If the data are incompatible (for example, when only some runs have SDC applied, or when all runs are SDC-less but have mixed phase-encoding directions), NiBabies falls back to `run`-level coregistration instead.
 
-:::{admonition} Output spaces and session-space BOLD
+:::{admonition} Output spaces and template-space BOLD
 :class: tip
 
-Adding `session` to `--output-spaces` when using `--bold-coreg-level session` saves each run
-resampled into the boldref template space.
+Adding `boldref` to `--output-spaces` when using `--bold-coreg-level session` saves each run
+resampled into the boldref space.
 :::
 
 ## Using the nibabies wrapper

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,8 @@ The session-level pipeline follows four steps:
 The full transform chain applied during resampling is therefore:
 `bold volume → orig boldref (HMC) → session boldref (orig2session) → T1w (boldref2anat) → standard space (anat2std)`.
 
+If `--bold-coreg-level session` is selected, NiBabies will first validate whether all runs can contribute to a common session template. If the data are incompatible (for example, when only some runs have SDC applied, or when all runs are SDC-less but have mixed phase-encoding directions), NiBabies falls back to `run`-level coregistration instead.
+
 :::{admonition} Output spaces and session-space BOLD
 :class: tip
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,6 +86,31 @@ The segmentation directory layout should consist of one or more template directo
 
 :::
 
+### BOLD coregistration level (`--bold-coreg-level`)
+
+By default (`run`), each BOLD run is independently registered to the anatomical image.
+The `session` option instead builds a session-wide mean BOLD template from all runs before
+registering that template to the anatomical image.
+This can improve BOLD-to-anatomical registration quality by averaging signal across runs
+before coregistration.
+
+The session-level pipeline follows four steps:
+
+1. Head-motion correction (HMC) is applied per-volume within each run.
+2. Susceptibility distortion correction (SDC) is applied to each run's BOLD reference image.
+3. Each run's SDC-corrected boldref is registered to a session-wide BOLD template using FreeSurfer's `mri_robust_template`.
+4. The session template is registered to the anatomical image.
+
+The full transform chain applied during resampling is therefore:
+`bold volume → orig boldref (HMC) → session boldref (orig2session) → T1w (boldref2anat) → standard space (anat2std)`.
+
+:::{admonition} Output spaces and session-space BOLD
+:class: tip
+
+Adding `session` to `--output-spaces` when using `--bold-coreg-level session` saves each run
+resampled into the session boldref template.
+:::
+
 ## Using the nibabies wrapper
 
 The wrapper will generate a Docker or Singularity command line for you, print it out for reporting purposes, and then execute it without further action needed.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,7 +102,7 @@ The session-level pipeline follows four steps:
 4. The session template is registered to the anatomical image.
 
 The full transform chain applied during resampling is therefore:
-`bold volume → orig boldref (HMC) → session boldref (orig2session) → T1w (boldref2anat) → standard space (anat2std)`.
+`bold volume → orig boldref (HMC) → boldref template (orig2template) → T1w (boldref2anat) → standard space (anat2std)`.
 
 If `--bold-coreg-level session` is selected, NiBabies will first validate whether all runs can contribute to a common session template. If the data are incompatible (for example, when only some runs have SDC applied, or when all runs are SDC-less but have mixed phase-encoding directions), NiBabies falls back to `run`-level coregistration instead.
 
@@ -110,7 +110,7 @@ If `--bold-coreg-level session` is selected, NiBabies will first validate whethe
 :class: tip
 
 Adding `session` to `--output-spaces` when using `--bold-coreg-level session` saves each run
-resampled into the session boldref template.
+resampled into the boldref template space.
 :::
 
 ## Using the nibabies wrapper

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -786,6 +786,12 @@ discourage its usage.""",
         help='For certain adult templates (MNI152NLin6Asym), perform two step '
         'registrations (native -> MNIInfant -> template) and concatenate into a single xfm',
     )
+    g_baby.add_argument(
+        '--bold-coreg-level',
+        choices=('run', 'session'),
+        default='run',
+        help='Determine BOLD reference image for coregistration at run or session level.',
+    )
     return parser
 
 

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -560,6 +560,8 @@ class workflow(_Config):
     bold2anat_init = 'auto'
     """Whether to use standard coregistration ('register') or to initialize coregistration from the
     BOLD image-header ('header')."""
+    bold_coreg_level = 'run'
+    """Level to coregister BOLD runs to a common reference, either 'run' (default) or 'session'."""
     cifti_output = None
     """Generate HCP Grayordinates, accepts either ``'91k'`` (default) or ``'170k'``."""
     dummy_scans = None
@@ -824,6 +826,7 @@ DEFAULT_CONFIG_HASH_FIELDS = {
         'surface_recon_method',
         'bold2anat_dof',
         'bold2anat_init',
+        'bold_coreg_level',
         'dummy_scans',
         'fd_radius',
         'fmap_bspline',

--- a/nibabies/data/io_spec_func.json
+++ b/nibabies/data/io_spec_func.json
@@ -39,9 +39,9 @@
           "suffix": "xfm",
           "extension": ".txt"
         },
-        "boldref2fmap": {
+        "run2fmap": {
           "datatype": "func",
-          "from": "boldref",
+          "from": "run",
           "mode": "image",
           "suffix": "xfm",
           "extension": ".txt"

--- a/nibabies/data/io_spec_func.json
+++ b/nibabies/data/io_spec_func.json
@@ -45,6 +45,15 @@
           "mode": "image",
           "suffix": "xfm",
           "extension": ".txt"
+        },
+        "orig2session": {
+          "datatype": "func",
+          "desc": "coreg",
+          "from": "orig",
+          "to": "session",
+          "mode": "image",
+          "suffix": "xfm",
+          "extension": ".txt"
         }
       }
     },

--- a/nibabies/data/io_spec_func.json
+++ b/nibabies/data/io_spec_func.json
@@ -55,6 +55,25 @@
           "suffix": "xfm",
           "extension": ".txt"
         }
+      },
+      "session": {
+        "boldref": {
+          "datatype": "func",
+          "desc": "coreg",
+          "suffix": "boldref",
+          "run": null,
+          "task": null,
+          "extension": [".nii.gz", ".nii"]
+        },
+        "bold_mask": {
+          "datatype": "func",
+          "space": "session",
+          "desc": "brain",
+          "suffix": "mask",
+          "run": null,
+          "task": null,
+          "extension": [".nii.gz", ".nii"]
+        }
       }
     },
     "patterns": [

--- a/nibabies/data/io_spec_func.json
+++ b/nibabies/data/io_spec_func.json
@@ -26,14 +26,14 @@
         "hmc": {
           "datatype": "func",
           "from": "orig",
-          "to": "boldref",
+          "to": "run",
           "mode": "image",
           "suffix": "xfm",
           "extension": ".txt"
         },
         "boldref2anat": {
           "datatype": "func",
-          "from": "orig",
+          "from": "boldref",
           "to": "anat",
           "mode": "image",
           "suffix": "xfm",
@@ -41,16 +41,16 @@
         },
         "boldref2fmap": {
           "datatype": "func",
-          "from": "orig",
+          "from": "boldref",
           "mode": "image",
           "suffix": "xfm",
           "extension": ".txt"
         },
-        "orig2session": {
+        "run2boldref": {
           "datatype": "func",
           "desc": "coreg",
-          "from": "orig",
-          "to": "session",
+          "from": "run",
+          "to": "boldref",
           "mode": "image",
           "suffix": "xfm",
           "extension": ".txt"

--- a/nibabies/data/io_spec_func.json
+++ b/nibabies/data/io_spec_func.json
@@ -55,25 +55,6 @@
           "suffix": "xfm",
           "extension": ".txt"
         }
-      },
-      "session": {
-        "boldref": {
-          "datatype": "func",
-          "desc": "coreg",
-          "suffix": "boldref",
-          "run": null,
-          "task": null,
-          "extension": [".nii.gz", ".nii"]
-        },
-        "bold_mask": {
-          "datatype": "func",
-          "space": "session",
-          "desc": "brain",
-          "suffix": "mask",
-          "run": null,
-          "task": null,
-          "extension": [".nii.gz", ".nii"]
-        }
       }
     },
     "patterns": [

--- a/nibabies/interfaces/reports.py
+++ b/nibabies/interfaces/reports.py
@@ -51,6 +51,7 @@ FUNCTIONAL_TEMPLATE = """\
 \t\t\t<li>Slice timing correction: {stc}</li>
 \t\t\t<li>Susceptibility distortion correction: {sdc}</li>
 \t\t\t<li>Registration: {registration}</li>
+\t\t\t<li>Registration level: {bold_coreg_level}</li>
 \t\t\t<li>Non-steady-state volumes: {dummy_scan_desc}</li>
 \t\t</ul>
 \t\t</details>
@@ -239,6 +240,9 @@ class FunctionalSummaryInputSpec(TraitedSpec):
         'FSL', 'FreeSurfer', mandatory=True, desc='Functional/anatomical registration method'
     )
     fallback = traits.Bool(desc='Boundary-based registration rejected')
+    bold_coreg_level = traits.Enum(
+        'run', 'session', desc='BOLD registration level (run or session)'
+    )
     registration_dof = traits.Enum(
         6, 9, 12, desc='Registration degrees of freedom', mandatory=True
     )
@@ -316,6 +320,7 @@ class FunctionalSummary(SummaryInterface):
             stc=stc,
             sdc=self.inputs.distortion_correction,
             registration=reg,
+            bold_coreg_level=self.inputs.bold_coreg_level,
             tr=self.inputs.tr,
             dummy_scan_desc=dummy_scan_msg,
             multiecho=multiecho,

--- a/nibabies/tests/test_config.py
+++ b/nibabies/tests/test_config.py
@@ -150,7 +150,7 @@ def _load_spaces(age):
 
 def test_hash_config():
     # This may change with changes to config defaults / new attributes!
-    expected = 'cfee5aaf'
+    expected = '4b5c8968'
     assert config.hash_config(config.get()) == expected
     _reset_config()
 

--- a/nibabies/tests/test_config.py
+++ b/nibabies/tests/test_config.py
@@ -150,7 +150,7 @@ def _load_spaces(age):
 
 def test_hash_config():
     # This may change with changes to config defaults / new attributes!
-    expected = '4b5c8968'
+    expected = '84226605'
     assert config.hash_config(config.get()) == expected
     _reset_config()
 

--- a/nibabies/utils/bids.py
+++ b/nibabies/utils/bids.py
@@ -362,6 +362,56 @@ def age_to_months(age: int | float, units: ty.Literal['weeks', 'months', 'years'
     return round(age)
 
 
+def is_valid_bold_template(
+    bold_runs: list[list[str]],
+    estimator_map: dict,
+    layout,
+) -> bool:
+    """Return True if BOLD template creation is possible.
+
+    Three independent conditions are checked:
+
+    1. **Insufficient runs** – fewer than two runs cannot form a meaningful
+       session template.
+
+    2. **Mixed SDC coverage** – if only some runs are distortion corrected,
+       the resulting boldrefs live in different geometric spaces even when their
+       phase-encoding directions agree.
+
+    3. **PE-direction heterogeneity** – when all runs are SDC-less, if more
+       than one distinct phase-encoding direction is present (including ``None``
+       for runs that lack the metadata), the distortions oppose each other in a
+       way that rigid/affine registration cannot recover.
+
+    Parameters
+    ----------
+    bold_runs
+        List of bold series (each series is a list of file paths).
+    estimator_map
+        Mapping of bold file → fieldmap estimator ID.  An absent key or None
+        value means no fieldmap / no SDC for that run.
+    layout
+        A :class:`bids.layout.BIDSLayout` instance used to read file metadata.
+
+    Returns
+    -------
+    compatible : bool
+        ``True`` if there are at least two runs, all share the same SDC status,
+        and SDC-less runs span exactly one phase-encoding direction.
+    """
+    if len(bold_runs) < 2:
+        return False
+
+    sdc_corrected = [bool(estimator_map.get(series[0])) for series in bold_runs]
+    if any(sdc_corrected):
+        return all(sdc_corrected)
+
+    pe_dirs = {
+        layout.get_metadata(series[0]).get('PhaseEncodingDirection') for series in bold_runs
+    }
+    return len(pe_dirs) == 1
+
+
 def combine_space(space, cohort) -> str:
     """Combine space and cohort into a single string.
 

--- a/nibabies/utils/derivatives.py
+++ b/nibabies/utils/derivatives.py
@@ -125,7 +125,7 @@ def collect_functional_derivatives(
 
     for xfm, qry in spec['transforms'].items():
         query = {**qry, **entities}
-        if xfm == 'boldref2fmap':
+        if xfm == 'run2fmap':
             query['to'] = fieldmap_id
         item = layout.get(return_type='filename', **query)
         if not item and xfm == 'hmc':

--- a/nibabies/utils/derivatives.py
+++ b/nibabies/utils/derivatives.py
@@ -131,6 +131,16 @@ def collect_functional_derivatives(
         if not item:
             continue
         derivs_cache[xfm] = item[0] if len(item) == 1 else item
+
+    # Session queries use {**entities, **qry} so spec null-values (run, task) override
+    # per-run entity values, ensuring only session-level files (lacking those entities) match.
+    for key, qry in spec.get('session', {}).items():
+        query = {**entities, **qry}
+        item = layout.get(return_type='filename', **query)
+        if not item:
+            continue
+        derivs_cache[f'session_{key}'] = item[0] if len(item) == 1 else item
+
     return derivs_cache
 
 

--- a/nibabies/utils/derivatives.py
+++ b/nibabies/utils/derivatives.py
@@ -119,15 +119,18 @@ def collect_functional_derivatives(
             continue
         derivs_cache[f'{key}_boldref'] = item[0] if len(item) == 1 else item
 
-    # coreg_boldref is the legacy derivative name for orig_boldref
-    if 'coreg_boldref' in derivs_cache and 'orig_boldref' not in derivs_cache:
-        derivs_cache['orig_boldref'] = derivs_cache['coreg_boldref']
+    # coreg_boldref is the legacy derivative name for run_boldref
+    if 'coreg_boldref' in derivs_cache and 'run_boldref' not in derivs_cache:
+        derivs_cache['run_boldref'] = derivs_cache['coreg_boldref']
 
     for xfm, qry in spec['transforms'].items():
         query = {**qry, **entities}
         if xfm == 'boldref2fmap':
             query['to'] = fieldmap_id
         item = layout.get(return_type='filename', **query)
+        if not item and xfm == 'hmc':
+            # legacy: from-orig_to-boldref (now from-orig_to-run)
+            item = layout.get(return_type='filename', **{**query, 'to': 'boldref'})
         if not item:
             continue
         derivs_cache[xfm] = item[0] if len(item) == 1 else item

--- a/nibabies/utils/derivatives.py
+++ b/nibabies/utils/derivatives.py
@@ -119,6 +119,10 @@ def collect_functional_derivatives(
             continue
         derivs_cache[f'{key}_boldref'] = item[0] if len(item) == 1 else item
 
+    # coreg_boldref is the legacy derivative name for orig_boldref
+    if 'coreg_boldref' in derivs_cache and 'orig_boldref' not in derivs_cache:
+        derivs_cache['orig_boldref'] = derivs_cache['coreg_boldref']
+
     for xfm, qry in spec['transforms'].items():
         query = {**qry, **entities}
         if xfm == 'boldref2fmap':

--- a/nibabies/utils/tests/full-derivatives.yml
+++ b/nibabies/utils/tests/full-derivatives.yml
@@ -97,6 +97,12 @@ dataset_description:
     mode: image
   - suffix: xfm
     extension: .txt
+    from: run
+    to: boldref
+    mode: image
+    desc: coreg
+  - suffix: xfm
+    extension: .txt
     from: orig
     to: boldref
     mode: image

--- a/nibabies/utils/tests/test_bids.py
+++ b/nibabies/utils/tests/test_bids.py
@@ -2,7 +2,46 @@ from pathlib import Path
 
 import pytest
 
-from nibabies.utils.bids import _get_age_from_tsv
+from nibabies.utils.bids import _get_age_from_tsv, is_valid_bold_template
+
+
+class _MockLayout:
+    """Minimal BIDSLayout stub for bold_coreg_compat tests."""
+
+    def __init__(self, pe_map: dict):
+        self._pe_map = pe_map
+
+    def get_metadata(self, f):
+        pe = self._pe_map.get(f)
+        return {'PhaseEncodingDirection': pe} if pe is not None else {}
+
+
+@pytest.mark.parametrize(
+    ('bold_runs', 'estimator_map', 'pe_map', 'expected'),
+    [
+        ([], {}, {}, False),
+        ([['a.nii']], {}, {'a.nii': 'j'}, False),
+        ([['a.nii'], ['b.nii']], {'a.nii': 'fmap1', 'b.nii': 'fmap2'}, {}, True),
+        ([['a.nii'], ['b.nii']], {'a.nii': 'fmap1'}, {'a.nii': 'j', 'b.nii': 'j'}, False),
+        ([['a.nii'], ['b.nii']], {}, {'a.nii': 'j', 'b.nii': 'j'}, True),
+        ([['a.nii'], ['b.nii']], {}, {'a.nii': 'j', 'b.nii': 'j-'}, False),
+        ([['a.nii'], ['b.nii']], {}, {}, True),
+        ([['a.nii'], ['b.nii']], {}, {'a.nii': 'j'}, False),
+    ],
+    ids=[
+        'false-no_runs',
+        'false-one_run',
+        'true-all_sdc',
+        'false-mixed_sdc',
+        'true-no_sdc_single_pe',
+        'false-no_sdc_opposing_pe',
+        'true-no_sdc_no_pe',
+        'false-no_sdc_missing_pe',
+    ],
+)
+def test_is_valid_bold_template(bold_runs, estimator_map, pe_map, expected):
+    layout = _MockLayout(pe_map)
+    assert is_valid_bold_template(bold_runs, estimator_map, layout) is expected
 
 
 def create_tsv(data: dict, out_file: Path) -> None:

--- a/nibabies/utils/tests/test_derivatives.py
+++ b/nibabies/utils/tests/test_derivatives.py
@@ -40,7 +40,7 @@ def test_collect_derivatives(tmp_path):
         assert len(anat_cache[surface]) == 2
 
     func_cache = collect_functional_derivatives(deriv_dir, {'subject': '01'}, None)
-    for val in ('hmc_boldref', 'coreg_boldref', 'hmc'):
+    for val in ('hmc_boldref', 'coreg_boldref', 'hmc', 'run2boldref'):
         assert func_cache[val]
 
 

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -719,16 +719,26 @@ tasks and sessions), the following preprocessing was performed.
             )
         config.workflow.bold2anat_init = 't2w' if has_t2w else 't1w'
 
-    # Common space for all BOLD runs in this session
-    if config.workflow.bold_coreg_level == 'session':
+    bold_coreg_level = config.workflow.bold_coreg_level
+
+    if bold_coreg_level != 'run':
+        # First check if common template is possible
+        from nibabies.utils.bids import is_valid_bold_template
+
+        if not is_valid_bold_template(bold_runs, estimator_map, config.execution.layout):
+            LOGGER.error(
+                'Error when creating BOLD coregistration template: '
+                'Either only some runs have SDC applied, or all are SDC-less '
+                'runs but contain multiple phase-encoding directions.'
+            )
+            bold_coreg_level = 'run'
+
+    if bold_coreg_level != 'run':
         from nibabies.workflows.bold.outputs import init_ds_registration_wf
         from nibabies.workflows.bold.registration import init_bold_reg_wf
         from nibabies.workflows.bold.session import init_coreg_session_bolds_wf
 
-        # TODO: Check each BOLD file phase encoding
-        # only allow if homogeneous
         LOGGER.info('Coregistering all BOLD runs to a common space')
-
         # session BOLD reference to anatomical registration (always needed)
         session_bold_reg_wf = init_bold_reg_wf(
             bold2anat_dof=config.workflow.bold2anat_dof,
@@ -776,12 +786,13 @@ tasks and sessions), the following preprocessing was performed.
 
         bold_id = _get_wf_name(bold_file, None).removesuffix('_wf')
 
+        # TODO: Volume check should happen when collecting BOLD files
         nvols, _ = estimate_bold_mem_usage(bold_file)
         if nvols <= 5 - config.execution.sloppy:
             config.loggers.workflow.warning(
                 f'Too short BOLD series (<= 5 timepoints). Skipping processing of <{bold_file}>.'
             )
-            if config.execution.bold_coreg_level == 'session':
+            if bold_coreg_level != 'session':
                 # TODO: Move this check prior to create session workflow to avoid hard crashes
                 raise RuntimeError(
                     'Cannot create session-level BOLD reference with invalid BOLD series.'
@@ -824,7 +835,7 @@ tasks and sessions), the following preprocessing was performed.
             fieldmap_id=fieldmap_id,
             reference_anat=reference_anat,
             omp_nthreads=omp_nthreads,
-            coreg_anat=config.workflow.bold_coreg_level == 'run',
+            coreg_anat=bool(bold_coreg_level == 'run'),
             name=f'bold_fit_{bold_id}_wf',
         )
         bold_fit_wf.__desc__ = func_pre_desc + (bold_fit_wf.__desc__ or '')
@@ -943,7 +954,7 @@ tasks and sessions), the following preprocessing was performed.
                 ]),
             ])  # fmt:skip
 
-        if config.workflow.bold_coreg_level == 'session':
+        if bold_coreg_level != 'run':
             from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 
             orig2session = functional_cache.get('orig2session')

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -49,6 +49,7 @@ import typing as ty
 import warnings
 from copy import deepcopy
 
+import nibabel as nb
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.interfaces.utility import KeySelect
@@ -58,14 +59,16 @@ from smriprep.workflows.outputs import init_template_iterator_wf
 
 from nibabies import config
 from nibabies.interfaces import DerivativesDataSink
-from nibabies.interfaces.reports import AboutSummary, SubjectSummary
-from nibabies.utils.bids import parse_bids_for_age_months
+from nibabies.interfaces.reports import AboutSummary, FunctionalSummary, SubjectSummary
+from nibabies.utils.bids import extract_entities, parse_bids_for_age_months
 from nibabies.workflows.anatomical.apply import init_infant_anat_apply_wf
 from nibabies.workflows.anatomical.fit import (
     init_infant_anat_fit_wf,
     init_infant_single_anat_fit_wf,
 )
-from nibabies.workflows.bold.base import init_bold_wf
+from nibabies.workflows.bold.base import init_bold_apply_wf
+from nibabies.workflows.bold.fit import init_bold_fit_wf
+from nibabies.workflows.bold.outputs import init_func_fit_reports_wf
 
 LOGGER = config.loggers.workflow
 
@@ -222,7 +225,7 @@ def init_single_subject_wf(
     from niworkflows.utils.bids import collect_data
     from niworkflows.utils.spaces import Reference
 
-    from ..utils.misc import fix_multi_source_name
+    from ..utils.misc import estimate_bold_mem_usage, fix_multi_source_name
 
     subject_session_id = _subject_session_id(subject_id, session_id)
     workflow = Workflow(name=f'single_subject_{subject_session_id}_wf')
@@ -716,16 +719,72 @@ tasks and sessions), the following preprocessing was performed.
             )
         config.workflow.bold2anat_init = 't2w' if has_t2w else 't1w'
 
-    for bold_series in bold_runs:
+    # Common space for all BOLD runs in this session
+    if config.workflow.bold_coreg_level == 'session':
+        from nibabies.workflows.bold.outputs import init_ds_registration_wf
+        from nibabies.workflows.bold.registration import init_bold_reg_wf
+        from nibabies.workflows.bold.session import init_coreg_session_bolds_wf
+
+        # TODO: Check each BOLD file phase encoding
+        # only allow if homogeneous
+        LOGGER.info('Coregistering all BOLD runs to a common space')
+
+        merge_fit_boldrefs = pe.Node(
+            niu.Merge(len(bold_runs)),
+            name='merge_fit_boldrefs',
+        )
+
+        coreg_bolds_wf = init_coreg_session_bolds_wf(
+            num_bold_runs=len(bold_runs),
+            omp_nthreads=omp_nthreads,
+        )
+
+        # session BOLD reference to anatomical registration
+        session_bold_reg_wf = init_bold_reg_wf(
+            bold2anat_dof=config.workflow.bold2anat_dof,
+            bold2anat_init=config.workflow.bold2anat_init,
+            use_bbr=config.workflow.use_bbr,
+            freesurfer=config.workflow.surface_recon_method is not None,
+            omp_nthreads=omp_nthreads,
+            mem_gb=2,  # Estimated
+            sloppy=config.execution.sloppy,
+            name='session_boldref_to_anat_reg_wf',
+        )
+
+        workflow.connect([
+            (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
+            (anat_fit_wf, session_bold_reg_wf, [
+                ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
+                ('outputnode.anat_mask', 'inputnode.anat_mask'),
+                ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
+                # Undefined if --fs-no-reconall, but this is safe
+                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+                ('outputnode.subject_id', 'inputnode.subject_id'),
+                ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
+            ]),
+            (coreg_bolds_wf, session_bold_reg_wf, [
+                ('outputnode.boldref', 'inputnode.ref_bold_brain'),
+            ]),
+    ])  # fmt:skip
+
+    for i, bold_series in enumerate(bold_runs):
         bold_file = bold_series[0]
+        entities = extract_entities(bold_series)
+        metadata = config.execution.layout.get_metadata(bold_file)
         fieldmap_id = estimator_map.get(bold_file)
+
+        bold_id = _get_wf_name(bold_file, None).removesuffix('_wf')
+
+        nvols, _ = estimate_bold_mem_usage(bold_file)
+        if nvols <= 5 - config.execution.sloppy:
+            config.loggers.workflow.warning(
+                f'Too short BOLD series (<= 5 timepoints). Skipping processing of <{bold_file}>.'
+            )
+            continue
 
         functional_cache = {}
         if config.execution.derivatives:
-            from nibabies.utils.bids import extract_entities
             from nibabies.utils.derivatives import collect_functional_derivatives
-
-            entities = extract_entities(bold_series)
 
             for deriv_dir in config.execution.derivatives.values():
                 functional_cache.update(
@@ -751,20 +810,208 @@ tasks and sessions), the following preprocessing was performed.
                     else None,
                 )
 
-        bold_wf = init_bold_wf(
-            reference_anat=reference_anat,
+        # HMC, STC, SDC
+        # Coregistration to anatomical is not needed if coregistering all BOLDs together
+        bold_fit_wf = init_bold_fit_wf(
             bold_series=bold_series,
             precomputed=functional_cache,
             fieldmap_id=fieldmap_id,
-            spaces=spaces,
+            reference_anat=reference_anat,
+            omp_nthreads=omp_nthreads,
+            coreg_anat=config.workflow.bold_coreg_level == 'run',
+            name=f'bold_fit_{bold_id}_wf',
         )
-        if bold_wf is None:
-            continue
+        bold_fit_wf.__desc__ = func_pre_desc + (bold_fit_wf.__desc__ or '')
 
-        bold_wf.__desc__ = func_pre_desc + (bold_wf.__desc__ or '')
+        # Buffer for BOLD reference files regardless of `coreg_bolds`
+        boldref_buffer = pe.Node(
+            niu.IdentityInterface(
+                fields=[
+                    'bold_file',
+                    'boldref2anat_xfm',
+                    'orig2boldref_xfm',
+                    'coreg_boldref',
+                    'bold_mask',
+                ],
+            ),
+            name=f'boldref_buffer_{bold_id}',
+        )
+        boldref_buffer.inputs.bold_file = bold_file
+
+        # Summary - used for func fit reports
+        func_fit_summary = pe.Node(
+            FunctionalSummary(
+                distortion_correction='None',  # Can override with connection
+                registration='FreeSurfer' if config.workflow.surface_recon_method else 'FSL',
+                registration_dof=config.workflow.bold2anat_dof,
+                registration_init=config.workflow.bold2anat_init,
+                pe_direction=metadata.get('PhaseEncodingDirection'),
+                echo_idx=entities.get('echo', []),
+                tr=metadata['RepetitionTime'],
+                orientation=''.join(nb.aff2axcodes(nb.load(bold_file).affine)),
+                dummy_scans=config.workflow.dummy_scans,
+            ),
+            name=f'func_fit_summary_{bold_id}',
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+            run_without_submitting=True,
+        )
+
+        func_fit_reports_wf = init_func_fit_reports_wf(
+            reference_anat=reference_anat,
+            sdc_correction=fieldmap_id is None,
+            output_dir=config.execution.output_dir,
+            name=f'func_fit_reports_{bold_id}_wf',
+        )
 
         workflow.connect([
-            (anat_fit_wf, bold_wf, [
+            (anat_fit_wf, bold_fit_wf, [
+                ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
+                ('outputnode.anat_mask', 'inputnode.anat_mask'),
+                ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
+                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+                ('outputnode.subject_id', 'inputnode.subject_id'),
+                ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
+            ]),
+            (bold_fit_wf, func_fit_summary, [
+                ('outputnode.algo_dummy_scans', 'algo_dummy_scans'),
+            ]),
+            (func_fit_summary, func_fit_reports_wf, [
+                ('out_report', 'inputnode.summary_report'),
+            ]),
+            (anat_fit_wf, func_fit_reports_wf, [
+                ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
+                ('outputnode.anat_mask', 'inputnode.anat_mask'),
+                ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
+                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+                ('outputnode.subject_id', 'inputnode.subject_id'),
+            ]),
+            (bold_fit_wf, func_fit_reports_wf, [
+                ('outputnode.validation_report', 'inputnode.validation_report'),
+                ('outputnode.sdc_boldref', 'inputnode.sdc_boldref'),
+                ('outputnode.fieldmap', 'inputnode.fieldmap'),
+                ('outputnode.orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+            ]),
+            (boldref_buffer, func_fit_reports_wf, [
+                ('bold_file', 'inputnode.source_file'),
+                ('coreg_boldref', 'inputnode.coreg_boldref'),
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ]),
+        ])  # fmt:skip
+
+        if fieldmap_id:
+            # Select fieldmap files relevant to this run
+            fmap_select = pe.Node(
+                KeySelect(
+                    fields=['fmap', 'fmap_ref', 'fmap_coeff', 'fmap_mask', 'sdc_method'],
+                    key=fieldmap_id,
+                ),
+                name=f'fmap_select_{bold_id}',
+                run_without_submitting=True,
+            )
+
+            workflow.connect([
+                (fmap_wf, fmap_select, [
+                    ('outputnode.fmap', 'fmap'),
+                    ('outputnode.fmap_ref', 'fmap_ref'),
+                    ('outputnode.fmap_coeff', 'fmap_coeff'),
+                    ('outputnode.fmap_mask', 'fmap_mask'),
+                    ('outputnode.method', 'sdc_method'),
+                    ('outputnode.fmap_id', 'keys'),
+                ]),
+                (fmap_select, bold_fit_wf, [
+                    ('fmap_ref', 'inputnode.fmap_ref'),
+                    ('fmap_coeff', 'inputnode.fmap_coeff'),
+                    ('fmap_mask', 'inputnode.fmap_mask'),
+                ]),
+                (fmap_select, func_fit_summary, [
+                    ('sdc_method', 'distortion_correction'),
+                ]),
+                (fmap_select, func_fit_reports_wf, [
+                    ('fmap_ref', 'inputnode.fmap_ref'),
+                ]),
+            ])  # fmt:skip
+
+        if config.workflow.bold_coreg_level == 'session':
+            select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
+
+            ds_orig2boldref_xfm = init_ds_registration_wf(
+                source_file=bold_file,
+                output_dir=config.execution.nibabies_dir,
+                source='orig',
+                dest='boldref',
+                desc='coreg',
+                name=f'ds_orig2boldref_xfm_{bold_id}',
+            )
+
+            ds_boldref2anat_wf = init_ds_registration_wf(
+                source_file=bold_file,
+                output_dir=config.execution.nibabies_dir,
+                source='boldref',
+                dest=reference_anat,
+                desc='coreg',
+                name=f'ds_boldref2anat_wf_{bold_id}',
+            )
+
+            workflow.connect([
+                (bold_fit_wf, merge_fit_boldrefs, [('outputnode.coreg_boldref', f'in{i+1}')]),
+                (coreg_bolds_wf, boldref_buffer, [
+                    ('outputnode.boldref', 'coreg_boldref'),
+                    ('outputnode.bold_mask', 'bold_mask'),
+                ]),
+
+                (coreg_bolds_wf, select_coreg_xfm, [('outputnode.orig2boldref_xfms', 'inlist')]),
+                (select_coreg_xfm, ds_orig2boldref_xfm, [('out', 'inputnode.xform')]),
+                (session_bold_reg_wf, ds_orig2boldref_xfm, [
+                    ('outputnode.metadata', 'inputnode.metadata'),
+                ]),
+                (coreg_bolds_wf, ds_orig2boldref_xfm, [
+                    ('outputnode.boldref_files', 'inputnode.source_files'),
+                ]),
+                (ds_orig2boldref_xfm, boldref_buffer, [('outputnode.xform', 'orig2boldref_xfm')]),
+
+                (session_bold_reg_wf, ds_boldref2anat_wf, [
+                    ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
+                ]),
+                (ds_boldref2anat_wf, boldref_buffer, [
+                    ('outputnode.xform', 'boldref2anat_xfm'),
+                ]),
+                (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
+            ])  # fmt:skip
+        else:
+            from niworkflows.data import load as nwf_load
+
+            boldref_buffer.inputs.orig2boldref_xfm = nwf_load('itkIdentityTransform.txt')
+            workflow.connect([
+                (bold_fit_wf, boldref_buffer, [
+                    ('outputnode.boldref2anat_xfm', 'boldref2anat_xfm'),
+                    ('outputnode.coreg_boldref', 'coreg_boldref'),
+                    ('outputnode.bold_mask', 'bold_mask'),
+                ]),
+                (bold_fit_wf, func_fit_summary, [
+                    ('outputnode.fallback', 'fallback'),
+                ])
+            ])  # fmt:skip
+
+        if config.workflow.level == 'minimal':
+            continue
+
+        # Slice timing correction will be present in outputs
+        func_fit_summary.inputs.slice_timing = (
+            bool(metadata.get('SliceTiming')) and 'slicetiming' not in config.workflow.ignore
+        )
+
+        bold_apply_wf = init_bold_apply_wf(
+            bold_series=bold_series,
+            fieldmap_id=fieldmap_id,
+            spaces=spaces,
+            reference_anat=reference_anat,
+            name=f'bold_apply_{bold_id}_wf',
+        )
+
+        workflow.connect([
+            (anat_fit_wf, bold_apply_wf, [
                 ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
                 ('outputnode.anat_mask', 'inputnode.anat_mask'),
                 ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
@@ -778,52 +1025,62 @@ tasks and sessions), the following preprocessing was performed.
                 ('outputnode.anat_ribbon', 'inputnode.anat_ribbon'),
                 (f'outputnode.{reg_sphere}', 'inputnode.sphere_reg_fsLR'),
             ]),
+            (bold_fit_wf, bold_apply_wf, [
+                # ('outputnode.coreg_boldref', 'inputnode.coreg_boldref'),
+                # ('outputnode.bold_mask', 'inputnode.bold_mask'),
+                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
+                ('outputnode.orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('outputnode.dummy_scans', 'inputnode.dummy_scans'),
+            ]),
+            (boldref_buffer, bold_apply_wf, [
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('coreg_boldref', 'inputnode.coreg_boldref'),
+                ('bold_mask', 'inputnode.bold_mask'),
+            ]),
         ])  # fmt:skip
+
         if fieldmap_id:
             workflow.connect([
-                (fmap_wf, bold_wf, [
-                    ('outputnode.fmap', 'inputnode.fmap'),
-                    ('outputnode.fmap_ref', 'inputnode.fmap_ref'),
-                    ('outputnode.fmap_coeff', 'inputnode.fmap_coeff'),
-                    ('outputnode.fmap_mask', 'inputnode.fmap_mask'),
-                    ('outputnode.fmap_id', 'inputnode.fmap_id'),
-                    ('outputnode.method', 'inputnode.sdc_method'),
+                (fmap_select, bold_apply_wf, [
+                    ('fmap_ref', 'inputnode.fmap_ref'),
+                    ('fmap_coeff', 'inputnode.fmap_coeff'),
                 ]),
             ])  # fmt:skip
 
-        if config.workflow.level == 'full':
-            if template_iterator_wf is not None:
-                workflow.connect([
-                    (template_iterator_wf, bold_wf, [
-                        ('outputnode.space', 'inputnode.std_space'),
-                        ('outputnode.resolution', 'inputnode.std_resolution'),
-                        ('outputnode.std_t1w', 'inputnode.std_t1w'),
-                        ('outputnode.std_mask', 'inputnode.std_mask'),
-                        ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
-                    ]),
-                ])  # fmt:skip
+        if template_iterator_wf is not None:
+            workflow.connect([
+                (template_iterator_wf, bold_apply_wf, [
+                    ('outputnode.space', 'inputnode.std_space'),
+                    ('outputnode.resolution', 'inputnode.std_resolution'),
+                    ('outputnode.cohort', 'inputnode.std_cohort'),
+                    ('outputnode.std_t1w', 'inputnode.std_t1w'),
+                    ('outputnode.std_mask', 'inputnode.std_mask'),
+                    ('outputnode.anat2std_xfm', 'inputnode.anat2std_xfm'),
+                ]),
+            ])  # fmt:skip
 
-            if select_MNIInfant_xfm is not None:
-                workflow.connect([
-                    (select_MNIInfant_xfm, bold_wf, [
-                        ('std2anat_xfm', 'inputnode.mniinfant2anat_xfm'),
-                        ('anat2std_xfm', 'inputnode.anat2mniinfant_xfm')
-                    ]),
-                ])  # fmt:skip
+        if select_MNIInfant_xfm is not None:
+            workflow.connect([
+                (select_MNIInfant_xfm, bold_apply_wf, [
+                    ('std2anat_xfm', 'inputnode.mniinfant2anat_xfm'),
+                    ('anat2std_xfm', 'inputnode.anat2mniinfant_xfm')
+                ]),
+            ])  # fmt:skip
 
-            if config.workflow.cifti_output:
+        if config.workflow.cifti_output:
+            workflow.connect([
+                (anat_fit_wf, bold_apply_wf, [
+                    ('outputnode.cortex_mask', 'inputnode.cortex_mask'),
+                ]),
+            ])  # fmt:skip
+            if anat_apply_wf is not None:
                 workflow.connect([
-                    (anat_fit_wf, bold_wf, [
-                        ('outputnode.cortex_mask', 'inputnode.cortex_mask'),
+                    (anat_apply_wf, bold_apply_wf, [
+                        ('outputnode.midthickness_fsLR', 'inputnode.midthickness_fsLR'),
+                        ('outputnode.anat_aseg', 'inputnode.anat_aseg'),
                     ]),
                 ])  # fmt:skip
-                if anat_apply_wf is not None:
-                    workflow.connect([
-                        (anat_apply_wf, bold_wf, [
-                            ('outputnode.midthickness_fsLR', 'inputnode.midthickness_fsLR'),
-                            ('outputnode.anat_aseg', 'inputnode.anat_aseg'),
-                        ]),
-                    ])  # fmt:skip
 
     return clean_datasinks(workflow)
 
@@ -1039,3 +1296,25 @@ def get_MNIInfant_key(spaces: SpatialReferences, res: str | int) -> str:
             return ref.fullname
 
     raise KeyError(f'MNIInfant (resolution {res}) not found in SpatialReferences: {spaces}')
+
+
+def _get_wf_name(bold_fname, prefix):
+    """
+    Derive the workflow name for supplied BOLD file.
+
+    >>> _get_wf_name("/completely/made/up/path/sub-01_task-nback_bold.nii.gz", "bold")
+    'bold_task_nback_wf'
+    >>> _get_wf_name(
+    ...     "/completely/made/up/path/sub-01_task-nback_run-01_echo-1_bold.nii.gz",
+    ...     "preproc",
+    ... )
+    'preproc_task_nback_run_01_echo_1_wf'
+
+    """
+    from nipype.utils.filemanip import split_filename
+
+    fname = split_filename(bold_fname)[1]
+    fname_nosub = '_'.join(fname.split('_')[1:-1])
+    if prefix is None:
+        return f'{fname_nosub}_wf'
+    return f'{prefix}_{fname_nosub.replace("-", "_")}_wf'

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -767,6 +767,8 @@ tasks and sessions), the following preprocessing was performed.
             ]),
     ])  # fmt:skip
 
+        _session_dismiss = ('task', 'run', 'echo', 'part', 'dir')
+
         ds_session_boldref = pe.Node(
             DerivativesDataSink(
                 source_file=bold_runs[0][0],
@@ -774,13 +776,27 @@ tasks and sessions), the following preprocessing was performed.
                 desc='coreg',
                 suffix='boldref',
                 compress=True,
-                dismiss_entities=('run', 'echo', 'part'),
+                dismiss_entities=_session_dismiss,
             ),
             name='ds_session_boldref',
             run_without_submitting=True,
         )
+        ds_session_bold_mask = pe.Node(
+            DerivativesDataSink(
+                source_file=bold_runs[0][0],
+                base_directory=config.execution.nibabies_dir,
+                space='session',
+                desc='brain',
+                suffix='mask',
+                compress=True,
+                dismiss_entities=_session_dismiss,
+            ),
+            name='ds_session_bold_mask',
+            run_without_submitting=True,
+        )
         workflow.connect([
             (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+            (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
         ])  # fmt:skip
 
     for i, bold_series in enumerate(bold_runs):

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -769,7 +769,7 @@ tasks and sessions), the following preprocessing was performed.
             omp_nthreads=omp_nthreads,
             mem_gb=2,  # Estimated
             sloppy=config.execution.sloppy,
-            name='session_boldref_to_anat_reg_wf',
+            name='boldref_template_to_anat_reg_wf',
         )
 
         workflow.connect([
@@ -860,7 +860,7 @@ tasks and sessions), the following preprocessing was performed.
                     'orig_boldref',
                     'orig_bold_mask',
                     'orig2anat_xfm',
-                    'session_boldref',
+                    'boldref_template',
                 ],
             ),
             name=f'boldref_buffer_{bold_id}',
@@ -991,7 +991,7 @@ tasks and sessions), the following preprocessing was performed.
                 (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
             ])  # fmt:skip
 
-            ds_session_boldref = pe.Node(
+            ds_boldref_template = pe.Node(
                 DerivativesDataSink(
                     source_file=bold_file,
                     base_directory=config.execution.nibabies_dir,
@@ -1000,7 +1000,7 @@ tasks and sessions), the following preprocessing was performed.
                     suffix='boldref',
                     compress=True,
                 ),
-                name=f'ds_session_boldref_{bold_id}',
+                name=f'ds_boldref_template_{bold_id}',
                 run_without_submitting=True,
             )
             ds_session_bold_mask = pe.Node(
@@ -1021,10 +1021,10 @@ tasks and sessions), the following preprocessing was performed.
                 ]),
                 (bold_template_wf, boldref_buffer, [
                     ('outputnode.boldref', 'coreg_boldref'),
-                    ('outputnode.boldref', 'session_boldref'),
+                    ('outputnode.boldref', 'boldref_template'),
                     ('outputnode.bold_mask', 'bold_mask'),
                 ]),
-                (bold_template_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+                (bold_template_wf, ds_boldref_template, [('outputnode.boldref', 'in_file')]),
                 (bold_template_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
             ])  # fmt:skip
 
@@ -1140,7 +1140,7 @@ tasks and sessions), the following preprocessing was performed.
                 ('orig_boldref', 'inputnode.orig_boldref'),
                 ('orig_bold_mask', 'inputnode.orig_bold_mask'),
                 ('orig2anat_xfm', 'inputnode.orig2anat_xfm'),
-                ('session_boldref', 'inputnode.session_boldref'),
+                ('boldref_template', 'inputnode.boldref_template'),
             ]),
         ])  # fmt:skip
 

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -729,32 +729,6 @@ tasks and sessions), the following preprocessing was performed.
         # only allow if homogeneous
         LOGGER.info('Coregistering all BOLD runs to a common space')
 
-        # Check for precomputed session boldref and mask
-        session_boldref = None
-        session_mask = None
-        if config.execution.derivatives:
-            from nibabies.utils.derivatives import collect_functional_derivatives
-
-            _session_ents = {'subject': subject_id}
-            if session_id:
-                _session_ents['session'] = session_id
-            _session_cache: dict = {}
-            for deriv_dir in config.execution.derivatives.values():
-                _session_cache.update(
-                    collect_functional_derivatives(
-                        derivatives_dir=deriv_dir,
-                        entities=_session_ents,
-                        fieldmap_id=None,
-                    )
-                )
-            session_boldref = _session_cache.get('session_boldref')
-            session_mask = _session_cache.get('session_bold_mask')
-            if bool(session_boldref) != bool(session_mask):
-                LOGGER.warning(
-                    'Found only one of session boldref/mask in derivatives — recomputing both.'
-                )
-                session_boldref = session_mask = None
-
         # session BOLD reference to anatomical registration (always needed)
         session_bold_reg_wf = init_bold_reg_wf(
             bold2anat_dof=config.workflow.bold2anat_dof,
@@ -779,55 +753,20 @@ tasks and sessions), the following preprocessing was performed.
             ]),
         ])  # fmt:skip
 
-        _session_dismiss = ('task', 'run', 'echo', 'part', 'dir')
-
-        if session_boldref:
-            LOGGER.info(f'Reusing session boldref: {session_boldref}')
-            LOGGER.info(f'Reusing session bold mask: {session_mask}')
-            session_bold_reg_wf.inputs.inputnode.ref_bold_brain = session_boldref
-        else:
-            merge_fit_boldrefs = pe.Node(
-                niu.Merge(len(bold_runs)),
-                name='merge_fit_boldrefs',
-            )
-            coreg_bolds_wf = init_coreg_session_bolds_wf(
-                num_bold_runs=len(bold_runs),
-                omp_nthreads=omp_nthreads,
-            )
-
-            ds_session_boldref = pe.Node(
-                DerivativesDataSink(
-                    source_file=bold_runs[0][0],
-                    base_directory=config.execution.nibabies_dir,
-                    desc='coreg',
-                    suffix='boldref',
-                    compress=True,
-                    dismiss_entities=_session_dismiss,
-                ),
-                name='ds_session_boldref',
-                run_without_submitting=True,
-            )
-            ds_session_bold_mask = pe.Node(
-                DerivativesDataSink(
-                    source_file=bold_runs[0][0],
-                    base_directory=config.execution.nibabies_dir,
-                    space='session',
-                    desc='brain',
-                    suffix='mask',
-                    compress=True,
-                    dismiss_entities=_session_dismiss,
-                ),
-                name='ds_session_bold_mask',
-                run_without_submitting=True,
-            )
-            workflow.connect([
-                (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
-                (coreg_bolds_wf, session_bold_reg_wf, [
-                    ('outputnode.boldref', 'inputnode.ref_bold_brain'),
-                ]),
-                (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
-                (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
-            ])  # fmt:skip
+        merge_fit_boldrefs = pe.Node(
+            niu.Merge(len(bold_runs)),
+            name='merge_fit_boldrefs',
+        )
+        coreg_bolds_wf = init_coreg_session_bolds_wf(
+            num_bold_runs=len(bold_runs),
+            omp_nthreads=omp_nthreads,
+        )
+        workflow.connect([
+            (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
+            (coreg_bolds_wf, session_bold_reg_wf, [
+                ('outputnode.boldref', 'inputnode.ref_bold_brain'),
+            ]),
+        ])  # fmt:skip
 
     for i, bold_series in enumerate(bold_runs):
         bold_file = bold_series[0]
@@ -1032,21 +971,42 @@ tasks and sessions), the following preprocessing was performed.
                 (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
             ])  # fmt:skip
 
-            if session_boldref:
-                boldref_buffer.inputs.coreg_boldref = session_boldref
-                boldref_buffer.inputs.session_boldref = session_boldref
-                boldref_buffer.inputs.bold_mask = session_mask
-            else:
-                workflow.connect([
-                    (bold_fit_wf, merge_fit_boldrefs, [
-                        ('outputnode.coreg_boldref', f'in{i+1}'),
-                    ]),
-                    (coreg_bolds_wf, boldref_buffer, [
-                        ('outputnode.boldref', 'coreg_boldref'),
-                        ('outputnode.boldref', 'session_boldref'),
-                        ('outputnode.bold_mask', 'bold_mask'),
-                    ]),
-                ])  # fmt:skip
+            ds_session_boldref = pe.Node(
+                DerivativesDataSink(
+                    source_file=bold_file,
+                    base_directory=config.execution.nibabies_dir,
+                    space='session',
+                    desc='coreg',
+                    suffix='boldref',
+                    compress=True,
+                ),
+                name=f'ds_session_boldref_{bold_id}',
+                run_without_submitting=True,
+            )
+            ds_session_bold_mask = pe.Node(
+                DerivativesDataSink(
+                    source_file=bold_file,
+                    base_directory=config.execution.nibabies_dir,
+                    space='session',
+                    desc='brain',
+                    suffix='mask',
+                    compress=True,
+                ),
+                name=f'ds_session_bold_mask_{bold_id}',
+                run_without_submitting=True,
+            )
+            workflow.connect([
+                (bold_fit_wf, merge_fit_boldrefs, [
+                    ('outputnode.coreg_boldref', f'in{i+1}'),
+                ]),
+                (coreg_bolds_wf, boldref_buffer, [
+                    ('outputnode.boldref', 'coreg_boldref'),
+                    ('outputnode.boldref', 'session_boldref'),
+                    ('outputnode.bold_mask', 'bold_mask'),
+                ]),
+                (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+                (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
+            ])  # fmt:skip
 
             # Compose run→session→anat for confounds
             merge_orig2anat_xfms = pe.Node(

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -918,7 +918,7 @@ tasks and sessions), the following preprocessing was performed.
                 ('outputnode.validation_report', 'inputnode.validation_report'),
                 ('outputnode.sdc_boldref', 'inputnode.sdc_boldref'),
                 ('outputnode.fieldmap', 'inputnode.fieldmap'),
-                ('outputnode.orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('outputnode.run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ]),
             (boldref_buffer, func_fit_reports_wf, [
                 ('bold_file', 'inputnode.source_file'),
@@ -1043,7 +1043,7 @@ tasks and sessions), the following preprocessing was performed.
                 # ('outputnode.coreg_boldref', 'inputnode.coreg_boldref'),
                 # ('outputnode.bold_mask', 'inputnode.bold_mask'),
                 ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-                ('outputnode.orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('outputnode.run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('outputnode.dummy_scans', 'inputnode.dummy_scans'),
             ]),
             (boldref_buffer, bold_apply_wf, [

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -879,6 +879,7 @@ tasks and sessions), the following preprocessing was performed.
                 tr=metadata['RepetitionTime'],
                 orientation=''.join(nb.aff2axcodes(nb.load(bold_file).affine)),
                 dummy_scans=config.workflow.dummy_scans,
+                bold_coreg_level=bold_coreg_level,
             ),
             name=f'func_fit_summary_{bold_id}',
             mem_gb=config.DEFAULT_MEMORY_MIN_GB,

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -85,7 +85,6 @@ MCRIBS_RECOMMEND_AGE_CAP = 3
 
 def _filter_short_bold_runs(bold_runs: list, min_vols: int = 5) -> list:
     """Exclude BOLD runs that are too short to process."""
-    import nibabel as nb
 
     filtered_bolds = []
     for run in bold_runs:
@@ -748,12 +747,13 @@ tasks and sessions), the following preprocessing was performed.
         from nibabies.utils.bids import is_valid_bold_template
 
         if not is_valid_bold_template(bold_runs, estimator_map, config.execution.layout):
-            LOGGER.error(
+            bold_refs = '\n'.join(f'  - {listify(series)[0]}' for series in bold_runs)
+            raise RuntimeError(
                 'Error when creating BOLD coregistration template: '
                 'Either only some runs have SDC applied, or all are SDC-less '
-                'runs but contain multiple phase-encoding directions.'
+                'runs but contain multiple phase-encoding directions.\n'
+                f'BOLD runs:\n{bold_refs}'
             )
-            bold_coreg_level = 'run'
 
     functional_caches = []
     for bold_series in bold_runs:

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -736,7 +736,7 @@ tasks and sessions), the following preprocessing was performed.
     if bold_coreg_level != 'run':
         from nibabies.workflows.bold.outputs import init_ds_registration_wf
         from nibabies.workflows.bold.registration import init_bold_reg_wf
-        from nibabies.workflows.bold.session import init_coreg_session_bolds_wf
+        from nibabies.workflows.bold.template import init_bold_template_wf
 
         LOGGER.info('Coregistering all BOLD runs to a common space')
         # session BOLD reference to anatomical registration (always needed)
@@ -767,13 +767,13 @@ tasks and sessions), the following preprocessing was performed.
             niu.Merge(len(bold_runs)),
             name='merge_fit_boldrefs',
         )
-        coreg_bolds_wf = init_coreg_session_bolds_wf(
+        bold_template_wf = init_bold_template_wf(
             num_bold_runs=len(bold_runs),
             omp_nthreads=omp_nthreads,
         )
         workflow.connect([
-            (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
-            (coreg_bolds_wf, session_bold_reg_wf, [
+            (merge_fit_boldrefs, bold_template_wf, [('out', 'inputnode.boldref_files')]),
+            (bold_template_wf, session_bold_reg_wf, [
                 ('outputnode.boldref', 'inputnode.ref_bold_brain'),
             ]),
         ])  # fmt:skip
@@ -1010,13 +1010,13 @@ tasks and sessions), the following preprocessing was performed.
                 (bold_fit_wf, merge_fit_boldrefs, [
                     ('outputnode.coreg_boldref', f'in{i+1}'),
                 ]),
-                (coreg_bolds_wf, boldref_buffer, [
+                (bold_template_wf, boldref_buffer, [
                     ('outputnode.boldref', 'coreg_boldref'),
                     ('outputnode.boldref', 'session_boldref'),
                     ('outputnode.bold_mask', 'bold_mask'),
                 ]),
-                (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
-                (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
+                (bold_template_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+                (bold_template_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
             ])  # fmt:skip
 
             # Compose run→session→anat for confounds
@@ -1050,14 +1050,14 @@ tasks and sessions), the following preprocessing was performed.
                     name=f'ds_orig2session_xfm_{bold_id}',
                 )
                 workflow.connect([
-                    (coreg_bolds_wf, select_coreg_xfm, [
+                    (bold_template_wf, select_coreg_xfm, [
                         ('outputnode.orig2session_xfms', 'inlist'),
                     ]),
                     (select_coreg_xfm, ds_orig2session_xfm, [('out', 'inputnode.xform')]),
                     (session_bold_reg_wf, ds_orig2session_xfm, [
                         ('outputnode.metadata', 'inputnode.metadata'),
                     ]),
-                    (coreg_bolds_wf, ds_orig2session_xfm, [
+                    (bold_template_wf, ds_orig2session_xfm, [
                         ('outputnode.boldref_files', 'inputnode.source_files'),
                     ]),
                     (ds_orig2session_xfm, boldref_buffer, [

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -767,6 +767,22 @@ tasks and sessions), the following preprocessing was performed.
             ]),
     ])  # fmt:skip
 
+        ds_session_boldref = pe.Node(
+            DerivativesDataSink(
+                source_file=bold_runs[0][0],
+                base_directory=config.execution.nibabies_dir,
+                desc='coreg',
+                suffix='boldref',
+                compress=True,
+                dismiss_entities=('run', 'echo', 'part'),
+            ),
+            name='ds_session_boldref',
+            run_without_submitting=True,
+        )
+        workflow.connect([
+            (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+        ])  # fmt:skip
+
     for i, bold_series in enumerate(bold_runs):
         bold_file = bold_series[0]
         entities = extract_entities(bold_series)

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -887,7 +887,7 @@ tasks and sessions), the following preprocessing was performed.
 
         func_fit_reports_wf = init_func_fit_reports_wf(
             reference_anat=reference_anat,
-            sdc_correction=fieldmap_id is None,
+            sdc_correction=fieldmap_id is not None,
             output_dir=config.execution.output_dir,
             name=f'func_fit_reports_{bold_id}_wf',
         )

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -854,10 +854,10 @@ tasks and sessions), the following preprocessing was performed.
                 fields=[
                     'bold_file',
                     'boldref2anat_xfm',
-                    'orig2session_xfm',
+                    'run2boldref_xfm',
                     'coreg_boldref',
                     'bold_mask',
-                    'orig_boldref',
+                    'run_boldref',
                     'orig_bold_mask',
                     'orig2anat_xfm',
                     'boldref_template',
@@ -925,7 +925,7 @@ tasks and sessions), the following preprocessing was performed.
                 ('bold_file', 'inputnode.source_file'),
                 ('coreg_boldref', 'inputnode.coreg_boldref'),
                 ('bold_mask', 'inputnode.bold_mask'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ]),
         ])  # fmt:skip
@@ -966,7 +966,7 @@ tasks and sessions), the following preprocessing was performed.
         if bold_coreg_level != 'run':
             from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 
-            orig2session = functional_cache.get('orig2session')
+            run2boldref = functional_cache.get('run2boldref')
 
             ds_boldref2anat_wf = init_ds_registration_wf(
                 source_file=bold_file,
@@ -979,7 +979,7 @@ tasks and sessions), the following preprocessing was performed.
 
             workflow.connect([
                 (bold_fit_wf, boldref_buffer, [
-                    ('outputnode.coreg_boldref', 'orig_boldref'),
+                    ('outputnode.coreg_boldref', 'run_boldref'),
                     ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
                 (session_bold_reg_wf, ds_boldref2anat_wf, [
@@ -995,7 +995,7 @@ tasks and sessions), the following preprocessing was performed.
                 DerivativesDataSink(
                     source_file=bold_file,
                     base_directory=config.execution.nibabies_dir,
-                    space='session',
+                    space='boldref',
                     desc='coreg',
                     suffix='boldref',
                     compress=True,
@@ -1007,7 +1007,7 @@ tasks and sessions), the following preprocessing was performed.
                 DerivativesDataSink(
                     source_file=bold_file,
                     base_directory=config.execution.nibabies_dir,
-                    space='session',
+                    space='boldref',
                     desc='brain',
                     suffix='mask',
                     compress=True,
@@ -1044,48 +1044,48 @@ tasks and sessions), the following preprocessing was performed.
                 (ds_boldref2anat_wf, merge_orig2anat_xfms, [('outputnode.xform', 'in2')]),
             ])  # fmt:skip
 
-            if orig2session:
-                LOGGER.info(f'Reusing orig2session transform: {orig2session}')
-                boldref_buffer.inputs.orig2session_xfm = orig2session
-                merge_orig2anat_xfms.inputs.in1 = orig2session
+            if run2boldref:
+                LOGGER.info(f'Reusing run2boldref transform: {run2boldref}')
+                boldref_buffer.inputs.run2boldref_xfm = run2boldref
+                merge_orig2anat_xfms.inputs.in1 = run2boldref
             else:
                 select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
-                ds_orig2session_xfm = init_ds_registration_wf(
+                ds_run2boldref_xfm = init_ds_registration_wf(
                     source_file=bold_file,
                     output_dir=config.execution.nibabies_dir,
-                    source='orig',
-                    dest='session',
+                    source='run',
+                    dest='boldref',
                     desc='coreg',
-                    name=f'ds_orig2session_xfm_{bold_id}',
+                    name=f'ds_run2boldref_xfm_{bold_id}',
                 )
                 workflow.connect([
                     (bold_template_wf, select_coreg_xfm, [
-                        ('outputnode.orig2session_xfms', 'inlist'),
+                        ('outputnode.run2boldref_xfms', 'inlist'),
                     ]),
-                    (select_coreg_xfm, ds_orig2session_xfm, [('out', 'inputnode.xform')]),
-                    (session_bold_reg_wf, ds_orig2session_xfm, [
+                    (select_coreg_xfm, ds_run2boldref_xfm, [('out', 'inputnode.xform')]),
+                    (session_bold_reg_wf, ds_run2boldref_xfm, [
                         ('outputnode.metadata', 'inputnode.metadata'),
                     ]),
-                    (bold_template_wf, ds_orig2session_xfm, [
+                    (bold_template_wf, ds_run2boldref_xfm, [
                         ('outputnode.boldref_files', 'inputnode.source_files'),
                     ]),
-                    (ds_orig2session_xfm, boldref_buffer, [
-                        ('outputnode.xform', 'orig2session_xfm'),
+                    (ds_run2boldref_xfm, boldref_buffer, [
+                        ('outputnode.xform', 'run2boldref_xfm'),
                     ]),
-                    (ds_orig2session_xfm, merge_orig2anat_xfms, [
+                    (ds_run2boldref_xfm, merge_orig2anat_xfms, [
                         ('outputnode.xform', 'in1'),
                     ]),
                 ])  # fmt:skip
         else:
             from niworkflows.data import load as nwf_load
 
-            boldref_buffer.inputs.orig2session_xfm = nwf_load('itkIdentityTransform.txt')
+            boldref_buffer.inputs.run2boldref_xfm = nwf_load('itkIdentityTransform.txt')
             workflow.connect([
                 (bold_fit_wf, boldref_buffer, [
                     ('outputnode.boldref2anat_xfm', 'boldref2anat_xfm'),
                     ('outputnode.boldref2anat_xfm', 'orig2anat_xfm'),
                     ('outputnode.coreg_boldref', 'coreg_boldref'),
-                    ('outputnode.coreg_boldref', 'orig_boldref'),
+                    ('outputnode.coreg_boldref', 'run_boldref'),
                     ('outputnode.bold_mask', 'bold_mask'),
                     ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
@@ -1134,10 +1134,10 @@ tasks and sessions), the following preprocessing was performed.
             ]),
             (boldref_buffer, bold_apply_wf, [
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('coreg_boldref', 'inputnode.coreg_boldref'),
                 ('bold_mask', 'inputnode.bold_mask'),
-                ('orig_boldref', 'inputnode.orig_boldref'),
+                ('run_boldref', 'inputnode.run_boldref'),
                 ('orig_bold_mask', 'inputnode.orig_bold_mask'),
                 ('orig2anat_xfm', 'inputnode.orig2anat_xfm'),
                 ('boldref_template', 'inputnode.boldref_template'),

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -67,6 +67,7 @@ from nibabies.workflows.anatomical.fit import (
     init_infant_single_anat_fit_wf,
 )
 from nibabies.workflows.bold.base import init_bold_apply_wf
+from nibabies.workflows.bold.coreg import init_bold_anat_coreg_wf
 from nibabies.workflows.bold.fit import init_bold_fit_wf
 from nibabies.workflows.bold.outputs import init_func_fit_reports_wf
 
@@ -754,64 +755,16 @@ tasks and sessions), the following preprocessing was performed.
             )
             bold_coreg_level = 'run'
 
-    if bold_coreg_level != 'run':
-        from nibabies.workflows.bold.outputs import init_ds_registration_wf
-        from nibabies.workflows.bold.registration import init_bold_reg_wf
-        from nibabies.workflows.bold.template import init_bold_template_wf
-
-        LOGGER.info('Coregistering all BOLD run references to a common space')
-        boldref_reg_wf = init_bold_reg_wf(
-            bold2anat_dof=config.workflow.bold2anat_dof,
-            bold2anat_init=config.workflow.bold2anat_init,
-            use_bbr=config.workflow.use_bbr,
-            freesurfer=config.workflow.surface_recon_method is not None,
-            omp_nthreads=omp_nthreads,
-            mem_gb=2,  # Estimated
-            sloppy=config.execution.sloppy,
-            name='boldref_reg_wf',
-        )
-
-        workflow.connect([
-            (anat_fit_wf, boldref_reg_wf, [
-                ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
-                ('outputnode.anat_mask', 'inputnode.anat_mask'),
-                ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
-                # Undefined if --fs-no-reconall, but this is safe
-                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
-                ('outputnode.subject_id', 'inputnode.subject_id'),
-                ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
-            ]),
-        ])  # fmt:skip
-
-        merge_fit_boldrefs = pe.Node(
-            niu.Merge(len(bold_runs)),
-            name='merge_fit_boldrefs',
-        )
-        bold_template_wf = init_bold_template_wf(
-            num_bold_runs=len(bold_runs),
-            omp_nthreads=omp_nthreads,
-        )
-        workflow.connect([
-            (merge_fit_boldrefs, bold_template_wf, [('out', 'inputnode.boldref_files')]),
-            (bold_template_wf, boldref_reg_wf, [
-                ('outputnode.boldref', 'inputnode.ref_bold_brain'),
-            ]),
-        ])  # fmt:skip
-
-    for i, bold_series in enumerate(bold_runs):
-        bold_file = bold_series[0]
-        entities = extract_entities(bold_series)
-        metadata = config.execution.layout.get_metadata(bold_file)
-        fieldmap_id = estimator_map.get(bold_file)
-
-        bold_id = _get_wf_name(bold_file, None).removesuffix('_wf')
-
-        functional_cache = {}
+    functional_caches = []
+    for bold_series in bold_runs:
+        cache = {}
         if config.execution.derivatives:
             from nibabies.utils.derivatives import collect_functional_derivatives
 
+            entities = extract_entities(bold_series)
+            fieldmap_id = estimator_map.get(bold_series[0])
             for deriv_dir in config.execution.derivatives.values():
-                functional_cache.update(
+                cache.update(
                     collect_functional_derivatives(
                         derivatives_dir=deriv_dir,
                         entities=entities,
@@ -824,7 +777,7 @@ tasks and sessions), the following preprocessing was performed.
 
                 LOGGER.info('Copying found func derivatives into output directory')
                 copy_derivatives(
-                    derivs=functional_cache,
+                    derivs=cache,
                     outdir=config.execution.nibabies_dir,
                     modality='func',
                     subject_id=f'sub-{subject_id}',
@@ -833,16 +786,71 @@ tasks and sessions), the following preprocessing was performed.
                     if config.execution.output_layout == 'multiverse'
                     else None,
                 )
+        functional_caches.append(cache)
 
-        # HMC, STC, SDC
-        # Coregistration to anatomical is not needed if coregistering all BOLDs together
+    # Coregister all BOLD run references to anatomical space
+    coreg_precomputed = {
+        'boldref2anat_xfm': [cache.get('boldref2anat') for cache in functional_caches],
+    }
+    if bold_coreg_level != 'run':
+        # When every run→template transform is available, the template calculation
+        # can be skipped: those transforms are applied to the run references instead.
+        coreg_precomputed['run2boldref_xfms'] = [
+            cache.get('run2boldref') for cache in functional_caches
+        ]
+
+    bold_anat_coreg_wf = init_bold_anat_coreg_wf(
+        bold_files=[series[0] for series in bold_runs],
+        coreg_level=bold_coreg_level,
+        bold2anat_dof=config.workflow.bold2anat_dof,
+        bold2anat_init=config.workflow.bold2anat_init,
+        use_bbr=config.workflow.use_bbr,
+        freesurfer=recon_method is not None,
+        omp_nthreads=omp_nthreads,
+        mem_gb=2,  # Estimated
+        sloppy=config.execution.sloppy,
+        output_dir=config.execution.nibabies_dir,
+        reference_anat=reference_anat,
+        precomputed=coreg_precomputed,
+    )
+
+    merge_fit_boldrefs = pe.Node(
+        niu.Merge(len(bold_runs)), name='merge_fit_boldrefs', run_without_submitting=True
+    )
+    merge_fit_masks = pe.Node(
+        niu.Merge(len(bold_runs)), name='merge_fit_masks', run_without_submitting=True
+    )
+
+    workflow.connect([
+        (anat_fit_wf, bold_anat_coreg_wf, [
+            ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
+            ('outputnode.anat_mask', 'inputnode.anat_mask'),
+            ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
+            # Undefined if --fs-no-reconall, but this is safe
+            ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
+            ('outputnode.subject_id', 'inputnode.subject_id'),
+            ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
+        ]),
+        (merge_fit_boldrefs, bold_anat_coreg_wf, [('out', 'inputnode.run_boldrefs')]),
+        (merge_fit_masks, bold_anat_coreg_wf, [('out', 'inputnode.run_masks')]),
+    ])  # fmt:skip
+
+    for i, bold_series in enumerate(bold_runs):
+        bold_file = bold_series[0]
+        entities = extract_entities(bold_series)
+        metadata = config.execution.layout.get_metadata(bold_file)
+        fieldmap_id = estimator_map.get(bold_file)
+
+        bold_id = _get_wf_name(bold_file, None).removesuffix('_wf')
+
+        functional_cache = functional_caches[i]
+
+        # HMC, STC, SDC (within-run)
         bold_fit_wf = init_bold_fit_wf(
             bold_series=bold_series,
             precomputed=functional_cache,
             fieldmap_id=fieldmap_id,
-            reference_anat=reference_anat,
             omp_nthreads=omp_nthreads,
-            coreg_anat=bool(bold_coreg_level == 'run'),
             name=f'bold_fit_{bold_id}_wf',
         )
         bold_fit_wf.__desc__ = func_pre_desc + (bold_fit_wf.__desc__ or '')
@@ -858,7 +866,7 @@ tasks and sessions), the following preprocessing was performed.
                     'bold_mask',
                     'run_boldref',
                     'orig_bold_mask',
-                    'orig2anat_xfm',
+                    'run2anat_xfm',
                     'boldref_template',
                 ],
             ),
@@ -870,7 +878,7 @@ tasks and sessions), the following preprocessing was performed.
         func_fit_summary = pe.Node(
             FunctionalSummary(
                 distortion_correction='None',  # Can override with connection
-                registration='FreeSurfer' if config.workflow.surface_recon_method else 'FSL',
+                registration='FreeSurfer' if recon_method else 'FSL',
                 registration_dof=config.workflow.bold2anat_dof,
                 registration_init=config.workflow.bold2anat_init,
                 pe_direction=metadata.get('PhaseEncodingDirection'),
@@ -893,14 +901,6 @@ tasks and sessions), the following preprocessing was performed.
         )
 
         workflow.connect([
-            (anat_fit_wf, bold_fit_wf, [
-                ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
-                ('outputnode.anat_mask', 'inputnode.anat_mask'),
-                ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
-                ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
-                ('outputnode.subject_id', 'inputnode.subject_id'),
-                ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
-            ]),
             (bold_fit_wf, func_fit_summary, [
                 ('outputnode.algo_dummy_scans', 'algo_dummy_scans'),
             ]),
@@ -962,136 +962,51 @@ tasks and sessions), the following preprocessing was performed.
                 ]),
             ])  # fmt:skip
 
-        if bold_coreg_level != 'run':
-            from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+        # Feed this run's fit reference/mask into the shared coregistration wf and
+        # fan its matched per-run list outputs back into boldref_buffer.
+        select_coreg_boldref = pe.Node(
+            niu.Select(index=i),
+            name=f'select_coreg_boldref_{bold_id}',
+            run_without_submitting=True,
+        )
+        select_bold_mask = pe.Node(
+            niu.Select(index=i), name=f'select_bold_mask_{bold_id}', run_without_submitting=True
+        )
+        select_run2boldref = pe.Node(
+            niu.Select(index=i), name=f'select_run2boldref_{bold_id}', run_without_submitting=True
+        )
+        select_boldref2anat = pe.Node(
+            niu.Select(index=i), name=f'select_boldref2anat_{bold_id}', run_without_submitting=True
+        )
+        select_run2anat = pe.Node(
+            niu.Select(index=i), name=f'select_run2anat_{bold_id}', run_without_submitting=True
+        )
+        select_fallback = pe.Node(
+            niu.Select(index=i), name=f'select_fallback_{bold_id}', run_without_submitting=True
+        )
 
-            run2boldref = functional_cache.get('run2boldref')
-
-            ds_boldref2anat_wf = init_ds_registration_wf(
-                source_file=bold_file,
-                output_dir=config.execution.nibabies_dir,
-                source='boldref',
-                dest=reference_anat,
-                desc='coreg',
-                name=f'ds_boldref2anat_wf_{bold_id}',
-            )
-
-            workflow.connect([
-                (bold_fit_wf, boldref_buffer, [
-                    ('outputnode.coreg_boldref', 'run_boldref'),
-                    ('outputnode.bold_mask', 'orig_bold_mask'),
-                ]),
-                (boldref_reg_wf, ds_boldref2anat_wf, [
-                    ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
-                ]),
-                (ds_boldref2anat_wf, boldref_buffer, [
-                    ('outputnode.xform', 'boldref2anat_xfm'),
-                ]),
-                (boldref_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
-            ])  # fmt:skip
-
-            ds_boldref_template = pe.Node(
-                DerivativesDataSink(
-                    source_file=bold_file,
-                    base_directory=config.execution.nibabies_dir,
-                    space='boldref',
-                    desc='coreg',
-                    suffix='boldref',
-                    compress=True,
-                ),
-                name=f'ds_boldref_template_{bold_id}',
-                run_without_submitting=True,
-            )
-            ds_boldref_mask = pe.Node(
-                DerivativesDataSink(
-                    source_file=bold_file,
-                    base_directory=config.execution.nibabies_dir,
-                    space='boldref',
-                    desc='brain',
-                    suffix='mask',
-                    compress=True,
-                ),
-                name=f'ds_boldref_mask_{bold_id}',
-                run_without_submitting=True,
-            )
-            workflow.connect([
-                (bold_fit_wf, merge_fit_boldrefs, [
-                    ('outputnode.coreg_boldref', f'in{i+1}'),
-                ]),
-                (bold_template_wf, boldref_buffer, [
-                    ('outputnode.boldref', 'coreg_boldref'),
-                    ('outputnode.boldref', 'boldref_template'),
-                    ('outputnode.bold_mask', 'bold_mask'),
-                ]),
-                (bold_template_wf, ds_boldref_template, [('outputnode.boldref', 'in_file')]),
-                (bold_template_wf, ds_boldref_mask, [('outputnode.bold_mask', 'in_file')]),
-            ])  # fmt:skip
-
-            # Compose run→session→anat for confounds
-            merge_orig2anat_xfms = pe.Node(
-                niu.Merge(2),
-                name=f'merge_orig2anat_xfms_{bold_id}',
-                run_without_submitting=True,
-            )
-            concat_orig2anat = pe.Node(
-                ConcatenateXFMs(),
-                name=f'concat_orig2anat_{bold_id}',
-            )
-            workflow.connect([
-                (merge_orig2anat_xfms, concat_orig2anat, [('out', 'in_xfms')]),
-                (concat_orig2anat, boldref_buffer, [('out_xfm', 'orig2anat_xfm')]),
-                (ds_boldref2anat_wf, merge_orig2anat_xfms, [('outputnode.xform', 'in2')]),
-            ])  # fmt:skip
-
-            if run2boldref:
-                LOGGER.info(f'Reusing run2boldref transform: {run2boldref}')
-                boldref_buffer.inputs.run2boldref_xfm = run2boldref
-                merge_orig2anat_xfms.inputs.in1 = run2boldref
-            else:
-                select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
-                ds_run2boldref_xfm = init_ds_registration_wf(
-                    source_file=bold_file,
-                    output_dir=config.execution.nibabies_dir,
-                    source='run',
-                    dest='boldref',
-                    desc='coreg',
-                    name=f'ds_run2boldref_xfm_{bold_id}',
-                )
-                workflow.connect([
-                    (bold_template_wf, select_coreg_xfm, [
-                        ('outputnode.run2boldref_xfms', 'inlist'),
-                    ]),
-                    (select_coreg_xfm, ds_run2boldref_xfm, [('out', 'inputnode.xform')]),
-                    (boldref_reg_wf, ds_run2boldref_xfm, [
-                        ('outputnode.metadata', 'inputnode.metadata'),
-                    ]),
-                    (bold_template_wf, ds_run2boldref_xfm, [
-                        ('outputnode.boldref_files', 'inputnode.source_files'),
-                    ]),
-                    (ds_run2boldref_xfm, boldref_buffer, [
-                        ('outputnode.xform', 'run2boldref_xfm'),
-                    ]),
-                    (ds_run2boldref_xfm, merge_orig2anat_xfms, [
-                        ('outputnode.xform', 'in1'),
-                    ]),
-                ])  # fmt:skip
-        else:
-            from niworkflows.data import load as nwf_load
-
-            boldref_buffer.inputs.run2boldref_xfm = nwf_load('itkIdentityTransform.txt')
-            workflow.connect([
-                (bold_fit_wf, boldref_buffer, [
-                    ('outputnode.boldref2anat_xfm', 'boldref2anat_xfm'),
-                    ('outputnode.boldref2anat_xfm', 'orig2anat_xfm'),
-                    ('outputnode.coreg_boldref', 'coreg_boldref'),
-                    ('outputnode.coreg_boldref', 'run_boldref'),
-                    ('outputnode.bold_mask', 'bold_mask'),
-                    ('outputnode.bold_mask', 'orig_bold_mask'),
-                ]),
-                (bold_fit_wf, func_fit_summary, [
-                    ('outputnode.fallback', 'fallback'),
-                ])
-            ])  # fmt:skip
+        workflow.connect([
+            (bold_fit_wf, merge_fit_boldrefs, [('outputnode.coreg_boldref', f'in{i + 1}')]),
+            (bold_fit_wf, merge_fit_masks, [('outputnode.bold_mask', f'in{i + 1}')]),
+            # run_boldref/orig_bold_mask are the run's own fit outputs
+            (bold_fit_wf, boldref_buffer, [
+                ('outputnode.coreg_boldref', 'run_boldref'),
+                ('outputnode.bold_mask', 'orig_bold_mask'),
+            ]),
+            (bold_anat_coreg_wf, select_coreg_boldref, [('outputnode.coreg_boldrefs', 'inlist')]),
+            (bold_anat_coreg_wf, select_bold_mask, [('outputnode.bold_masks', 'inlist')]),
+            (bold_anat_coreg_wf, select_run2boldref, [('outputnode.run2boldref_xfms', 'inlist')]),
+            (bold_anat_coreg_wf, select_boldref2anat, [('outputnode.boldref2anat_xfms', 'inlist')]),
+            (bold_anat_coreg_wf, select_run2anat, [('outputnode.run2anat_xfms', 'inlist')]),
+            (bold_anat_coreg_wf, select_fallback, [('outputnode.fallbacks', 'inlist')]),
+            (select_coreg_boldref, boldref_buffer, [('out', 'coreg_boldref')]),
+            (select_bold_mask, boldref_buffer, [('out', 'bold_mask')]),
+            (select_run2boldref, boldref_buffer, [('out', 'run2boldref_xfm')]),
+            (select_boldref2anat, boldref_buffer, [('out', 'boldref2anat_xfm')]),
+            (select_run2anat, boldref_buffer, [('out', 'run2anat_xfm')]),
+            (bold_anat_coreg_wf, boldref_buffer, [('outputnode.boldref_template', 'boldref_template')]),
+            (select_fallback, func_fit_summary, [('out', 'fallback')]),
+        ])  # fmt:skip
 
         if config.workflow.level == 'minimal':
             continue
@@ -1138,7 +1053,7 @@ tasks and sessions), the following preprocessing was performed.
                 ('bold_mask', 'inputnode.bold_mask'),
                 ('run_boldref', 'inputnode.run_boldref'),
                 ('orig_bold_mask', 'inputnode.orig_bold_mask'),
-                ('orig2anat_xfm', 'inputnode.orig2anat_xfm'),
+                ('run2anat_xfm', 'inputnode.run2anat_xfm'),
                 ('boldref_template', 'inputnode.boldref_template'),
             ]),
         ])  # fmt:skip

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -832,6 +832,10 @@ tasks and sessions), the following preprocessing was performed.
                     'orig2session_xfm',
                     'coreg_boldref',
                     'bold_mask',
+                    'orig_boldref',
+                    'orig_bold_mask',
+                    'orig2anat_xfm',
+                    'session_boldref',
                 ],
             ),
             name=f'boldref_buffer_{bold_id}',
@@ -958,7 +962,12 @@ tasks and sessions), the following preprocessing was performed.
                 (bold_fit_wf, merge_fit_boldrefs, [('outputnode.coreg_boldref', f'in{i+1}')]),
                 (coreg_bolds_wf, boldref_buffer, [
                     ('outputnode.boldref', 'coreg_boldref'),
+                    ('outputnode.boldref', 'session_boldref'),
                     ('outputnode.bold_mask', 'bold_mask'),
+                ]),
+                (bold_fit_wf, boldref_buffer, [
+                    ('outputnode.coreg_boldref', 'orig_boldref'),
+                    ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
 
                 (coreg_bolds_wf, select_coreg_xfm, [('outputnode.orig2session_xfms', 'inlist')]),
@@ -979,6 +988,25 @@ tasks and sessions), the following preprocessing was performed.
                 ]),
                 (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
             ])  # fmt:skip
+
+            # Compose run→session→anat for confounds (run-space bold needs run→anat)
+            from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+
+            merge_orig2anat_xfms = pe.Node(
+                niu.Merge(2),
+                name=f'merge_orig2anat_xfms_{bold_id}',
+                run_without_submitting=True,
+            )
+            concat_orig2anat = pe.Node(
+                ConcatenateXFMs(),
+                name=f'concat_orig2anat_{bold_id}',
+            )
+            workflow.connect([
+                (ds_orig2session_xfm, merge_orig2anat_xfms, [('outputnode.xform', 'in1')]),
+                (ds_boldref2anat_wf, merge_orig2anat_xfms, [('outputnode.xform', 'in2')]),
+                (merge_orig2anat_xfms, concat_orig2anat, [('out', 'in_xfms')]),
+                (concat_orig2anat, boldref_buffer, [('out_xfm', 'orig2anat_xfm')]),
+            ])  # fmt:skip
         else:
             from niworkflows.data import load as nwf_load
 
@@ -986,8 +1014,11 @@ tasks and sessions), the following preprocessing was performed.
             workflow.connect([
                 (bold_fit_wf, boldref_buffer, [
                     ('outputnode.boldref2anat_xfm', 'boldref2anat_xfm'),
+                    ('outputnode.boldref2anat_xfm', 'orig2anat_xfm'),
                     ('outputnode.coreg_boldref', 'coreg_boldref'),
+                    ('outputnode.coreg_boldref', 'orig_boldref'),
                     ('outputnode.bold_mask', 'bold_mask'),
+                    ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
                 (bold_fit_wf, func_fit_summary, [
                     ('outputnode.fallback', 'fallback'),
@@ -1037,6 +1068,10 @@ tasks and sessions), the following preprocessing was performed.
                 ('orig2session_xfm', 'inputnode.orig2session_xfm'),
                 ('coreg_boldref', 'inputnode.coreg_boldref'),
                 ('bold_mask', 'inputnode.bold_mask'),
+                ('orig_boldref', 'inputnode.orig_boldref'),
+                ('orig_bold_mask', 'inputnode.orig_bold_mask'),
+                ('orig2anat_xfm', 'inputnode.orig2anat_xfm'),
+                ('session_boldref', 'inputnode.session_boldref'),
             ]),
         ])  # fmt:skip
 

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -82,6 +82,25 @@ if ty.TYPE_CHECKING:
 MCRIBS_RECOMMEND_AGE_CAP = 3
 
 
+def _filter_short_bold_runs(bold_runs: list, min_vols: int = 5) -> list:
+    """Exclude BOLD runs that are too short to process."""
+    import nibabel as nb
+
+    filtered_bolds = []
+    for run in bold_runs:
+        bold_file = listify(run)[0]
+        img = nb.load(bold_file)
+        if len(img.shape) < 4 or img.shape[3] < min_vols:
+            LOGGER.warning(
+                f'Too short BOLD series (<= {min_vols} timepoints). '
+                f'Skipping processing of <{bold_file}>.'
+            )
+            continue
+        filtered_bolds.append(run)
+
+    return filtered_bolds
+
+
 def init_nibabies_wf(subworkflows_list: list[SubjectSession]):
     """
     Build *NiBabies*'s pipeline.
@@ -225,7 +244,7 @@ def init_single_subject_wf(
     from niworkflows.utils.bids import collect_data
     from niworkflows.utils.spaces import Reference
 
-    from ..utils.misc import estimate_bold_mem_usage, fix_multi_source_name
+    from ..utils.misc import fix_multi_source_name
 
     subject_session_id = _subject_session_id(subject_id, session_id)
     workflow = Workflow(name=f'single_subject_{subject_session_id}_wf')
@@ -268,6 +287,8 @@ It is released under the [CC0]\
         echo=config.execution.echo_idx,
         bids_filters=config.execution.bids_filters,
     )[0]
+
+    subject_data['bold'] = _filter_short_bold_runs(subject_data['bold'])
 
     if 'flair' in config.workflow.ignore:
         subject_data['flair'] = []
@@ -785,19 +806,6 @@ tasks and sessions), the following preprocessing was performed.
         fieldmap_id = estimator_map.get(bold_file)
 
         bold_id = _get_wf_name(bold_file, None).removesuffix('_wf')
-
-        # TODO: Volume check should happen when collecting BOLD files
-        nvols, _ = estimate_bold_mem_usage(bold_file)
-        if nvols <= 5 - config.execution.sloppy:
-            config.loggers.workflow.warning(
-                f'Too short BOLD series (<= 5 timepoints). Skipping processing of <{bold_file}>.'
-            )
-            if bold_coreg_level != 'session':
-                # TODO: Move this check prior to create session workflow to avoid hard crashes
-                raise RuntimeError(
-                    'Cannot create session-level BOLD reference with invalid BOLD series.'
-                )
-            continue
 
         functional_cache = {}
         if config.execution.derivatives:

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -759,9 +759,8 @@ tasks and sessions), the following preprocessing was performed.
         from nibabies.workflows.bold.registration import init_bold_reg_wf
         from nibabies.workflows.bold.template import init_bold_template_wf
 
-        LOGGER.info('Coregistering all BOLD runs to a common space')
-        # session BOLD reference to anatomical registration (always needed)
-        session_bold_reg_wf = init_bold_reg_wf(
+        LOGGER.info('Coregistering all BOLD run references to a common space')
+        boldref_reg_wf = init_bold_reg_wf(
             bold2anat_dof=config.workflow.bold2anat_dof,
             bold2anat_init=config.workflow.bold2anat_init,
             use_bbr=config.workflow.use_bbr,
@@ -769,11 +768,11 @@ tasks and sessions), the following preprocessing was performed.
             omp_nthreads=omp_nthreads,
             mem_gb=2,  # Estimated
             sloppy=config.execution.sloppy,
-            name='boldref_template_to_anat_reg_wf',
+            name='boldref_reg_wf',
         )
 
         workflow.connect([
-            (anat_fit_wf, session_bold_reg_wf, [
+            (anat_fit_wf, boldref_reg_wf, [
                 ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
                 ('outputnode.anat_mask', 'inputnode.anat_mask'),
                 ('outputnode.anat_dseg', 'inputnode.anat_dseg'),
@@ -794,7 +793,7 @@ tasks and sessions), the following preprocessing was performed.
         )
         workflow.connect([
             (merge_fit_boldrefs, bold_template_wf, [('out', 'inputnode.boldref_files')]),
-            (bold_template_wf, session_bold_reg_wf, [
+            (bold_template_wf, boldref_reg_wf, [
                 ('outputnode.boldref', 'inputnode.ref_bold_brain'),
             ]),
         ])  # fmt:skip
@@ -982,13 +981,13 @@ tasks and sessions), the following preprocessing was performed.
                     ('outputnode.coreg_boldref', 'run_boldref'),
                     ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
-                (session_bold_reg_wf, ds_boldref2anat_wf, [
+                (boldref_reg_wf, ds_boldref2anat_wf, [
                     ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
                 ]),
                 (ds_boldref2anat_wf, boldref_buffer, [
                     ('outputnode.xform', 'boldref2anat_xfm'),
                 ]),
-                (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
+                (boldref_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
             ])  # fmt:skip
 
             ds_boldref_template = pe.Node(
@@ -1003,7 +1002,7 @@ tasks and sessions), the following preprocessing was performed.
                 name=f'ds_boldref_template_{bold_id}',
                 run_without_submitting=True,
             )
-            ds_session_bold_mask = pe.Node(
+            ds_boldref_mask = pe.Node(
                 DerivativesDataSink(
                     source_file=bold_file,
                     base_directory=config.execution.nibabies_dir,
@@ -1012,7 +1011,7 @@ tasks and sessions), the following preprocessing was performed.
                     suffix='mask',
                     compress=True,
                 ),
-                name=f'ds_session_bold_mask_{bold_id}',
+                name=f'ds_boldref_mask_{bold_id}',
                 run_without_submitting=True,
             )
             workflow.connect([
@@ -1025,7 +1024,7 @@ tasks and sessions), the following preprocessing was performed.
                     ('outputnode.bold_mask', 'bold_mask'),
                 ]),
                 (bold_template_wf, ds_boldref_template, [('outputnode.boldref', 'in_file')]),
-                (bold_template_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
+                (bold_template_wf, ds_boldref_mask, [('outputnode.bold_mask', 'in_file')]),
             ])  # fmt:skip
 
             # Compose run→session→anat for confounds
@@ -1063,7 +1062,7 @@ tasks and sessions), the following preprocessing was performed.
                         ('outputnode.run2boldref_xfms', 'inlist'),
                     ]),
                     (select_coreg_xfm, ds_run2boldref_xfm, [('out', 'inputnode.xform')]),
-                    (session_bold_reg_wf, ds_run2boldref_xfm, [
+                    (boldref_reg_wf, ds_run2boldref_xfm, [
                         ('outputnode.metadata', 'inputnode.metadata'),
                     ]),
                     (bold_template_wf, ds_run2boldref_xfm, [

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -829,7 +829,7 @@ tasks and sessions), the following preprocessing was performed.
                 fields=[
                     'bold_file',
                     'boldref2anat_xfm',
-                    'orig2boldref_xfm',
+                    'orig2session_xfm',
                     'coreg_boldref',
                     'bold_mask',
                 ],
@@ -895,7 +895,7 @@ tasks and sessions), the following preprocessing was performed.
                 ('bold_file', 'inputnode.source_file'),
                 ('coreg_boldref', 'inputnode.coreg_boldref'),
                 ('bold_mask', 'inputnode.bold_mask'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ]),
         ])  # fmt:skip
@@ -936,13 +936,13 @@ tasks and sessions), the following preprocessing was performed.
         if config.workflow.bold_coreg_level == 'session':
             select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
 
-            ds_orig2boldref_xfm = init_ds_registration_wf(
+            ds_orig2session_xfm = init_ds_registration_wf(
                 source_file=bold_file,
                 output_dir=config.execution.nibabies_dir,
                 source='orig',
-                dest='boldref',
+                dest='session',
                 desc='coreg',
-                name=f'ds_orig2boldref_xfm_{bold_id}',
+                name=f'ds_orig2session_xfm_{bold_id}',
             )
 
             ds_boldref2anat_wf = init_ds_registration_wf(
@@ -961,15 +961,15 @@ tasks and sessions), the following preprocessing was performed.
                     ('outputnode.bold_mask', 'bold_mask'),
                 ]),
 
-                (coreg_bolds_wf, select_coreg_xfm, [('outputnode.orig2boldref_xfms', 'inlist')]),
-                (select_coreg_xfm, ds_orig2boldref_xfm, [('out', 'inputnode.xform')]),
-                (session_bold_reg_wf, ds_orig2boldref_xfm, [
+                (coreg_bolds_wf, select_coreg_xfm, [('outputnode.orig2session_xfms', 'inlist')]),
+                (select_coreg_xfm, ds_orig2session_xfm, [('out', 'inputnode.xform')]),
+                (session_bold_reg_wf, ds_orig2session_xfm, [
                     ('outputnode.metadata', 'inputnode.metadata'),
                 ]),
-                (coreg_bolds_wf, ds_orig2boldref_xfm, [
+                (coreg_bolds_wf, ds_orig2session_xfm, [
                     ('outputnode.boldref_files', 'inputnode.source_files'),
                 ]),
-                (ds_orig2boldref_xfm, boldref_buffer, [('outputnode.xform', 'orig2boldref_xfm')]),
+                (ds_orig2session_xfm, boldref_buffer, [('outputnode.xform', 'orig2session_xfm')]),
 
                 (session_bold_reg_wf, ds_boldref2anat_wf, [
                     ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
@@ -982,7 +982,7 @@ tasks and sessions), the following preprocessing was performed.
         else:
             from niworkflows.data import load as nwf_load
 
-            boldref_buffer.inputs.orig2boldref_xfm = nwf_load('itkIdentityTransform.txt')
+            boldref_buffer.inputs.orig2session_xfm = nwf_load('itkIdentityTransform.txt')
             workflow.connect([
                 (bold_fit_wf, boldref_buffer, [
                     ('outputnode.boldref2anat_xfm', 'boldref2anat_xfm'),
@@ -1034,7 +1034,7 @@ tasks and sessions), the following preprocessing was performed.
             ]),
             (boldref_buffer, bold_apply_wf, [
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
                 ('coreg_boldref', 'inputnode.coreg_boldref'),
                 ('bold_mask', 'inputnode.bold_mask'),
             ]),

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -729,17 +729,33 @@ tasks and sessions), the following preprocessing was performed.
         # only allow if homogeneous
         LOGGER.info('Coregistering all BOLD runs to a common space')
 
-        merge_fit_boldrefs = pe.Node(
-            niu.Merge(len(bold_runs)),
-            name='merge_fit_boldrefs',
-        )
+        # Check for precomputed session boldref and mask
+        session_boldref = None
+        session_mask = None
+        if config.execution.derivatives:
+            from nibabies.utils.derivatives import collect_functional_derivatives
 
-        coreg_bolds_wf = init_coreg_session_bolds_wf(
-            num_bold_runs=len(bold_runs),
-            omp_nthreads=omp_nthreads,
-        )
+            _session_ents = {'subject': subject_id}
+            if session_id:
+                _session_ents['session'] = session_id
+            _session_cache: dict = {}
+            for deriv_dir in config.execution.derivatives.values():
+                _session_cache.update(
+                    collect_functional_derivatives(
+                        derivatives_dir=deriv_dir,
+                        entities=_session_ents,
+                        fieldmap_id=None,
+                    )
+                )
+            session_boldref = _session_cache.get('session_boldref')
+            session_mask = _session_cache.get('session_bold_mask')
+            if bool(session_boldref) != bool(session_mask):
+                LOGGER.warning(
+                    'Found only one of session boldref/mask in derivatives — recomputing both.'
+                )
+                session_boldref = session_mask = None
 
-        # session BOLD reference to anatomical registration
+        # session BOLD reference to anatomical registration (always needed)
         session_bold_reg_wf = init_bold_reg_wf(
             bold2anat_dof=config.workflow.bold2anat_dof,
             bold2anat_init=config.workflow.bold2anat_init,
@@ -752,7 +768,6 @@ tasks and sessions), the following preprocessing was performed.
         )
 
         workflow.connect([
-            (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
             (anat_fit_wf, session_bold_reg_wf, [
                 ('outputnode.anat_preproc', 'inputnode.anat_preproc'),
                 ('outputnode.anat_mask', 'inputnode.anat_mask'),
@@ -762,42 +777,57 @@ tasks and sessions), the following preprocessing was performed.
                 ('outputnode.subject_id', 'inputnode.subject_id'),
                 ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
             ]),
-            (coreg_bolds_wf, session_bold_reg_wf, [
-                ('outputnode.boldref', 'inputnode.ref_bold_brain'),
-            ]),
-    ])  # fmt:skip
+        ])  # fmt:skip
 
         _session_dismiss = ('task', 'run', 'echo', 'part', 'dir')
 
-        ds_session_boldref = pe.Node(
-            DerivativesDataSink(
-                source_file=bold_runs[0][0],
-                base_directory=config.execution.nibabies_dir,
-                desc='coreg',
-                suffix='boldref',
-                compress=True,
-                dismiss_entities=_session_dismiss,
-            ),
-            name='ds_session_boldref',
-            run_without_submitting=True,
-        )
-        ds_session_bold_mask = pe.Node(
-            DerivativesDataSink(
-                source_file=bold_runs[0][0],
-                base_directory=config.execution.nibabies_dir,
-                space='session',
-                desc='brain',
-                suffix='mask',
-                compress=True,
-                dismiss_entities=_session_dismiss,
-            ),
-            name='ds_session_bold_mask',
-            run_without_submitting=True,
-        )
-        workflow.connect([
-            (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
-            (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
-        ])  # fmt:skip
+        if session_boldref:
+            LOGGER.info(f'Reusing session boldref: {session_boldref}')
+            LOGGER.info(f'Reusing session bold mask: {session_mask}')
+            session_bold_reg_wf.inputs.inputnode.ref_bold_brain = session_boldref
+        else:
+            merge_fit_boldrefs = pe.Node(
+                niu.Merge(len(bold_runs)),
+                name='merge_fit_boldrefs',
+            )
+            coreg_bolds_wf = init_coreg_session_bolds_wf(
+                num_bold_runs=len(bold_runs),
+                omp_nthreads=omp_nthreads,
+            )
+
+            ds_session_boldref = pe.Node(
+                DerivativesDataSink(
+                    source_file=bold_runs[0][0],
+                    base_directory=config.execution.nibabies_dir,
+                    desc='coreg',
+                    suffix='boldref',
+                    compress=True,
+                    dismiss_entities=_session_dismiss,
+                ),
+                name='ds_session_boldref',
+                run_without_submitting=True,
+            )
+            ds_session_bold_mask = pe.Node(
+                DerivativesDataSink(
+                    source_file=bold_runs[0][0],
+                    base_directory=config.execution.nibabies_dir,
+                    space='session',
+                    desc='brain',
+                    suffix='mask',
+                    compress=True,
+                    dismiss_entities=_session_dismiss,
+                ),
+                name='ds_session_bold_mask',
+                run_without_submitting=True,
+            )
+            workflow.connect([
+                (merge_fit_boldrefs, coreg_bolds_wf, [('out', 'inputnode.boldref_files')]),
+                (coreg_bolds_wf, session_bold_reg_wf, [
+                    ('outputnode.boldref', 'inputnode.ref_bold_brain'),
+                ]),
+                (coreg_bolds_wf, ds_session_boldref, [('outputnode.boldref', 'in_file')]),
+                (coreg_bolds_wf, ds_session_bold_mask, [('outputnode.bold_mask', 'in_file')]),
+            ])  # fmt:skip
 
     for i, bold_series in enumerate(bold_runs):
         bold_file = bold_series[0]
@@ -812,6 +842,11 @@ tasks and sessions), the following preprocessing was performed.
             config.loggers.workflow.warning(
                 f'Too short BOLD series (<= 5 timepoints). Skipping processing of <{bold_file}>.'
             )
+            if config.execution.bold_coreg_level == 'session':
+                # TODO: Move this check prior to create session workflow to avoid hard crashes
+                raise RuntimeError(
+                    'Cannot create session-level BOLD reference with invalid BOLD series.'
+                )
             continue
 
         functional_cache = {}
@@ -970,16 +1005,9 @@ tasks and sessions), the following preprocessing was performed.
             ])  # fmt:skip
 
         if config.workflow.bold_coreg_level == 'session':
-            select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
+            from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 
-            ds_orig2session_xfm = init_ds_registration_wf(
-                source_file=bold_file,
-                output_dir=config.execution.nibabies_dir,
-                source='orig',
-                dest='session',
-                desc='coreg',
-                name=f'ds_orig2session_xfm_{bold_id}',
-            )
+            orig2session = functional_cache.get('orig2session')
 
             ds_boldref2anat_wf = init_ds_registration_wf(
                 source_file=bold_file,
@@ -991,27 +1019,10 @@ tasks and sessions), the following preprocessing was performed.
             )
 
             workflow.connect([
-                (bold_fit_wf, merge_fit_boldrefs, [('outputnode.coreg_boldref', f'in{i+1}')]),
-                (coreg_bolds_wf, boldref_buffer, [
-                    ('outputnode.boldref', 'coreg_boldref'),
-                    ('outputnode.boldref', 'session_boldref'),
-                    ('outputnode.bold_mask', 'bold_mask'),
-                ]),
                 (bold_fit_wf, boldref_buffer, [
                     ('outputnode.coreg_boldref', 'orig_boldref'),
                     ('outputnode.bold_mask', 'orig_bold_mask'),
                 ]),
-
-                (coreg_bolds_wf, select_coreg_xfm, [('outputnode.orig2session_xfms', 'inlist')]),
-                (select_coreg_xfm, ds_orig2session_xfm, [('out', 'inputnode.xform')]),
-                (session_bold_reg_wf, ds_orig2session_xfm, [
-                    ('outputnode.metadata', 'inputnode.metadata'),
-                ]),
-                (coreg_bolds_wf, ds_orig2session_xfm, [
-                    ('outputnode.boldref_files', 'inputnode.source_files'),
-                ]),
-                (ds_orig2session_xfm, boldref_buffer, [('outputnode.xform', 'orig2session_xfm')]),
-
                 (session_bold_reg_wf, ds_boldref2anat_wf, [
                     ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
                 ]),
@@ -1021,9 +1032,23 @@ tasks and sessions), the following preprocessing was performed.
                 (session_bold_reg_wf, func_fit_summary, [('outputnode.fallback', 'fallback')]),
             ])  # fmt:skip
 
-            # Compose run→session→anat for confounds (run-space bold needs run→anat)
-            from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+            if session_boldref:
+                boldref_buffer.inputs.coreg_boldref = session_boldref
+                boldref_buffer.inputs.session_boldref = session_boldref
+                boldref_buffer.inputs.bold_mask = session_mask
+            else:
+                workflow.connect([
+                    (bold_fit_wf, merge_fit_boldrefs, [
+                        ('outputnode.coreg_boldref', f'in{i+1}'),
+                    ]),
+                    (coreg_bolds_wf, boldref_buffer, [
+                        ('outputnode.boldref', 'coreg_boldref'),
+                        ('outputnode.boldref', 'session_boldref'),
+                        ('outputnode.bold_mask', 'bold_mask'),
+                    ]),
+                ])  # fmt:skip
 
+            # Compose run→session→anat for confounds
             merge_orig2anat_xfms = pe.Node(
                 niu.Merge(2),
                 name=f'merge_orig2anat_xfms_{bold_id}',
@@ -1034,11 +1059,43 @@ tasks and sessions), the following preprocessing was performed.
                 name=f'concat_orig2anat_{bold_id}',
             )
             workflow.connect([
-                (ds_orig2session_xfm, merge_orig2anat_xfms, [('outputnode.xform', 'in1')]),
-                (ds_boldref2anat_wf, merge_orig2anat_xfms, [('outputnode.xform', 'in2')]),
                 (merge_orig2anat_xfms, concat_orig2anat, [('out', 'in_xfms')]),
                 (concat_orig2anat, boldref_buffer, [('out_xfm', 'orig2anat_xfm')]),
+                (ds_boldref2anat_wf, merge_orig2anat_xfms, [('outputnode.xform', 'in2')]),
             ])  # fmt:skip
+
+            if orig2session:
+                LOGGER.info(f'Reusing orig2session transform: {orig2session}')
+                boldref_buffer.inputs.orig2session_xfm = orig2session
+                merge_orig2anat_xfms.inputs.in1 = orig2session
+            else:
+                select_coreg_xfm = pe.Node(niu.Select(index=i), name=f'select_coreg_xfm_{bold_id}')
+                ds_orig2session_xfm = init_ds_registration_wf(
+                    source_file=bold_file,
+                    output_dir=config.execution.nibabies_dir,
+                    source='orig',
+                    dest='session',
+                    desc='coreg',
+                    name=f'ds_orig2session_xfm_{bold_id}',
+                )
+                workflow.connect([
+                    (coreg_bolds_wf, select_coreg_xfm, [
+                        ('outputnode.orig2session_xfms', 'inlist'),
+                    ]),
+                    (select_coreg_xfm, ds_orig2session_xfm, [('out', 'inputnode.xform')]),
+                    (session_bold_reg_wf, ds_orig2session_xfm, [
+                        ('outputnode.metadata', 'inputnode.metadata'),
+                    ]),
+                    (coreg_bolds_wf, ds_orig2session_xfm, [
+                        ('outputnode.boldref_files', 'inputnode.source_files'),
+                    ]),
+                    (ds_orig2session_xfm, boldref_buffer, [
+                        ('outputnode.xform', 'orig2session_xfm'),
+                    ]),
+                    (ds_orig2session_xfm, merge_orig2anat_xfms, [
+                        ('outputnode.xform', 'in1'),
+                    ]),
+                ])  # fmt:skip
         else:
             from niworkflows.data import load as nwf_load
 

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import nipype.interfaces.utility as niu
 import nipype.pipeline.engine as pe
 from niworkflows.interfaces.nibabel import GenerateSamplingReference
-from niworkflows.interfaces.utility import KeySelect
 
 from nibabies.interfaces.resampling import (
     DistortionParameters,
@@ -64,19 +63,20 @@ def init_bold_volumetric_resample_wf(
     motion_xfm
         List of affine transforms aligning each volume to ``bold_ref_file``.
         If undefined, no motion correction is performed.
-    boldref2fmap_xfm
+    orig2fmap_xfm
         Affine transform from ``bold_ref_file`` to the fieldmap reference image.
     fmap_ref
         Fieldmap reference image defining the valid field of view for the fieldmap.
     fmap_coeff
         B-Spline coefficients for the fieldmap.
-    fmap_id
-        Fieldmap identifier, to select correct fieldmap in case there are multiple.
     boldref2anat_xfm
         Affine transform from ``bold_ref_file`` to the anatomical reference image.
     anat2std_xfm
         Affine transform from the anatomical reference image to standard space.
         Leave undefined to resample to anatomical reference space.
+    orig2boldref_xfm
+        Transform mapping run-level BOLD reference with session space. If only run
+        level processing, will be an identity transform.
 
     Outputs
     -------
@@ -99,10 +99,11 @@ def init_bold_volumetric_resample_wf(
                 # HMC
                 'motion_xfm',
                 # SDC
-                'boldref2fmap_xfm',
+                'orig2fmap_xfm',
                 'fmap_ref',
                 'fmap_coeff',
-                'fmap_id',
+                # boldref
+                'orig2boldref_xfm',
                 # Anatomical
                 'boldref2anat_xfm',
                 # Template
@@ -121,7 +122,7 @@ def init_bold_volumetric_resample_wf(
 
     gen_ref = pe.Node(GenerateSamplingReference(), name='gen_ref', mem_gb=0.3)
 
-    boldref2target = pe.Node(niu.Merge(2), name='boldref2target', run_without_submitting=True)
+    boldref2target = pe.Node(niu.Merge(3), name='boldref2target', run_without_submitting=True)
     bold2target = pe.Node(niu.Merge(2), name='bold2target', run_without_submitting=True)
     resample = pe.Node(
         ResampleSeries(jacobian=jacobian, num_threads=omp_nthreads),
@@ -138,8 +139,9 @@ def init_bold_volumetric_resample_wf(
             (('resolution', _is_native), 'keep_native'),
         ]),
         (inputnode, boldref2target, [
-            ('boldref2anat_xfm', 'in1'),
-            ('anat2std_xfm', 'in2'),
+            ('orig2boldref_xfm', 'in1'),
+            ('boldref2anat_xfm', 'in2'),
+            ('anat2std_xfm', 'in3'),
         ]),
         (inputnode, bold2target, [('motion_xfm', 'in1')]),
         (inputnode, resample, [('bold_file', 'in_file')]),
@@ -153,11 +155,6 @@ def init_bold_volumetric_resample_wf(
     if not fieldmap_id:
         return workflow
 
-    fmap_select = pe.Node(
-        KeySelect(fields=['fmap_ref', 'fmap_coeff'], key=fieldmap_id),
-        name='fmap_select',
-        run_without_submitting=True,
-    )
     distortion_params = pe.Node(
         DistortionParameters(metadata=metadata),
         name='distortion_params',
@@ -173,17 +170,12 @@ def init_bold_volumetric_resample_wf(
     fmap_recon = pe.Node(ReconstructFieldmap(), name='fmap_recon', mem_gb=1)
 
     workflow.connect([
-        (inputnode, fmap_select, [
-            ('fmap_ref', 'fmap_ref'),
-            ('fmap_coeff', 'fmap_coeff'),
-            ('fmap_id', 'keys'),
-        ]),
         (inputnode, distortion_params, [('bold_file', 'in_file')]),
-        (inputnode, fmap2target, [('boldref2fmap_xfm', 'in1')]),
+        (inputnode, fmap2target, [('orig2fmap_xfm', 'in1')]),
         (gen_ref, fmap_recon, [('out_file', 'target_ref_file')]),
         (boldref2target, fmap2target, [('out', 'in2')]),
         (boldref2target, inverses, [('out', 'inlist')]),
-        (fmap_select, fmap_recon, [
+        (inputnode, fmap_recon, [
             ('fmap_coeff', 'in_coeffs'),
             ('fmap_ref', 'fmap_ref_file'),
         ]),

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -74,7 +74,7 @@ def init_bold_volumetric_resample_wf(
     anat2std_xfm
         Affine transform from the anatomical reference image to standard space.
         Leave undefined to resample to anatomical reference space.
-    orig2session_xfm
+    run2boldref_xfm
         Transform mapping run-level BOLD reference to boldref template space.
         Identity when ``--bold-coreg-level run``.
 
@@ -103,7 +103,7 @@ def init_bold_volumetric_resample_wf(
                 'fmap_ref',
                 'fmap_coeff',
                 # boldref
-                'orig2session_xfm',
+                'run2boldref_xfm',
                 # Anatomical
                 'boldref2anat_xfm',
                 # Template
@@ -139,7 +139,7 @@ def init_bold_volumetric_resample_wf(
             (('resolution', _is_native), 'keep_native'),
         ]),
         (inputnode, boldref2target, [
-            ('orig2session_xfm', 'in1'),
+            ('run2boldref_xfm', 'in1'),
             ('boldref2anat_xfm', 'in2'),
             ('anat2std_xfm', 'in3'),
         ]),

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -75,7 +75,7 @@ def init_bold_volumetric_resample_wf(
         Affine transform from the anatomical reference image to standard space.
         Leave undefined to resample to anatomical reference space.
     orig2session_xfm
-        Transform mapping run-level BOLD reference to session boldref space.
+        Transform mapping run-level BOLD reference to boldref template space.
         Identity when ``--bold-coreg-level run``.
 
     Outputs

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -74,9 +74,9 @@ def init_bold_volumetric_resample_wf(
     anat2std_xfm
         Affine transform from the anatomical reference image to standard space.
         Leave undefined to resample to anatomical reference space.
-    orig2boldref_xfm
-        Transform mapping run-level BOLD reference with session space. If only run
-        level processing, will be an identity transform.
+    orig2session_xfm
+        Transform mapping run-level BOLD reference to session boldref space.
+        Identity when ``--bold-coreg-level run``.
 
     Outputs
     -------
@@ -103,7 +103,7 @@ def init_bold_volumetric_resample_wf(
                 'fmap_ref',
                 'fmap_coeff',
                 # boldref
-                'orig2boldref_xfm',
+                'orig2session_xfm',
                 # Anatomical
                 'boldref2anat_xfm',
                 # Template
@@ -139,7 +139,7 @@ def init_bold_volumetric_resample_wf(
             (('resolution', _is_native), 'keep_native'),
         ]),
         (inputnode, boldref2target, [
-            ('orig2boldref_xfm', 'in1'),
+            ('orig2session_xfm', 'in1'),
             ('boldref2anat_xfm', 'in2'),
             ('anat2std_xfm', 'in3'),
         ]),

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -63,7 +63,7 @@ def init_bold_volumetric_resample_wf(
     motion_xfm
         List of affine transforms aligning each volume to ``bold_ref_file``.
         If undefined, no motion correction is performed.
-    orig2fmap_xfm
+    run2fmap_xfm
         Affine transform from ``bold_ref_file`` to the fieldmap reference image.
     fmap_ref
         Fieldmap reference image defining the valid field of view for the fieldmap.
@@ -99,7 +99,7 @@ def init_bold_volumetric_resample_wf(
                 # HMC
                 'motion_xfm',
                 # SDC
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 'fmap_ref',
                 'fmap_coeff',
                 # boldref
@@ -171,7 +171,7 @@ def init_bold_volumetric_resample_wf(
 
     workflow.connect([
         (inputnode, distortion_params, [('bold_file', 'in_file')]),
-        (inputnode, fmap2target, [('orig2fmap_xfm', 'in1')]),
+        (inputnode, fmap2target, [('run2fmap_xfm', 'in1')]),
         (gen_ref, fmap_recon, [('out_file', 'target_ref_file')]),
         (boldref2target, fmap2target, [('out', 'in2')]),
         (boldref2target, inverses, [('out', 'inlist')]),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -186,7 +186,7 @@ def init_bold_apply_wf(
                 'bold_mask',
                 'run_boldref',
                 'orig_bold_mask',
-                'orig2anat_xfm',
+                'run2anat_xfm',
                 'motion_xfm',
                 'orig2fmap_xfm',
                 'dummy_scans',
@@ -702,7 +702,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             ('orig_bold_mask', 'inputnode.bold_mask'),
             ('run_boldref', 'inputnode.hmc_boldref'),
             ('motion_xfm', 'inputnode.motion_xfm'),
-            ('orig2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ('run2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ('dummy_scans', 'inputnode.skip_vols'),
         ]),
         (bold_native_wf, bold_confounds_wf, [
@@ -733,7 +733,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             (inputnode, carpetplot_wf, [
                 ('dummy_scans', 'inputnode.dummy_scans'),
                 ('orig_bold_mask', 'inputnode.bold_mask'),
-                ('orig2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('run2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ]),
             (bold_native_wf, carpetplot_wf, [
                 ('outputnode.bold_native', 'inputnode.bold'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -44,10 +44,10 @@ from nibabies.utils.misc import estimate_bold_mem_usage
 # BOLD workflows
 from nibabies.workflows.bold.apply import init_bold_volumetric_resample_wf
 from nibabies.workflows.bold.confounds import init_bold_confs_wf, init_carpetplot_wf
-from nibabies.workflows.bold.fit import init_bold_native_wf, init_bold_session_wf
+from nibabies.workflows.bold.fit import init_bold_boldref_wf, init_bold_native_wf
 from nibabies.workflows.bold.outputs import (
+    init_ds_bold_boldref_wf,
     init_ds_bold_native_wf,
-    init_ds_bold_session_wf,
     init_ds_volumes_wf,
     prepare_timing_parameters,
 )
@@ -258,15 +258,15 @@ def init_bold_apply_wf(
         ]),
     ])  # fmt:skip
 
-    boldref_out = bool(nonstd_spaces.intersection(('func', 'run', 'bold', 'boldref', 'sbref')))
-    boldref_out &= config.workflow.level == 'full'
+    run_out = bool(nonstd_spaces.intersection(('func', 'run', 'bold', 'sbref')))
+    run_out &= config.workflow.level == 'full'
     echos_out = multiecho and config.execution.me_output_echos
 
-    if boldref_out or echos_out:
+    if run_out or echos_out:
         ds_bold_native_wf = init_ds_bold_native_wf(
             bids_root=str(config.execution.bids_dir),
             output_dir=output_dir,
-            bold_output=boldref_out,
+            bold_output=run_out,
             echo_output=echos_out,
             multiecho=multiecho,
             all_metadata=all_metadata,
@@ -287,40 +287,40 @@ def init_bold_apply_wf(
             ]),
         ])  # fmt:skip
 
-    session_out = 'boldref' in nonstd_spaces and config.workflow.bold_coreg_level == 'session'
-    if session_out:
-        bold_session_wf = init_bold_session_wf(
+    boldref_out = bool(nonstd_spaces.intersection(('boldref', 'session', 'subject')))
+    if boldref_out:
+        bold_boldref_wf = init_bold_boldref_wf(
             bold_series=bold_series,
             fieldmap_id=fieldmap_id,
             omp_nthreads=omp_nthreads,
         )
         workflow.connect([
-            (inputnode, bold_session_wf, [
+            (inputnode, bold_boldref_wf, [
                 ('boldref_template', 'inputnode.boldref_template'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
             ]),
-            (bold_native_wf, bold_session_wf, [
+            (bold_native_wf, bold_boldref_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_minimal'),
                 ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
             ]),
         ])  # fmt:skip
 
-        ds_bold_session_wf = init_ds_bold_session_wf(
+        ds_bold_boldref_wf = init_ds_bold_boldref_wf(
             bids_root=str(config.execution.bids_dir),
             output_dir=output_dir,
             multiecho=multiecho,
             all_metadata=all_metadata,
         )
-        ds_bold_session_wf.inputs.inputnode.source_files = bold_series
+        ds_bold_boldref_wf.inputs.inputnode.source_files = bold_series
 
         workflow.connect([
-            (bold_session_wf, ds_bold_session_wf, [
-                ('outputnode.bold_session', 'inputnode.bold'),
+            (bold_boldref_wf, ds_bold_boldref_wf, [
+                ('outputnode.bold_boldref', 'inputnode.bold'),
             ]),
-            (inputnode, ds_bold_session_wf, [
+            (inputnode, ds_bold_boldref_wf, [
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -47,6 +47,7 @@ from nibabies.workflows.bold.confounds import init_bold_confs_wf, init_carpetplo
 from nibabies.workflows.bold.fit import init_bold_native_wf, init_bold_session_wf
 from nibabies.workflows.bold.outputs import (
     init_ds_bold_native_wf,
+    init_ds_bold_session_wf,
     init_ds_volumes_wf,
     prepare_timing_parameters,
 )
@@ -304,6 +305,26 @@ def init_bold_apply_wf(
             (bold_native_wf, bold_session_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_minimal'),
                 ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
+            ]),
+        ])  # fmt:skip
+
+        ds_bold_session_wf = init_ds_bold_session_wf(
+            bids_root=str(config.execution.bids_dir),
+            output_dir=output_dir,
+            multiecho=multiecho,
+            all_metadata=all_metadata,
+        )
+        ds_bold_session_wf.inputs.inputnode.source_files = bold_series
+
+        workflow.connect([
+            (bold_session_wf, ds_bold_session_wf, [
+                ('outputnode.bold_session', 'inputnode.bold'),
+            ]),
+            (inputnode, ds_bold_session_wf, [
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('motion_xfm', 'inputnode.motion_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ]),
         ])  # fmt:skip
 

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -186,7 +186,7 @@ def init_bold_apply_wf(
                 'orig2fmap_xfm',
                 'dummy_scans',
                 'boldref2anat_xfm',
-                'orig2boldref_xfm',  # identity if not coregistering across BOLDs
+                'orig2session_xfm',  # identity if not coregistering across BOLDs
                 # Anatomical coregistration
                 'anat_preproc',
                 'anat_mask',
@@ -250,7 +250,7 @@ def init_bold_apply_wf(
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ('dummy_scans', 'inputnode.dummy_scans'),
-            ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+            ('orig2session_xfm', 'inputnode.orig2session_xfm'),
         ]),
     ])  # fmt:skip
 
@@ -279,7 +279,7 @@ def init_bold_apply_wf(
                 ('bold_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
             ]),
         ])  # fmt:skip
 
@@ -347,7 +347,7 @@ def init_bold_apply_wf(
             ('coreg_boldref', 'inputnode.bold_ref_file'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-            ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+            ('orig2session_xfm', 'inputnode.orig2session_xfm'),
         ]),
         (bold_native_wf, bold_anat_wf, [
             ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -374,7 +374,7 @@ def init_bold_apply_wf(
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
             ]),
             (bold_native_wf, ds_bold_anat_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_anat_wf, ds_bold_anat_wf, [
@@ -415,7 +415,7 @@ def init_bold_apply_wf(
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
             ]),
             (bold_native_wf, bold_std_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -432,7 +432,7 @@ def init_bold_apply_wf(
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
             ]),
             (bold_native_wf, ds_bold_std_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_std_wf, ds_bold_std_wf, [
@@ -475,7 +475,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         workflow.connect([
             (inputnode, merge_surface_sources, [
                 ('motion_xfm', 'in2'),
-                ('orig2boldref_xfm', 'in3'),
+                ('orig2session_xfm', 'in3'),
                 ('boldref2anat_xfm', 'in4'),
                 ('fsnative2anat_xfm', 'in5'),
             ]),
@@ -576,7 +576,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
             ]),
             (bold_native_wf, bold_MNIInfant_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -184,14 +184,14 @@ def init_bold_apply_wf(
                 'coreg_boldref',
                 'boldref_template',
                 'bold_mask',
-                'orig_boldref',
+                'run_boldref',
                 'orig_bold_mask',
                 'orig2anat_xfm',
                 'motion_xfm',
                 'orig2fmap_xfm',
                 'dummy_scans',
                 'boldref2anat_xfm',
-                'orig2session_xfm',  # identity if not coregistering across BOLDs
+                'run2boldref_xfm',  # identity if not coregistering across BOLDs
                 # Anatomical coregistration
                 'anat_preproc',
                 'anat_mask',
@@ -250,7 +250,7 @@ def init_bold_apply_wf(
         (inputnode, bold_native_wf, [
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('orig_boldref', 'inputnode.orig_boldref'),
+            ('run_boldref', 'inputnode.run_boldref'),
             ('bold_mask', 'inputnode.bold_mask'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
@@ -283,11 +283,11 @@ def init_bold_apply_wf(
                 ('orig_bold_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
         ])  # fmt:skip
 
-    session_out = 'session' in nonstd_spaces and config.workflow.bold_coreg_level == 'session'
+    session_out = 'boldref' in nonstd_spaces and config.workflow.bold_coreg_level == 'session'
     if session_out:
         bold_session_wf = init_bold_session_wf(
             bold_series=bold_series,
@@ -297,7 +297,7 @@ def init_bold_apply_wf(
         workflow.connect([
             (inputnode, bold_session_wf, [
                 ('boldref_template', 'inputnode.boldref_template'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
@@ -322,7 +322,7 @@ def init_bold_apply_wf(
             ]),
             (inputnode, ds_bold_session_wf, [
                 ('motion_xfm', 'inputnode.motion_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ]),
         ])  # fmt:skip
@@ -391,7 +391,7 @@ def init_bold_apply_wf(
             ('coreg_boldref', 'inputnode.bold_ref_file'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-            ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+            ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
         ]),
         (bold_native_wf, bold_anat_wf, [
             ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -418,7 +418,7 @@ def init_bold_apply_wf(
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_anat_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_anat_wf, ds_bold_anat_wf, [
@@ -459,7 +459,7 @@ def init_bold_apply_wf(
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, bold_std_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -476,7 +476,7 @@ def init_bold_apply_wf(
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_std_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_std_wf, ds_bold_std_wf, [
@@ -519,7 +519,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         workflow.connect([
             (inputnode, merge_surface_sources, [
                 ('motion_xfm', 'in2'),
-                ('orig2session_xfm', 'in3'),
+                ('run2boldref_xfm', 'in3'),
                 ('boldref2anat_xfm', 'in4'),
                 ('fsnative2anat_xfm', 'in5'),
             ]),
@@ -620,7 +620,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, bold_MNIInfant_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -700,7 +700,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             ('anat_tpms', 'inputnode.anat_tpms'),
             ('anat_mask', 'inputnode.anat_mask'),
             ('orig_bold_mask', 'inputnode.bold_mask'),
-            ('orig_boldref', 'inputnode.hmc_boldref'),
+            ('run_boldref', 'inputnode.hmc_boldref'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('orig2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ('dummy_scans', 'inputnode.skip_vols'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -166,8 +166,6 @@ def init_bold_apply_wf(
     * :func:`~nibabies.workflows.bold.confounds.init_carpetplot_wf`
 
     """
-    if fieldmap_id is None:
-        fieldmap_id = None
 
     bold_file = bold_series[0]
     output_dir = str(config.execution.nibabies_dir)

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -182,7 +182,7 @@ def init_bold_apply_wf(
             fields=[
                 # Fit outputs
                 'coreg_boldref',
-                'session_boldref',
+                'boldref_template',
                 'bold_mask',
                 'orig_boldref',
                 'orig_bold_mask',
@@ -296,7 +296,7 @@ def init_bold_apply_wf(
         )
         workflow.connect([
             (inputnode, bold_session_wf, [
-                ('session_boldref', 'inputnode.session_boldref'),
+                ('boldref_template', 'inputnode.boldref_template'),
                 ('orig2session_xfm', 'inputnode.orig2session_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -44,7 +44,7 @@ from nibabies.utils.misc import estimate_bold_mem_usage
 # BOLD workflows
 from nibabies.workflows.bold.apply import init_bold_volumetric_resample_wf
 from nibabies.workflows.bold.confounds import init_bold_confs_wf, init_carpetplot_wf
-from nibabies.workflows.bold.fit import init_bold_native_wf
+from nibabies.workflows.bold.fit import init_bold_native_wf, init_bold_session_wf
 from nibabies.workflows.bold.outputs import (
     init_ds_bold_native_wf,
     init_ds_volumes_wf,
@@ -181,6 +181,7 @@ def init_bold_apply_wf(
             fields=[
                 # Fit outputs
                 'coreg_boldref',
+                'session_boldref',
                 'bold_mask',
                 'motion_xfm',
                 'orig2fmap_xfm',
@@ -245,12 +246,11 @@ def init_bold_apply_wf(
         (inputnode, bold_native_wf, [
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('coreg_boldref', 'inputnode.boldref'),
+            ('coreg_boldref', 'inputnode.run_boldref'),
             ('bold_mask', 'inputnode.bold_mask'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
             ('dummy_scans', 'inputnode.dummy_scans'),
-            ('orig2session_xfm', 'inputnode.orig2session_xfm'),
         ]),
     ])  # fmt:skip
 
@@ -280,6 +280,27 @@ def init_bold_apply_wf(
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+            ]),
+        ])  # fmt:skip
+
+    session_out = 'session' in nonstd_spaces and config.workflow.bold_coreg_level == 'session'
+    if session_out:
+        bold_session_wf = init_bold_session_wf(
+            bold_series=bold_series,
+            fieldmap_id=fieldmap_id,
+            omp_nthreads=omp_nthreads,
+        )
+        workflow.connect([
+            (inputnode, bold_session_wf, [
+                ('session_boldref', 'inputnode.session_boldref'),
+                ('orig2session_xfm', 'inputnode.orig2session_xfm'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('fmap_ref', 'inputnode.fmap_ref'),
+                ('fmap_coeff', 'inputnode.fmap_coeff'),
+            ]),
+            (bold_native_wf, bold_session_wf, [
+                ('outputnode.bold_minimal', 'inputnode.bold_minimal'),
+                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
             ]),
         ])  # fmt:skip
 

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -280,7 +280,7 @@ def init_bold_apply_wf(
                 ('outputnode.t2star_map', 'inputnode.t2star'),
             ]),
             (inputnode, ds_bold_native_wf, [
-                ('bold_mask', 'inputnode.bold_mask'),
+                ('orig_bold_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
                 ('orig2session_xfm', 'inputnode.orig2session_xfm'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -321,7 +321,6 @@ def init_bold_apply_wf(
                 ('outputnode.bold_session', 'inputnode.bold'),
             ]),
             (inputnode, ds_bold_session_wf, [
-                ('bold_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('orig2session_xfm', 'inputnode.orig2session_xfm'),
                 ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -188,7 +188,7 @@ def init_bold_apply_wf(
                 'orig_bold_mask',
                 'run2anat_xfm',
                 'motion_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 'dummy_scans',
                 'boldref2anat_xfm',
                 'run2boldref_xfm',  # identity if not coregistering across BOLDs
@@ -253,7 +253,7 @@ def init_bold_apply_wf(
             ('run_boldref', 'inputnode.run_boldref'),
             ('bold_mask', 'inputnode.bold_mask'),
             ('motion_xfm', 'inputnode.motion_xfm'),
-            ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+            ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ('dummy_scans', 'inputnode.dummy_scans'),
         ]),
     ])  # fmt:skip
@@ -282,7 +282,7 @@ def init_bold_apply_wf(
             (inputnode, ds_bold_native_wf, [
                 ('orig_bold_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
         ])  # fmt:skip
@@ -298,7 +298,7 @@ def init_bold_apply_wf(
             (inputnode, bold_boldref_wf, [
                 ('boldref_template', 'inputnode.boldref_template'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
             ]),
@@ -323,7 +323,7 @@ def init_bold_apply_wf(
             (inputnode, ds_bold_boldref_wf, [
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ]),
         ])  # fmt:skip
 
@@ -389,7 +389,7 @@ def init_bold_apply_wf(
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
             ('coreg_boldref', 'inputnode.bold_ref_file'),
-            ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+            ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
         ]),
@@ -417,7 +417,7 @@ def init_bold_apply_wf(
                 ('coreg_boldref', 'inputnode.bold_ref'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_anat_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
@@ -457,7 +457,7 @@ def init_bold_apply_wf(
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
@@ -475,7 +475,7 @@ def init_bold_apply_wf(
                 ('coreg_boldref', 'inputnode.bold_ref'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_std_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
@@ -618,7 +618,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
                 ('coreg_boldref', 'inputnode.bold_ref_file'),
-                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
                 ('run2boldref_xfm', 'inputnode.run2boldref_xfm'),
             ]),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -25,7 +25,6 @@ Orchestrating the BOLD-preprocessing workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: init_bold_wf
-.. autofunction:: init_bold_fit_wf
 .. autofunction:: init_bold_native_wf
 
 """
@@ -34,6 +33,7 @@ import typing as ty
 
 from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.utils.connections import listify
 
 from nibabies import config
@@ -44,7 +44,7 @@ from nibabies.utils.misc import estimate_bold_mem_usage
 # BOLD workflows
 from nibabies.workflows.bold.apply import init_bold_volumetric_resample_wf
 from nibabies.workflows.bold.confounds import init_bold_confs_wf, init_carpetplot_wf
-from nibabies.workflows.bold.fit import init_bold_fit_wf, init_bold_native_wf
+from nibabies.workflows.bold.fit import init_bold_native_wf
 from nibabies.workflows.bold.outputs import (
     init_ds_bold_native_wf,
     init_ds_volumes_wf,
@@ -59,16 +59,20 @@ if ty.TYPE_CHECKING:
 DEFAULT_DISMISS_ENTITIES = config.DEFAULT_DISMISS_ENTITIES
 
 
-def init_bold_wf(
+def init_bold_apply_wf(
     *,
     reference_anat: Anatomical,
     bold_series: list[str],
-    precomputed: dict | None = None,
     fieldmap_id: str | None = None,
     spaces: 'SpatialReferences',
+    name: str = 'bold_apply_wf',
 ) -> pe.Workflow:
     """
-    This workflow controls the functional preprocessing stages of *fMRIPrep*.
+    This workflow controls the functional preprocessing stages of *NiBabies*
+    that occur *after* BOLD fitting (HMC, SDC, Coregistration).
+
+    It expects that `init_bold_fit_wf` and `init_bold_coreg_runs_wf` (if applicable)
+    have already been run.
 
     Workflow Graph
         .. workflow::
@@ -89,8 +93,6 @@ def init_bold_wf(
     ----------
     bold_series
         List of paths to NIfTI files.
-    precomputed
-        Dictionary containing precomputed derivatives to reuse, if possible.
     fieldmap_id
         ID of the fieldmap to use to correct this BOLD series. If :obj:`None`,
         no correction will be applied.
@@ -122,18 +124,10 @@ def init_bold_wf(
         Registration spheres from fsnative to fsLR space, collated left, then right
     anat_ribbon
         Binary cortical ribbon mask in anat space
-    fmap_id
-        Unique identifiers to select fieldmap files
-    fmap
-        List of estimated fieldmaps (collated with fmap_id)
     fmap_ref
-        List of fieldmap reference files (collated with fmap_id)
+        Fieldmap reference file
     fmap_coeff
-        List of lists of spline coefficient files (collated with fmap_id)
-    fmap_mask
-        List of fieldmap masks (collated with fmap_id)
-    sdc_method
-        List of fieldmap correction method names (collated with fmap_id)
+        List of spline coefficient files
     anat2std_xfm
         Transform from anatomical space to standard space
     std_t1w
@@ -159,59 +153,40 @@ def init_bold_wf(
     See Also
     --------
 
-    * :func:`~fmriprep.workflows.bold.fit.init_bold_fit_wf`
-    * :func:`~fmriprep.workflows.bold.fit.init_bold_native_wf`
-    * :func:`~fmriprep.workflows.bold.apply.init_bold_volumetric_resample_wf`
-    * :func:`~fmriprep.workflows.bold.outputs.init_ds_bold_native_wf`
-    * :func:`~fmriprep.workflows.bold.outputs.init_ds_volumes_wf`
-    * :func:`~fmriprep.workflows.bold.t2s.init_t2s_reporting_wf`
-    * :func:`~fmriprep.workflows.bold.resampling.init_bold_surf_wf`
-    * :func:`~fmriprep.workflows.bold.resampling.init_bold_fsLR_resampling_wf`
-    * :func:`~fmriprep.workflows.bold.resampling.init_bold_grayords_wf`
-    * :func:`~fmriprep.workflows.bold.confounds.init_bold_confs_wf`
-    * :func:`~fmriprep.workflows.bold.confounds.init_carpetplot_wf`
+    * :func:`~nibabies.workflows.bold.fit.init_bold_native_wf`
+    * :func:`~nibabies.workflows.bold.apply.init_bold_volumetric_resample_wf`
+    * :func:`~nibabies.workflows.bold.outputs.init_ds_bold_native_wf`
+    * :func:`~nibabies.workflows.bold.outputs.init_ds_volumes_wf`
+    * :func:`~nibabies.workflows.bold.t2s.init_t2s_reporting_wf`
+    * :func:`~nibabies.workflows.bold.resampling.init_bold_surf_wf`
+    * :func:`~nibabies.workflows.bold.resampling.init_bold_fsLR_resampling_wf`
+    * :func:`~nibabies.workflows.bold.resampling.init_bold_grayords_wf`
+    * :func:`~nibabies.workflows.bold.confounds.init_bold_confs_wf`
+    * :func:`~nibabies.workflows.bold.confounds.init_carpetplot_wf`
 
     """
-    from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+    if fieldmap_id is None:
+        fieldmap_id = None
 
-    if precomputed is None:
-        precomputed = {}
     bold_file = bold_series[0]
-
     output_dir = str(config.execution.nibabies_dir)
     omp_nthreads = config.nipype.omp_nthreads
     all_metadata = [config.execution.layout.get_metadata(file) for file in bold_series]
+    _, mem_gb = estimate_bold_mem_usage(bold_file)
 
-    nvols, mem_gb = estimate_bold_mem_usage(bold_file)
-    if nvols <= 5 - config.execution.sloppy:
-        config.loggers.workflow.warning(
-            f'Too short BOLD series (<= 5 timepoints). Skipping processing of <{bold_file}>.'
-        )
-        return
-
-    config.loggers.workflow.debug(
-        'Creating bold processing workflow for <%s> (%.2f GB / %d TRs). '
-        'Memory resampled/largemem=%.2f/%.2f GB.',
-        bold_file,
-        mem_gb['filesize'],
-        nvols,
-        mem_gb['resampled'],
-        mem_gb['largemem'],
-    )
-
-    workflow = Workflow(name=_get_wf_name(bold_file, 'bold'))
-    workflow.__postdesc__ = """\
-All resamplings can be performed with *a single interpolation
-step* by composing all the pertinent transformations (i.e. head-motion
-transform matrices, susceptibility distortion correction when available,
-and co-registrations to anatomical and output spaces).
-Gridded (volumetric) resamplings were performed using `nitransforms`,
-configured with cubic B-spline interpolation.
-"""
+    workflow = Workflow(name=name)
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
+                # Fit outputs
+                'coreg_boldref',
+                'bold_mask',
+                'motion_xfm',
+                'orig2fmap_xfm',
+                'dummy_scans',
+                'boldref2anat_xfm',
+                'orig2boldref_xfm',  # identity if not coregistering across BOLDs
                 # Anatomical coregistration
                 'anat_preproc',
                 'anat_mask',
@@ -230,23 +205,15 @@ configured with cubic B-spline interpolation.
                 'cortex_mask',
                 'anat_ribbon',
                 # Fieldmap registration
-                'fmap',
                 'fmap_ref',
                 'fmap_coeff',
-                'fmap_mask',
-                'fmap_id',
-                'sdc_method',
                 # Volumetric templates
                 'anat2std_xfm',
                 'std_t1w',
                 'std_mask',
                 'std_space',
                 'std_resolution',
-                # MNI152NLin6Asym warp, for CIFTI use
-                # 'anat2mni6_xfm',
-                # 'mni6_mask',
-                # MNI152NLin2009cAsym inverse warp, for carpetplotting (NOT USED)
-                # 'mni2009c2anat_xfm',
+                'std_cohort',
                 # MNIInfant <cohort> warp, for CIFTI use
                 'anat2mniinfant_xfm',
                 'mniinfant2anat_xfm',
@@ -255,38 +222,6 @@ configured with cubic B-spline interpolation.
         ),
         name='inputnode',
     )
-
-    #
-    # Minimal workflow
-    #
-
-    bold_fit_wf = init_bold_fit_wf(
-        bold_series=bold_series,
-        reference_anat=reference_anat,
-        precomputed=precomputed,
-        fieldmap_id=fieldmap_id,
-        omp_nthreads=omp_nthreads,
-    )
-
-    workflow.connect([
-        (inputnode, bold_fit_wf, [
-            ('anat_preproc', 'inputnode.anat_preproc'),
-            ('anat_mask', 'inputnode.anat_mask'),
-            ('anat_dseg', 'inputnode.anat_dseg'),
-            ('subjects_dir', 'inputnode.subjects_dir'),
-            ('subject_id', 'inputnode.subject_id'),
-            ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
-            ('fmap', 'inputnode.fmap'),
-            ('fmap_ref', 'inputnode.fmap_ref'),
-            ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('fmap_mask', 'inputnode.fmap_mask'),
-            ('fmap_id', 'inputnode.fmap_id'),
-            ('sdc_method', 'inputnode.sdc_method'),
-        ]),
-    ])  # fmt:skip
-
-    if config.workflow.level == 'minimal':
-        return workflow
 
     # Now that we're resampling and combining, multiecho matters
     multiecho = len(bold_series) > 2
@@ -310,14 +245,12 @@ configured with cubic B-spline interpolation.
         (inputnode, bold_native_wf, [
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('fmap_id', 'inputnode.fmap_id'),
-        ]),
-        (bold_fit_wf, bold_native_wf, [
-            ('outputnode.coreg_boldref', 'inputnode.boldref'),
-            ('outputnode.bold_mask', 'inputnode.bold_mask'),
-            ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-            ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-            ('outputnode.dummy_scans', 'inputnode.dummy_scans'),
+            ('coreg_boldref', 'inputnode.boldref'),
+            ('bold_mask', 'inputnode.bold_mask'),
+            ('motion_xfm', 'inputnode.motion_xfm'),
+            ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+            ('dummy_scans', 'inputnode.dummy_scans'),
+            ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
         ]),
     ])  # fmt:skip
 
@@ -337,15 +270,16 @@ configured with cubic B-spline interpolation.
         ds_bold_native_wf.inputs.inputnode.source_files = bold_series
 
         workflow.connect([
-            (bold_fit_wf, ds_bold_native_wf, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask'),
-                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-            ]),
             (bold_native_wf, ds_bold_native_wf, [
                 ('outputnode.bold_native', 'inputnode.bold'),
                 ('outputnode.bold_echos', 'inputnode.bold_echos'),
                 ('outputnode.t2star_map', 'inputnode.t2star'),
+            ]),
+            (inputnode, ds_bold_native_wf, [
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('motion_xfm', 'inputnode.motion_xfm'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
             ]),
         ])  # fmt:skip
 
@@ -373,10 +307,10 @@ configured with cubic B-spline interpolation.
         )
 
         workflow.connect([
-            (inputnode, t2s_reporting_wf, [('anat_dseg', 'inputnode.label_file')]),
-            (bold_fit_wf, t2s_reporting_wf, [
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('outputnode.coreg_boldref', 'inputnode.boldref'),
+            (inputnode, t2s_reporting_wf, [
+                ('anat_dseg', 'inputnode.label_file'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('coreg_boldref', 'inputnode.boldref'),
             ]),
             (bold_native_wf, t2s_reporting_wf, [
                 ('outputnode.t2star_map', 'inputnode.t2star_file'),
@@ -410,12 +344,10 @@ configured with cubic B-spline interpolation.
             ('anat_mask', 'inputnode.target_mask'),
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('fmap_id', 'inputnode.fmap_id'),
-        ]),
-        (bold_fit_wf, bold_anat_wf, [
-            ('outputnode.coreg_boldref', 'inputnode.bold_ref_file'),
-            ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-            ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ('coreg_boldref', 'inputnode.bold_ref_file'),
+            ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+            ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
         ]),
         (bold_native_wf, bold_anat_wf, [
             ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -436,12 +368,13 @@ configured with cubic B-spline interpolation.
         ds_bold_anat_wf.inputs.inputnode.space = reference_anat
 
         workflow.connect([
-            (bold_fit_wf, ds_bold_anat_wf, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask'),
-                ('outputnode.coreg_boldref', 'inputnode.bold_ref'),
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
+            (inputnode, ds_bold_anat_wf, [
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('coreg_boldref', 'inputnode.bold_ref'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('motion_xfm', 'inputnode.motion_xfm'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_anat_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_anat_wf, ds_bold_anat_wf, [
@@ -479,12 +412,10 @@ configured with cubic B-spline interpolation.
                 ('std_resolution', 'inputnode.resolution'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
-                ('fmap_id', 'inputnode.fmap_id'),
-            ]),
-            (bold_fit_wf, bold_std_wf, [
-                ('outputnode.coreg_boldref', 'inputnode.bold_ref_file'),
-                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('coreg_boldref', 'inputnode.bold_ref_file'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
             ]),
             (bold_native_wf, bold_std_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -495,13 +426,13 @@ configured with cubic B-spline interpolation.
                 ('std_t1w', 'inputnode.template'),
                 ('std_space', 'inputnode.space'),
                 ('std_resolution', 'inputnode.resolution'),
-            ]),
-            (bold_fit_wf, ds_bold_std_wf, [
-                ('outputnode.bold_mask', 'inputnode.bold_mask'),
-                ('outputnode.coreg_boldref', 'inputnode.bold_ref'),
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-                ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
+                ('std_cohort', 'inputnode.cohort'),
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('coreg_boldref', 'inputnode.bold_ref'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('motion_xfm', 'inputnode.motion_xfm'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
             ]),
             (bold_native_wf, ds_bold_std_wf, [('outputnode.t2star_map', 'inputnode.t2star')]),
             (bold_std_wf, ds_bold_std_wf, [
@@ -536,18 +467,17 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
         # sources are bold_file, motion_xfm, boldref2anat_xfm, fsnative2anat_xfm
         merge_surface_sources = pe.Node(
-            niu.Merge(4),
+            niu.Merge(5),
             name='merge_surface_sources',
             run_without_submitting=True,
         )
         merge_surface_sources.inputs.in1 = bold_file
         workflow.connect([
-            (bold_fit_wf, merge_surface_sources, [
-                ('outputnode.motion_xfm', 'in2'),
-                ('outputnode.boldref2anat_xfm', 'in3'),
-            ]),
             (inputnode, merge_surface_sources, [
-                ('fsnative2anat_xfm', 'in4'),
+                ('motion_xfm', 'in2'),
+                ('orig2boldref_xfm', 'in3'),
+                ('boldref2anat_xfm', 'in4'),
+                ('fsnative2anat_xfm', 'in5'),
             ]),
             (merge_surface_sources, bold_surf_wf, [
                 ('out', 'inputnode.sources'),
@@ -643,12 +573,10 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ('anat2mniinfant_xfm', 'inputnode.anat2std_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
-                ('fmap_id', 'inputnode.fmap_id'),
-            ]),
-            (bold_fit_wf, bold_MNIInfant_wf, [
-                ('outputnode.coreg_boldref', 'inputnode.bold_ref_file'),
-                ('outputnode.boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('coreg_boldref', 'inputnode.bold_ref_file'),
+                ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('orig2boldref_xfm', 'inputnode.orig2boldref_xfm'),
             ]),
             (bold_native_wf, bold_MNIInfant_wf, [
                 ('outputnode.bold_minimal', 'inputnode.bold_file'),
@@ -727,13 +655,11 @@ excluding voxels whose time-series have a locally high coefficient of variation.
         (inputnode, bold_confounds_wf, [
             ('anat_tpms', 'inputnode.anat_tpms'),
             ('anat_mask', 'inputnode.anat_mask'),
-        ]),
-        (bold_fit_wf, bold_confounds_wf, [
-            ('outputnode.bold_mask', 'inputnode.bold_mask'),
-            ('outputnode.hmc_boldref', 'inputnode.hmc_boldref'),
-            ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
-            ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-            ('outputnode.dummy_scans', 'inputnode.skip_vols'),
+            ('bold_mask', 'inputnode.bold_mask'),
+            ('coreg_boldref', 'inputnode.hmc_boldref'),
+            ('motion_xfm', 'inputnode.motion_xfm'),
+            ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ('dummy_scans', 'inputnode.skip_vols'),
         ]),
         (bold_native_wf, bold_confounds_wf, [
             ('outputnode.bold_native', 'inputnode.bold'),
@@ -760,10 +686,10 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             (bold_grayords_wf, carpetplot_wf, [
                 ('outputnode.dtseries', 'inputnode.cifti_bold'),
             ]),
-            (bold_fit_wf, carpetplot_wf, [
-                ('outputnode.dummy_scans', 'inputnode.dummy_scans'),
-                ('outputnode.bold_mask', 'inputnode.bold_mask'),
-                ('outputnode.boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            (inputnode, carpetplot_wf, [
+                ('dummy_scans', 'inputnode.dummy_scans'),
+                ('bold_mask', 'inputnode.bold_mask'),
+                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ]),
             (bold_native_wf, carpetplot_wf, [
                 ('outputnode.bold_native', 'inputnode.bold'),
@@ -782,26 +708,6 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             workflow.get_node(node).inputs.source_file = bold_file
 
     return workflow
-
-
-def _get_wf_name(bold_fname, prefix):
-    """
-    Derive the workflow name for supplied BOLD file.
-
-    >>> _get_wf_name("/completely/made/up/path/sub-01_task-nback_bold.nii.gz", "bold")
-    'bold_task_nback_wf'
-    >>> _get_wf_name(
-    ...     "/completely/made/up/path/sub-01_task-nback_run-01_echo-1_bold.nii.gz",
-    ...     "preproc",
-    ... )
-    'preproc_task_nback_run_01_echo_1_wf'
-
-    """
-    from nipype.utils.filemanip import split_filename
-
-    fname = split_filename(bold_fname)[1]
-    fname_nosub = '_'.join(fname.split('_')[1:-1])
-    return f'{prefix}_{fname_nosub.replace("-", "_")}_wf'
 
 
 def extract_entities(file_list):

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -183,6 +183,9 @@ def init_bold_apply_wf(
                 'coreg_boldref',
                 'session_boldref',
                 'bold_mask',
+                'orig_boldref',
+                'orig_bold_mask',
+                'orig2anat_xfm',
                 'motion_xfm',
                 'orig2fmap_xfm',
                 'dummy_scans',
@@ -246,7 +249,7 @@ def init_bold_apply_wf(
         (inputnode, bold_native_wf, [
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('coreg_boldref', 'inputnode.run_boldref'),
+            ('orig_boldref', 'inputnode.orig_boldref'),
             ('bold_mask', 'inputnode.bold_mask'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('orig2fmap_xfm', 'inputnode.orig2fmap_xfm'),
@@ -676,10 +679,10 @@ excluding voxels whose time-series have a locally high coefficient of variation.
         (inputnode, bold_confounds_wf, [
             ('anat_tpms', 'inputnode.anat_tpms'),
             ('anat_mask', 'inputnode.anat_mask'),
-            ('bold_mask', 'inputnode.bold_mask'),
-            ('coreg_boldref', 'inputnode.hmc_boldref'),
+            ('orig_bold_mask', 'inputnode.bold_mask'),
+            ('orig_boldref', 'inputnode.hmc_boldref'),
             ('motion_xfm', 'inputnode.motion_xfm'),
-            ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+            ('orig2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ('dummy_scans', 'inputnode.skip_vols'),
         ]),
         (bold_native_wf, bold_confounds_wf, [
@@ -709,8 +712,8 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             ]),
             (inputnode, carpetplot_wf, [
                 ('dummy_scans', 'inputnode.dummy_scans'),
-                ('bold_mask', 'inputnode.bold_mask'),
-                ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
+                ('orig_bold_mask', 'inputnode.bold_mask'),
+                ('orig2anat_xfm', 'inputnode.boldref2anat_xfm'),
             ]),
             (bold_native_wf, carpetplot_wf, [
                 ('outputnode.bold_native', 'inputnode.bold'),

--- a/nibabies/workflows/bold/coreg.py
+++ b/nibabies/workflows/bold/coreg.py
@@ -1,0 +1,445 @@
+"""BOLD anatomical coregistration workflow."""
+
+from __future__ import annotations
+
+import logging
+
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+
+from nibabies._types import Anatomical
+from nibabies.interfaces import DerivativesDataSink
+
+logger = logging.getLogger('nipype.workflow')
+
+
+def _expand(value, n):
+    return [value] * n
+
+
+def init_bold_anat_coreg_wf(
+    *,
+    bold_files: list[str],
+    coreg_level: str,
+    bold2anat_dof: int,
+    bold2anat_init: str,
+    use_bbr: bool | None,
+    freesurfer: bool,
+    omp_nthreads: int,
+    mem_gb: float,
+    sloppy: bool,
+    output_dir: str,
+    reference_anat: Anatomical,
+    precomputed: dict | None = None,
+    name: str = 'bold_anat_coreg_wf',
+) -> Workflow:
+    """
+    Build a workflow to coregister BOLD run references to anatomical space.
+
+    Behavior is controlled by ``coreg_level``, either ``"session"`` or ``"run"``.
+
+    Session-level coregistration first builds a common BOLD template from all run
+    references and registers that template to the anatomical, composing per-run
+    ``run->template->anat`` transforms.
+
+    Run-level coregistration registers each run reference to the anatomical independently.
+
+    Either way, per-run lists are returned so downstream workflows can be wired uniformly.
+
+    Writes coregistration derivatives (template boldref, template mask,
+    ``run2boldref_xfms`` and ``boldref2anat_xfm``). When a derivative is supplied
+    via ``precomputed``, the corresponding computation and datasink are skipped and
+    the precomputed path is reused.
+
+    Parameters
+    ----------
+    precomputed
+        Dictionary of precomputed coregistration derivatives to reuse. Recognized
+        keys:
+
+        ``boldref2anat_xfm``
+            Run-level: list of per-run boldref→anat transforms (``None`` where
+            absent). Session-level: a single template→anat transform. Where a
+            transform is present, registration is skipped for that boldref.
+        ``run2boldref_xfms``
+            Session-level: list of per-run run→template transforms. When all runs
+            are present, the template workflow is skipped and these transforms are
+            applied to the run references to reconstruct the template space.
+
+    Inputs
+    ------
+    run_boldrefs
+        List of per-run SDC-corrected BOLD references.
+    run_masks
+        List of per-run brain masks.
+    anat_preproc
+        Bias-corrected anatomical image.
+    anat_mask
+        Skull-strip mask.
+    anat_dseg
+        Tissue segmentation image.
+    subjects_dir
+        FreeSurfer SUBJECTS_DIR (may be undefined).
+    subject_id
+        FreeSurfer subject ID (may be undefined).
+    fsnative2anat_xfm
+        Transform from FreeSurfer native to anatomical space (may be undefined).
+
+    Outputs
+    -------
+    coreg_boldrefs
+        Per-run boldref in coregistration target space: session template repeated
+        n times (session-level) or each run's own boldref (run-level).
+    bold_masks
+        Per-run masks in coregistration target space.
+    run2boldref_xfms
+        Per-run transform from run space to the coregistration template.
+        Identity transforms for run-level coregistration.
+    boldref2anat_xfms
+        Per-run transform from coregistration target to anatomical space.
+    run2anat_xfms
+        Per-run composed run→anat transform.
+    boldref_template
+        Scalar session-level template boldref; unset for run-level.
+    fallbacks
+        Per-run fallback flags from registration.
+    """
+    from nibabies.workflows.base import _get_wf_name
+    from nibabies.workflows.bold.outputs import init_ds_registration_wf
+    from nibabies.workflows.bold.registration import init_bold_reg_wf
+
+    precomputed = precomputed or {}
+    n_runs = len(bold_files)
+    bold_ids = [_get_wf_name(bold_file, None).removesuffix('_wf') for bold_file in bold_files]
+
+    reg_kwargs = {
+        'bold2anat_dof': bold2anat_dof,
+        'bold2anat_init': bold2anat_init,
+        'use_bbr': use_bbr,
+        'freesurfer': freesurfer,
+        'omp_nthreads': omp_nthreads,
+        'mem_gb': mem_gb,
+        'sloppy': sloppy,
+    }
+    anat_reg_inputs = [
+        ('anat_preproc', 'inputnode.anat_preproc'),
+        ('anat_mask', 'inputnode.anat_mask'),
+        ('anat_dseg', 'inputnode.anat_dseg'),
+        ('subjects_dir', 'inputnode.subjects_dir'),
+        ('subject_id', 'inputnode.subject_id'),
+        ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
+    ]
+
+    def _ds_boldref2anat_wf(bold_file, bold_id):
+        return init_ds_registration_wf(
+            source_file=bold_file,
+            output_dir=output_dir,
+            source='boldref',
+            dest=reference_anat,
+            desc='coreg',
+            name=f'ds_boldref2anat_{bold_id}',
+        )
+
+    workflow = Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                'run_boldrefs',
+                'run_masks',
+                'anat_preproc',
+                'anat_mask',
+                'anat_dseg',
+                'subjects_dir',
+                'subject_id',
+                'fsnative2anat_xfm',
+            ]
+        ),
+        name='inputnode',
+    )
+
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                'coreg_boldrefs',
+                'bold_masks',
+                'run2boldref_xfms',
+                'boldref2anat_xfms',
+                'run2anat_xfms',
+                'boldref_template',
+                'fallbacks',
+            ]
+        ),
+        name='outputnode',
+    )
+
+    # Template-level: all runs coregistered together first, then that template is coregistered to anat.
+    if coreg_level != 'run':
+        from niworkflows.interfaces.nitransforms import ConcatenateXFMs
+
+        from nibabies.workflows.bold.template import init_bold_template_wf
+
+        run2boldref_xfms = precomputed.get('run2boldref_xfms') or [None] * n_runs
+        boldref2anat_xfm = precomputed.get('boldref2anat_xfm')
+        if isinstance(boldref2anat_xfm, (list, tuple)):
+            boldref2anat_xfm = boldref2anat_xfm[0] if boldref2anat_xfm else None
+
+        # Only skip if ALL run -> boldref transforms are present.
+        skip_template = all(run2boldref_xfms)
+        # If template needs to be recomputed, redo coregistration to anat
+        skip_reg = bool(boldref2anat_xfm) and skip_template
+        if boldref2anat_xfm and not skip_template:
+            logger.warning(
+                'A precomputed boldref2anat transform was found without a complete set '
+                'of run2boldref transforms; ignoring it and recomputing registration '
+                'against the rebuilt template.'
+            )
+
+        template_buffer = pe.Node(
+            niu.IdentityInterface(fields=['boldref', 'mask', 'run2boldref_xfms']),
+            name='template_buffer',
+        )
+        if skip_template:
+            logger.info(
+                'Found precomputed run2boldref transforms; skipping boldref template generation.'
+            )
+            from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
+
+            template_buffer.inputs.run2boldref_xfms = list(run2boldref_xfms)
+
+            select_boldref0 = pe.Node(
+                niu.Select(index=0), name='select_boldref0', run_without_submitting=True
+            )
+            select_mask0 = pe.Node(
+                niu.Select(index=0), name='select_mask0', run_without_submitting=True
+            )
+            warp_template_boldref = pe.Node(
+                ApplyTransforms(
+                    transforms=[run2boldref_xfms[0]], interpolation='LanczosWindowedSinc'
+                ),
+                name='warp_template_boldref',
+            )
+            warp_template_mask = pe.Node(
+                ApplyTransforms(transforms=[run2boldref_xfms[0]], interpolation='MultiLabel'),
+                name='warp_template_mask',
+            )
+            workflow.connect([
+                (inputnode, select_boldref0, [('run_boldrefs', 'inlist')]),
+                (inputnode, select_mask0, [('run_masks', 'inlist')]),
+                (select_boldref0, warp_template_boldref, [
+                    ('out', 'input_image'),
+                    ('out', 'reference_image'),
+                ]),
+                (select_mask0, warp_template_mask, [
+                    ('out', 'input_image'),
+                    ('out', 'reference_image'),
+                ]),
+                (warp_template_boldref, template_buffer, [('output_image', 'boldref')]),
+                (warp_template_mask, template_buffer, [('output_image', 'mask')]),
+            ])  # fmt:skip
+        else:
+            if any(run2boldref_xfms):
+                logger.warning(
+                    'Only some run2boldref transforms were found - ignoring and recomputing the template.'
+                )
+            bold_template_wf = init_bold_template_wf(
+                num_bold_runs=n_runs,
+                omp_nthreads=omp_nthreads,
+            )
+            workflow.connect([
+                (inputnode, bold_template_wf, [('run_boldrefs', 'inputnode.boldref_files')]),
+                (bold_template_wf, template_buffer, [
+                    ('outputnode.boldref', 'boldref'),
+                    ('outputnode.bold_mask', 'mask'),
+                    ('outputnode.run2boldref_xfms', 'run2boldref_xfms'),
+                ]),
+            ])  # fmt:skip
+
+            # Datasink the session template boldref + mask (one copy per run naming)
+            ds_boldref_template = pe.MapNode(
+                DerivativesDataSink(
+                    base_directory=output_dir,
+                    space='boldref',
+                    desc='coreg',
+                    suffix='boldref',
+                    compress=True,
+                ),
+                iterfield=['source_file'],
+                name='ds_boldref_template',
+                run_without_submitting=True,
+            )
+            ds_boldref_template.inputs.source_file = bold_files
+            ds_boldref_mask = pe.MapNode(
+                DerivativesDataSink(
+                    base_directory=output_dir,
+                    space='boldref',
+                    desc='brain',
+                    suffix='mask',
+                    compress=True,
+                ),
+                iterfield=['source_file'],
+                name='ds_boldref_mask',
+                run_without_submitting=True,
+            )
+            ds_boldref_mask.inputs.source_file = bold_files
+            workflow.connect([
+                (template_buffer, ds_boldref_template, [('boldref', 'in_file')]),
+                (template_buffer, ds_boldref_mask, [('mask', 'in_file')]),
+            ])  # fmt:skip
+
+        reg_buffer = pe.Node(
+            niu.IdentityInterface(fields=['boldref2anat', 'fallback']),
+            name='reg_buffer',
+        )
+        if skip_reg:
+            logger.info('Found precomputed boldref2anat transform; skipping coregistration.')
+            reg_buffer.inputs.boldref2anat = boldref2anat_xfm
+            reg_buffer.inputs.fallback = False
+        else:
+            boldref_reg_wf = init_bold_reg_wf(name='boldref_reg_wf', **reg_kwargs)
+            workflow.connect([
+                (template_buffer, boldref_reg_wf, [('boldref', 'inputnode.ref_bold_brain')]),
+                (inputnode, boldref_reg_wf, anat_reg_inputs),
+                (boldref_reg_wf, reg_buffer, [
+                    ('outputnode.itk_bold_to_anat', 'boldref2anat'),
+                    ('outputnode.fallback', 'fallback'),
+                ]),
+            ])  # fmt:skip
+
+        merge_run2boldref = pe.Node(
+            niu.Merge(n_runs), name='merge_run2boldref', run_without_submitting=True
+        )
+        merge_boldref2anat = pe.Node(
+            niu.Merge(n_runs), name='merge_boldref2anat', run_without_submitting=True
+        )
+        merge_run2anat_xfms = pe.Node(
+            niu.Merge(n_runs), name='merge_run2anat_xfms', run_without_submitting=True
+        )
+
+        for i, (bold_file, bold_id) in enumerate(zip(bold_files, bold_ids, strict=True)):
+            select_run2boldref = pe.Node(
+                niu.Select(index=i),
+                name=f'select_run2boldref_{bold_id}',
+                run_without_submitting=True,
+            )
+            workflow.connect(template_buffer, 'run2boldref_xfms', select_run2boldref, 'inlist')
+
+            merge_run2anat = pe.Node(
+                niu.Merge(2), name=f'merge_run2anat_{bold_id}', run_without_submitting=True
+            )
+            concat = pe.Node(ConcatenateXFMs(), name=f'concat_run2anat_{bold_id}')
+
+            if skip_template:
+                workflow.connect([
+                    (select_run2boldref, merge_run2boldref, [('out', f'in{i + 1}')]),
+                    (select_run2boldref, merge_run2anat, [('out', 'in1')]),
+                ])  # fmt:skip
+            else:
+                ds_run2boldref = init_ds_registration_wf(
+                    source_file=bold_file,
+                    output_dir=output_dir,
+                    source='run',
+                    dest='boldref',
+                    desc='coreg',
+                    name=f'ds_run2boldref_{bold_id}',
+                )
+                workflow.connect([
+                    (inputnode, ds_run2boldref, [('run_boldrefs', 'inputnode.source_files')]),
+                    (select_run2boldref, ds_run2boldref, [('out', 'inputnode.xform')]),
+                    (ds_run2boldref, merge_run2boldref, [('outputnode.xform', f'in{i + 1}')]),
+                    (ds_run2boldref, merge_run2anat, [('outputnode.xform', 'in1')]),
+                ])  # fmt:skip
+
+            if skip_reg:
+                setattr(merge_boldref2anat.inputs, f'in{i + 1}', boldref2anat_xfm)
+                merge_run2anat.inputs.in2 = boldref2anat_xfm
+            else:
+                ds_boldref2anat = _ds_boldref2anat_wf(bold_file, bold_id)
+                workflow.connect([
+                    (inputnode, ds_boldref2anat, [('run_boldrefs', 'inputnode.source_files')]),
+                    (reg_buffer, ds_boldref2anat, [('boldref2anat', 'inputnode.xform')]),
+                    (ds_boldref2anat, merge_boldref2anat, [('outputnode.xform', f'in{i + 1}')]),
+                    (ds_boldref2anat, merge_run2anat, [('outputnode.xform', 'in2')]),
+                ])  # fmt:skip
+
+            workflow.connect([
+                (merge_run2anat, concat, [('out', 'in_xfms')]),
+                (concat, merge_run2anat_xfms, [('out_xfm', f'in{i + 1}')]),
+            ])  # fmt:skip
+
+        # Broadcast the session template image/mask/fallback into per-run lists
+        expand_boldref = pe.Node(niu.Function(function=_expand), name='expand_boldref')
+        expand_mask = pe.Node(niu.Function(function=_expand), name='expand_mask')
+        expand_fallback = pe.Node(niu.Function(function=_expand), name='expand_fallback')
+        for node in (expand_boldref, expand_mask, expand_fallback):
+            node.inputs.n = n_runs
+            node.run_without_submitting = True
+
+        workflow.connect([
+            (template_buffer, expand_boldref, [('boldref', 'value')]),
+            (template_buffer, expand_mask, [('mask', 'value')]),
+            (reg_buffer, expand_fallback, [('fallback', 'value')]),
+            (template_buffer, outputnode, [('boldref', 'boldref_template')]),
+            (expand_boldref, outputnode, [('out', 'coreg_boldrefs')]),
+            (expand_mask, outputnode, [('out', 'bold_masks')]),
+            (expand_fallback, outputnode, [('out', 'fallbacks')]),
+            (merge_run2boldref, outputnode, [('out', 'run2boldref_xfms')]),
+            (merge_boldref2anat, outputnode, [('out', 'boldref2anat_xfms')]),
+            (merge_run2anat_xfms, outputnode, [('out', 'run2anat_xfms')]),
+        ])  # fmt:skip
+        return workflow
+
+    # Run-level: each run is coregistered to anat independently
+    from niworkflows.data import load as nwf_load
+
+    boldref2anat_xfm = precomputed.get('boldref2anat_xfm') or [None] * n_runs
+
+    identity_xfm = str(nwf_load('itkIdentityTransform.txt'))
+    outputnode.inputs.run2boldref_xfms = [identity_xfm] * n_runs
+
+    merge_boldref2anat = pe.Node(
+        niu.Merge(n_runs), name='merge_boldref2anat', run_without_submitting=True
+    )
+    merge_fallbacks = pe.Node(
+        niu.Merge(n_runs), name='merge_fallbacks', run_without_submitting=True
+    )
+
+    for i, (bold_file, bold_id) in enumerate(zip(bold_files, bold_ids, strict=True)):
+        if boldref2anat_xfm[i]:
+            setattr(merge_boldref2anat.inputs, f'in{i + 1}', boldref2anat_xfm[i])
+            setattr(merge_fallbacks.inputs, f'in{i + 1}', False)
+            continue
+
+        select_boldref = pe.Node(
+            niu.Select(index=i), name=f'select_boldref_{bold_id}', run_without_submitting=True
+        )
+        reg_wf = init_bold_reg_wf(name=f'boldref_reg_{bold_id}_wf', **reg_kwargs)
+        ds_boldref2anat = _ds_boldref2anat_wf(bold_file, bold_id)
+
+        workflow.connect([
+            (inputnode, select_boldref, [('run_boldrefs', 'inlist')]),
+            (select_boldref, reg_wf, [('out', 'inputnode.ref_bold_brain')]),
+            (inputnode, reg_wf, anat_reg_inputs),
+            (inputnode, ds_boldref2anat, [('run_boldrefs', 'inputnode.source_files')]),
+            (reg_wf, ds_boldref2anat, [
+                ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
+                ('outputnode.metadata', 'inputnode.metadata'),
+            ]),
+            (ds_boldref2anat, merge_boldref2anat, [('outputnode.xform', f'in{i + 1}')]),
+            (reg_wf, merge_fallbacks, [('outputnode.fallback', f'in{i + 1}')]),
+        ])  # fmt:skip
+
+    workflow.connect([
+        (inputnode, outputnode, [
+            ('run_boldrefs', 'coreg_boldrefs'),
+            ('run_masks', 'bold_masks'),
+        ]),
+        (merge_boldref2anat, outputnode, [
+            ('out', 'boldref2anat_xfms'),
+            ('out', 'run2anat_xfms'),
+        ]),
+        (merge_fallbacks, outputnode, [('out', 'fallbacks')]),
+    ])  # fmt:skip
+
+    return workflow

--- a/nibabies/workflows/bold/coreg.py
+++ b/nibabies/workflows/bold/coreg.py
@@ -406,6 +406,18 @@ def init_bold_anat_coreg_wf(
     )
 
     for i, (bold_file, bold_id) in enumerate(zip(bold_files, bold_ids, strict=True)):
+        # Save an identity transform for output space consistency
+        ds_run2boldref = init_ds_registration_wf(
+            source_file=bold_file,
+            output_dir=output_dir,
+            source='run',
+            dest='boldref',
+            desc='coreg',
+            name=f'ds_run2boldref_{bold_id}',
+        )
+        ds_run2boldref.inputs.inputnode.xform = identity_xfm
+        workflow.connect(inputnode, 'run_boldrefs', ds_run2boldref, 'inputnode.source_files')
+
         if boldref2anat_xfm[i]:
             setattr(merge_boldref2anat.inputs, f'in{i + 1}', boldref2anat_xfm[i])
             setattr(merge_fallbacks.inputs, f'in{i + 1}', False)

--- a/nibabies/workflows/bold/coreg.py
+++ b/nibabies/workflows/bold/coreg.py
@@ -8,8 +8,10 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 
+from nibabies import config
 from nibabies._types import Anatomical
 from nibabies.interfaces import DerivativesDataSink
+from nibabies.interfaces.bids import BIDSURI
 
 logger = logging.getLogger('nipype.workflow')
 
@@ -283,9 +285,21 @@ def init_bold_anat_coreg_wf(
                 run_without_submitting=True,
             )
             ds_boldref_mask.inputs.source_file = bold_files
+            template_sources = pe.Node(
+                BIDSURI(
+                    numinputs=1,
+                    dataset_links=config.execution.dataset_links,
+                    out_dir=str(output_dir),
+                ),
+                name='template_sources',
+                run_without_submitting=True,
+            )
             workflow.connect([
+                (inputnode, template_sources, [('run_boldrefs', 'in1')]),
                 (template_buffer, ds_boldref_template, [('boldref', 'in_file')]),
                 (template_buffer, ds_boldref_mask, [('mask', 'in_file')]),
+                (template_sources, ds_boldref_template, [('out', 'Sources')]),
+                (template_sources, ds_boldref_mask, [('out', 'Sources')]),
             ])  # fmt:skip
 
         reg_buffer = pe.Node(
@@ -406,6 +420,11 @@ def init_bold_anat_coreg_wf(
     )
 
     for i, (bold_file, bold_id) in enumerate(zip(bold_files, bold_ids, strict=True)):
+        select_boldref = pe.Node(
+            niu.Select(index=i), name=f'select_boldref_{bold_id}', run_without_submitting=True
+        )
+        workflow.connect(inputnode, 'run_boldrefs', select_boldref, 'inlist')
+
         # Save an identity transform for output space consistency
         ds_run2boldref = init_ds_registration_wf(
             source_file=bold_file,
@@ -416,24 +435,20 @@ def init_bold_anat_coreg_wf(
             name=f'ds_run2boldref_{bold_id}',
         )
         ds_run2boldref.inputs.inputnode.xform = identity_xfm
-        workflow.connect(inputnode, 'run_boldrefs', ds_run2boldref, 'inputnode.source_files')
+        workflow.connect(select_boldref, 'out', ds_run2boldref, 'inputnode.source_files')
 
         if boldref2anat_xfm[i]:
             setattr(merge_boldref2anat.inputs, f'in{i + 1}', boldref2anat_xfm[i])
             setattr(merge_fallbacks.inputs, f'in{i + 1}', False)
             continue
 
-        select_boldref = pe.Node(
-            niu.Select(index=i), name=f'select_boldref_{bold_id}', run_without_submitting=True
-        )
         reg_wf = init_bold_reg_wf(name=f'boldref_reg_{bold_id}_wf', **reg_kwargs)
         ds_boldref2anat = _ds_boldref2anat_wf(bold_file, bold_id)
 
         workflow.connect([
-            (inputnode, select_boldref, [('run_boldrefs', 'inlist')]),
             (select_boldref, reg_wf, [('out', 'inputnode.ref_bold_brain')]),
             (inputnode, reg_wf, anat_reg_inputs),
-            (inputnode, ds_boldref2anat, [('run_boldrefs', 'inputnode.source_files')]),
+            (select_boldref, ds_boldref2anat, [('out', 'inputnode.source_files')]),
             (reg_wf, ds_boldref2anat, [
                 ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
                 ('outputnode.metadata', 'inputnode.metadata'),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -915,7 +915,7 @@ def init_bold_session_wf(
 
     Takes the minimally-processed BOLD (``bold_minimal``, STC-only for
     single-echo, T2\*-combined for multi-echo) produced by
-    :py:func:`init_bold_native_wf` and resamples to the session boldref with
+    :py:func:`init_bold_native_wf` and resamples to the boldref template with
     head motion and susceptibility distortion correction applied. STC is not
     repeated here.
 
@@ -932,10 +932,10 @@ def init_bold_session_wf(
     ------
     bold_minimal
         STC-only BOLD series (output of :py:func:`init_bold_native_wf`).
-    session_boldref
-        Session-level BOLD reference image.
+    boldref_template
+        BOLD reference template image.
     orig2session_xfm
-        Affine transform from the run-level boldref to the session boldref.
+        Affine transform from the run-level boldref to the boldref template.
     motion_xfm
         Per-volume affine transforms (HMC).
     orig2fmap_xfm
@@ -948,7 +948,7 @@ def init_bold_session_wf(
     Outputs
     -------
     bold_session
-        BOLD series resampled into session boldref space with HMC and SDC applied.
+        BOLD series resampled into boldref template space with HMC and SDC applied.
 
     """
     bold_file = bold_series[0]
@@ -961,7 +961,7 @@ def init_bold_session_wf(
         niu.IdentityInterface(
             fields=[
                 'bold_minimal',
-                'session_boldref',
+                'boldref_template',
                 'orig2session_xfm',
                 'motion_xfm',
                 'orig2fmap_xfm',
@@ -998,7 +998,7 @@ def init_bold_session_wf(
         ]),
         (inputnode, boldref_bold, [
             ('bold_minimal', 'in_file'),
-            ('session_boldref', 'ref_file'),
+            ('boldref_template', 'ref_file'),
         ]),
         (merge_bold2session, boldref_bold, [('out', 'transforms')]),
         (boldref_bold, outputnode, [('out_file', 'bold_session')]),
@@ -1026,7 +1026,7 @@ def init_bold_session_wf(
                 ('orig2session_xfm', 'in2'),
             ]),
             (inputnode, boldref_fmap, [
-                ('session_boldref', 'target_ref_file'),
+                ('boldref_template', 'target_ref_file'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
             ]),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -54,7 +54,6 @@ from nibabies.workflows.bold.outputs import (
     init_ds_registration_wf,
 )
 from nibabies.workflows.bold.reference import init_raw_boldref_wf, init_validation_and_dummies_wf
-from nibabies.workflows.bold.registration import init_bold_reg_wf
 from nibabies.workflows.bold.stc import init_bold_stc_wf
 from nibabies.workflows.bold.t2s import init_bold_t2s_wf
 
@@ -99,7 +98,6 @@ def init_bold_fit_wf(
     precomputed: dict | None = None,
     fieldmap_id: str | None = None,
     jacobian: bool = False,
-    coreg_anat: bool = True,
     omp_nthreads: int = 1,
     name: str = 'bold_fit_wf',
 ) -> pe.Workflow:
@@ -173,9 +171,6 @@ def init_bold_fit_wf(
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
         as concatenated ITK affine transforms.
-    boldref2anat_xfm
-        Affine transform mapping from BOLD reference space to the anatomical
-        space.
     orig2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
@@ -190,7 +185,6 @@ def init_bold_fit_wf(
     * :py:func:`~niworkflows.func.utils.init_enhance_and_skullstrip_bold_wf`
     * :py:func:`~sdcflows.workflows.apply.registration.init_coeff2epi_wf`
     * :py:func:`~sdcflows.workflows.apply.correction.init_unwarp_wf`
-    * :py:func:`~nibabies.workflows.bold.registration.init_bold_reg_wf`
     * :py:func:`~nibabies.workflows.bold.outputs.init_ds_boldref_wf`
     * :py:func:`~nibabies.workflows.bold.outputs.init_ds_hmc_wf`
     * :py:func:`~nibabies.workflows.bold.outputs.init_ds_registration_wf`
@@ -244,7 +238,6 @@ def init_bold_fit_wf(
     transforms = precomputed.get('transforms', {})
     hmc_xforms = transforms.get('hmc')
     boldref2fmap_xform = transforms.get('boldref2fmap')
-    boldref2anat_xform = transforms.get('boldref2anat')
 
     workflow = Workflow(name=name)
 
@@ -277,11 +270,9 @@ def init_bold_fit_wf(
                 'coreg_boldref',
                 'bold_mask',
                 'motion_xfm',
-                'boldref2anat_xfm',  # Undefined if coreg_anat is False
                 'orig2fmap_xfm',
                 # summary (can be undefined)
                 'algo_dummy_scans',  # if hmc
-                'fallback',  # if run -> anat coregistration
                 # func fit reports wf
                 'validation_report',
                 'sdc_boldref',
@@ -583,51 +574,6 @@ def init_bold_fit_wf(
         workflow.connect([
             (skullstrip_precomp_ref_wf, regref_buffer, [('outputnode.mask_file', 'boldmask')])
         ])  # fmt:skip
-
-    if coreg_anat and not boldref2anat_xform:
-        config.loggers.workflow.info('Stage 5: Adding coregistration workflow')
-        # calculate BOLD registration to T1w
-        bold_reg_wf = init_bold_reg_wf(
-            bold2anat_dof=config.workflow.bold2anat_dof,
-            bold2anat_init=config.workflow.bold2anat_init,
-            use_bbr=config.workflow.use_bbr,
-            freesurfer=config.workflow.surface_recon_method is not None,
-            omp_nthreads=omp_nthreads,
-            mem_gb=mem_gb['resampled'],
-            sloppy=config.execution.sloppy,
-        )
-
-        ds_boldreg_wf = init_ds_registration_wf(
-            source_file=bold_file,
-            output_dir=config.execution.nibabies_dir,
-            source='boldref',
-            dest=reference_anat,
-            desc='coreg',
-            name='ds_boldreg_wf',
-        )
-
-        workflow.connect([
-            (inputnode, bold_reg_wf, [
-                ('anat_preproc', 'inputnode.anat_preproc'),
-                ('anat_mask', 'inputnode.anat_mask'),
-                ('anat_dseg', 'inputnode.anat_dseg'),
-                # Undefined if --fs-no-reconall, but this is safe
-                ('subjects_dir', 'inputnode.subjects_dir'),
-                ('subject_id', 'inputnode.subject_id'),
-                ('fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
-            ]),
-            (regref_buffer, bold_reg_wf, [('boldref', 'inputnode.ref_bold_brain')]),
-            # Incomplete sources
-            (regref_buffer, ds_boldreg_wf, [('boldref', 'inputnode.source_files')]),
-            (bold_reg_wf, ds_boldreg_wf, [
-                ('outputnode.itk_bold_to_anat', 'inputnode.xform'),
-                ('outputnode.metadata', 'inputnode.metadata'),
-            ]),
-            (ds_boldreg_wf, outputnode, [('outputnode.xform', 'boldref2anat_xfm')]),
-        ])  # fmt:skip
-    else:
-        config.loggers.workflow.info('Found coregistration transform - skipping Stage 5')
-        outputnode.inputs.boldref2anat_xfm = boldref2anat_xform
 
     return workflow
 

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -903,6 +903,140 @@ def init_bold_native_wf(
     return workflow
 
 
+def init_bold_session_wf(
+    *,
+    bold_series: list[str],
+    fieldmap_id: str | None = None,
+    omp_nthreads: int = 1,
+    name: str = 'bold_session_wf',
+) -> pe.Workflow:
+    r"""
+    Resample BOLD series to session-level boldref space.
+
+    Takes the minimally-processed BOLD (``bold_minimal``, STC-only for
+    single-echo, T2\*-combined for multi-echo) produced by
+    :py:func:`init_bold_native_wf` and resamples to the session boldref with
+    head motion and susceptibility distortion correction applied. STC is not
+    repeated here.
+
+    Parameters
+    ----------
+    bold_series
+        List of paths to NIfTI files (used to derive metadata).
+    fieldmap_id
+        Fieldmap identifier. If :obj:`None`, no SDC is applied.
+    omp_nthreads
+        Maximum number of threads per process.
+
+    Inputs
+    ------
+    bold_minimal
+        STC-only BOLD series (output of :py:func:`init_bold_native_wf`).
+    session_boldref
+        Session-level BOLD reference image.
+    orig2session_xfm
+        Affine transform from the run-level boldref to the session boldref.
+    motion_xfm
+        Per-volume affine transforms (HMC).
+    orig2fmap_xfm
+        Affine from boldref space to fieldmap space (SDC only).
+    fmap_ref
+        Fieldmap reference file (SDC only).
+    fmap_coeff
+        B-spline fieldmap coefficients (SDC only).
+
+    Outputs
+    -------
+    bold_session
+        BOLD series resampled into session boldref space with HMC and SDC applied.
+
+    """
+    bold_file = bold_series[0]
+    metadata = config.execution.layout.get_metadata(bold_file)
+    _, mem_gb = estimate_bold_mem_usage(bold_file)
+
+    workflow = pe.Workflow(name=name)
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                'bold_minimal',
+                'session_boldref',
+                'orig2session_xfm',
+                'motion_xfm',
+                'orig2fmap_xfm',
+                'fmap_ref',
+                'fmap_coeff',
+            ],
+        ),
+        name='inputnode',
+    )
+
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=['bold_session']),
+        name='outputnode',
+    )
+
+    merge_bold2session = pe.Node(
+        niu.Merge(2), name='merge_bold2session', run_without_submitting=True
+    )
+
+    boldref_bold = pe.Node(
+        ResampleSeries(
+            jacobian='fmap-jacobian' not in config.workflow.ignore,
+            num_threads=omp_nthreads,
+        ),
+        name='boldref_bold',
+        n_procs=omp_nthreads,
+        mem_gb=mem_gb['resampled'],
+    )
+
+    workflow.connect([
+        (inputnode, merge_bold2session, [
+            ('motion_xfm', 'in1'),
+            ('orig2session_xfm', 'in2'),
+        ]),
+        (inputnode, boldref_bold, [
+            ('bold_minimal', 'in_file'),
+            ('session_boldref', 'ref_file'),
+        ]),
+        (merge_bold2session, boldref_bold, [('out', 'transforms')]),
+        (boldref_bold, outputnode, [('out_file', 'bold_session')]),
+    ])  # fmt:skip
+
+    if fieldmap_id:
+        distortion_params = pe.Node(
+            DistortionParameters(metadata=metadata, in_file=bold_file),
+            name='distortion_params',
+            run_without_submitting=True,
+        )
+        fmap2session = pe.Node(niu.Merge(2), name='fmap2session', run_without_submitting=True)
+        boldref_fmap = pe.Node(
+            ReconstructFieldmap(inverse=[True, False]),
+            name='boldref_fmap',
+            mem_gb=1,
+        )
+        workflow.connect([
+            (distortion_params, boldref_bold, [
+                ('readout_time', 'ro_time'),
+                ('pe_direction', 'pe_dir'),
+            ]),
+            (inputnode, fmap2session, [
+                ('orig2fmap_xfm', 'in1'),
+                ('orig2session_xfm', 'in2'),
+            ]),
+            (inputnode, boldref_fmap, [
+                ('session_boldref', 'target_ref_file'),
+                ('fmap_coeff', 'in_coeffs'),
+                ('fmap_ref', 'fmap_ref_file'),
+            ]),
+            (fmap2session, boldref_fmap, [('out', 'transforms')]),
+            (boldref_fmap, boldref_bold, [('out_file', 'fieldmap')]),
+        ])  # fmt:skip
+
+    return workflow
+
+
 def _select_ref(sbref_files, boldref_files):
     """Select first sbref or boldref file, preferring sbref if available"""
     from niworkflows.utils.connections import listify

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -155,7 +155,7 @@ def init_bold_fit_wf(
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
         as concatenated ITK affine transforms.
-    orig2fmap_xfm
+    run2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
     dummy_scans
@@ -216,12 +216,12 @@ def init_bold_fit_wf(
     hmc_boldref = precomputed.get('hmc_boldref')
     coreg_boldref = precomputed.get('coreg_boldref')
     # Can contain
-    #  1) boldref2fmap
+    #  1) run2fmap
     #  2) boldref2anat
     #  3) hmc
     transforms = precomputed.get('transforms', {})
     hmc_xforms = transforms.get('hmc')
-    boldref2fmap_xform = transforms.get('boldref2fmap')
+    run2fmap_xform = transforms.get('run2fmap')
 
     workflow = Workflow(name=name)
 
@@ -247,7 +247,7 @@ def init_bold_fit_wf(
                 'coreg_boldref',
                 'bold_mask',
                 'motion_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 # summary (can be undefined)
                 'algo_dummy_scans',  # if hmc
                 # func fit reports wf
@@ -268,9 +268,7 @@ def init_bold_fit_wf(
     )
     fmapref_buffer = pe.Node(niu.Function(function=_select_ref), name='fmapref_buffer')
     hmc_buffer = pe.Node(niu.IdentityInterface(fields=['hmc_xforms']), name='hmc_buffer')
-    fmapreg_buffer = pe.Node(
-        niu.IdentityInterface(fields=['orig2fmap_xfm']), name='fmapreg_buffer'
-    )
+    fmapreg_buffer = pe.Node(niu.IdentityInterface(fields=['run2fmap_xfm']), name='fmapreg_buffer')
     regref_buffer = pe.Node(
         niu.IdentityInterface(fields=['boldref', 'boldmask']), name='regref_buffer'
     )
@@ -281,9 +279,9 @@ def init_bold_fit_wf(
     if hmc_xforms:
         hmc_buffer.inputs.hmc_xforms = hmc_xforms
         config.loggers.workflow.debug(f'Reusing motion correction transforms: {hmc_xforms}')
-    if boldref2fmap_xform:
-        fmapreg_buffer.inputs.orig2fmap_xfm = boldref2fmap_xform
-        config.loggers.workflow.debug(f'Reusing BOLD-to-fieldmap transform: {boldref2fmap_xform}')
+    if run2fmap_xform:
+        fmapreg_buffer.inputs.run2fmap_xfm = run2fmap_xform
+        config.loggers.workflow.debug(f'Reusing BOLD-to-fieldmap transform: {run2fmap_xform}')
     if coreg_boldref:
         regref_buffer.inputs.boldref = coreg_boldref
         config.loggers.workflow.debug(f'Reusing coregistration reference: {coreg_boldref}')
@@ -299,7 +297,7 @@ def init_bold_fit_wf(
             ('boldref', 'coreg_boldref'),
             ('boldmask', 'bold_mask'),
         ]),
-        (fmapreg_buffer, outputnode, [('orig2fmap_xfm', 'orig2fmap_xfm')]),
+        (fmapreg_buffer, outputnode, [('run2fmap_xfm', 'run2fmap_xfm')]),
         (hmc_buffer, outputnode, [('hmc_xforms', 'motion_xfm')]),
     ])  # fmt:skip
 
@@ -387,7 +385,7 @@ def init_bold_fit_wf(
 
         workflow.connect([
             (fmapref_buffer, boldref_fmap, [('out', 'target_ref_file')]),
-            (fmapreg_buffer, boldref_fmap, [('orig2fmap_xfm', 'transforms')]),
+            (fmapreg_buffer, boldref_fmap, [('run2fmap_xfm', 'transforms')]),
             (inputnode, boldref_fmap, [
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
@@ -396,7 +394,7 @@ def init_bold_fit_wf(
             (boldref_fmap, outputnode, [('out_file', 'fieldmap')]),
         ])  # fmt:skip
 
-        if not boldref2fmap_xform:
+        if not run2fmap_xform:
             config.loggers.workflow.info('Stage 3: Registering fieldmap to boldref')
             fmapreg_wf = init_coeff2epi_wf(
                 debug='fieldmaps' in config.execution.debug,
@@ -410,16 +408,10 @@ def init_bold_fit_wf(
                 niu.Merge(2), name='fmapreg_source_files', run_without_submitting=True
             )
 
-            # TODO: the registration reference here is the run-level boldref
-            # (HMC target), so per the orig->run->boldref->anat space chain this
-            # should be source='run' (from-run_to-<fmap>) and the transform
-            # renamed orig2fmap_xfm -> run2fmap_xfm. Also update the io_spec key
-            # (boldref2fmap -> run2fmap) and docs/outputs.md. Changes the fmap
-            # registration derivative filename.
             ds_fmapreg_wf = init_ds_registration_wf(
                 source_file=bold_file,
                 output_dir=config.execution.nibabies_dir,
-                source='boldref',
+                source='run',
                 dest=re.sub(r'[^a-zA-Z0-9]', '', fieldmap_id),
                 desc='fmap',
                 name='ds_fmapreg_wf',
@@ -437,7 +429,7 @@ def init_bold_fit_wf(
                 (fmapreg_wf, itk_mat2txt, [('outputnode.target2fmap_xfm', 'in_xfms')]),
                 (itk_mat2txt, ds_fmapreg_wf, [('out_xfm', 'inputnode.xform')]),
                 (fmapreg_source_files, ds_fmapreg_wf, [('out', 'inputnode.source_files')]),
-                (ds_fmapreg_wf, fmapreg_buffer, [('outputnode.xform', 'orig2fmap_xfm')]),
+                (ds_fmapreg_wf, fmapreg_buffer, [('outputnode.xform', 'run2fmap_xfm')]),
             ])  # fmt:skip
         else:
             config.loggers.workflow.info(
@@ -526,11 +518,11 @@ def init_bold_fit_wf(
                 (skullstrip_bold_wf, ds_boldmask_wf, [
                     ('outputnode.mask_file', 'inputnode.boldmask'),
                 ]),
-                (fmapreg_buffer, coreg_ref_source_files, [('orig2fmap_xfm', 'in2')]),
+                (fmapreg_buffer, coreg_ref_source_files, [('run2fmap_xfm', 'in2')]),
                 (inputnode, coreg_ref_source_files, [('fmap_coeff', 'in3')]),
             ])  # fmt:skip
 
-            if not boldref2fmap_xform:
+            if not run2fmap_xform:
                 workflow.connect([
                     (enhance_boldref_wf, fmapreg_wf, [
                         ('outputnode.bias_corrected_file', 'inputnode.target_ref'),
@@ -606,7 +598,7 @@ def init_bold_native_wf(
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
         as concatenated ITK affine transforms.
-    orig2fmap_xfm
+    run2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
     fmap_ref
@@ -684,7 +676,7 @@ def init_bold_native_wf(
                 'run_boldref',
                 'bold_mask',
                 'motion_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 'dummy_scans',
                 # Fieldmap fit
                 'fmap_ref',
@@ -784,7 +776,7 @@ def init_bold_native_wf(
         workflow.connect([
             (inputnode, boldref_fmap, [
                 ('run_boldref', 'target_ref_file'),
-                ('orig2fmap_xfm', 'transforms'),
+                ('run2fmap_xfm', 'transforms'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
             ]),
@@ -867,7 +859,7 @@ def init_bold_boldref_wf(
         Affine transform from the run-level boldref to the boldref template.
     motion_xfm
         Per-volume affine transforms (HMC).
-    orig2fmap_xfm
+    run2fmap_xfm
         Affine from boldref space to fieldmap space (SDC only).
     fmap_ref
         Fieldmap reference file (SDC only).
@@ -893,7 +885,7 @@ def init_bold_boldref_wf(
                 'boldref_template',
                 'run2boldref_xfm',
                 'motion_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 'fmap_ref',
                 'fmap_coeff',
             ],
@@ -951,7 +943,7 @@ def init_bold_boldref_wf(
                 ('pe_direction', 'pe_dir'),
             ]),
             (inputnode, fmap2boldref, [
-                ('orig2fmap_xfm', 'in1'),
+                ('run2fmap_xfm', 'in1'),
                 ('run2boldref_xfm', 'in2'),
             ]),
             (inputnode, boldref_fmap, [

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -670,8 +670,8 @@ def init_bold_native_wf(
 
     Inputs
     ------
-    boldref
-        BOLD reference file
+    run_boldref
+        Per-run BOLD reference file (sbref or average volume from the run).
     bold_mask
         Mask of BOLD reference file
     motion_xfm
@@ -680,9 +680,6 @@ def init_bold_native_wf(
     orig2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
-    orig2session_xfm
-        Transform mapping run-level BOLD reference to session boldref space, if applicable.
-        Identity when ``--bold-coreg-level run``.
     fmap_ref
         Fieldmap reference file
     fmap_coeff
@@ -695,10 +692,10 @@ def init_bold_native_wf(
         slice-timing correction (STC) may have been applied. For multi-echo
         data, this is identical to bold_native.
     bold_native
-        BOLD series resampled into BOLD reference space. Slice-timing,
+        BOLD series resampled into run-level BOLD reference space. Slice-timing,
         head motion and susceptibility distortion correction (STC, HMC, SDC)
-        will all be applied to each file. For multi-echo data, the echos
-        are combined to form an `optimal combination`_.
+        will all be applied. For multi-echo data, the echos are combined to
+        form an `optimal combination`_.
     metadata
         Metadata dictionary of BOLD series with the shortest echo
     motion_xfm
@@ -755,10 +752,9 @@ def init_bold_native_wf(
         niu.IdentityInterface(
             fields=[
                 # BOLD fit
-                'boldref',
+                'run_boldref',
                 'bold_mask',
                 'motion_xfm',
-                'orig2session_xfm',
                 'orig2fmap_xfm',
                 'dummy_scans',
                 # Fieldmap fit
@@ -842,20 +838,10 @@ def init_bold_native_wf(
         mem_gb=mem_gb['resampled'],
     )
 
-    merge_orig2session = pe.Node(
-        niu.Merge(2), name='merge_orig2session', run_without_submitting=True
-    )
-
     workflow.connect([
-        (inputnode, merge_orig2session, [
-            ('motion_xfm', 'in1'),
-            ('orig2session_xfm', 'in2'),
-        ]),
-        (merge_orig2session, boldref_bold, [
-            ('out', 'transforms'),
-        ]),
         (inputnode, boldref_bold, [
-            ('boldref', 'ref_file'),
+            ('motion_xfm', 'transforms'),
+            ('run_boldref', 'ref_file'),
         ]),
         (boldbuffer, boldref_bold, [
             ('bold_file', 'in_file'),
@@ -868,7 +854,7 @@ def init_bold_native_wf(
         boldref_fmap = pe.Node(ReconstructFieldmap(inverse=[True]), name='boldref_fmap', mem_gb=1)
         workflow.connect([
             (inputnode, boldref_fmap, [
-                ('boldref', 'target_ref_file'),
+                ('run_boldref', 'target_ref_file'),
                 ('orig2fmap_xfm', 'transforms'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -680,8 +680,9 @@ def init_bold_native_wf(
     orig2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
-    orig2boldref_xfm
-        Transform mapping run-level BOLD reference with session space, if applicable.
+    orig2session_xfm
+        Transform mapping run-level BOLD reference to session boldref space, if applicable.
+        Identity when ``--bold-coreg-level run``.
     fmap_ref
         Fieldmap reference file
     fmap_coeff
@@ -757,7 +758,7 @@ def init_bold_native_wf(
                 'boldref',
                 'bold_mask',
                 'motion_xfm',
-                'orig2boldref_xfm',
+                'orig2session_xfm',
                 'orig2fmap_xfm',
                 'dummy_scans',
                 # Fieldmap fit
@@ -841,14 +842,16 @@ def init_bold_native_wf(
         mem_gb=mem_gb['resampled'],
     )
 
-    merge_xfms = pe.Node(niu.Merge(2), name='merge_xfms', run_without_submitting=True)
+    merge_orig2session = pe.Node(
+        niu.Merge(2), name='merge_orig2session', run_without_submitting=True
+    )
 
     workflow.connect([
-        (inputnode, merge_xfms, [
+        (inputnode, merge_orig2session, [
             ('motion_xfm', 'in1'),
-            ('orig2boldref_xfm', 'in2'),
+            ('orig2session_xfm', 'in2'),
         ]),
-        (merge_xfms, boldref_bold, [
+        (merge_orig2session, boldref_bold, [
             ('out', 'transforms'),
         ]),
         (inputnode, boldref_bold, [

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -670,7 +670,7 @@ def init_bold_native_wf(
 
     Inputs
     ------
-    orig_boldref
+    run_boldref
         Per-run BOLD reference file (sbref or average volume from the run).
     bold_mask
         Mask of BOLD reference file
@@ -752,7 +752,7 @@ def init_bold_native_wf(
         niu.IdentityInterface(
             fields=[
                 # BOLD fit
-                'orig_boldref',
+                'run_boldref',
                 'bold_mask',
                 'motion_xfm',
                 'orig2fmap_xfm',
@@ -841,7 +841,7 @@ def init_bold_native_wf(
     workflow.connect([
         (inputnode, boldref_bold, [
             ('motion_xfm', 'transforms'),
-            ('orig_boldref', 'ref_file'),
+            ('run_boldref', 'ref_file'),
         ]),
         (boldbuffer, boldref_bold, [
             ('bold_file', 'in_file'),
@@ -854,7 +854,7 @@ def init_bold_native_wf(
         boldref_fmap = pe.Node(ReconstructFieldmap(inverse=[True]), name='boldref_fmap', mem_gb=1)
         workflow.connect([
             (inputnode, boldref_fmap, [
-                ('orig_boldref', 'target_ref_file'),
+                ('run_boldref', 'target_ref_file'),
                 ('orig2fmap_xfm', 'transforms'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
@@ -934,7 +934,7 @@ def init_bold_session_wf(
         STC-only BOLD series (output of :py:func:`init_bold_native_wf`).
     boldref_template
         BOLD reference template image.
-    orig2session_xfm
+    run2boldref_xfm
         Affine transform from the run-level boldref to the boldref template.
     motion_xfm
         Per-volume affine transforms (HMC).
@@ -962,7 +962,7 @@ def init_bold_session_wf(
             fields=[
                 'bold_minimal',
                 'boldref_template',
-                'orig2session_xfm',
+                'run2boldref_xfm',
                 'motion_xfm',
                 'orig2fmap_xfm',
                 'fmap_ref',
@@ -994,7 +994,7 @@ def init_bold_session_wf(
     workflow.connect([
         (inputnode, merge_bold2session, [
             ('motion_xfm', 'in1'),
-            ('orig2session_xfm', 'in2'),
+            ('run2boldref_xfm', 'in2'),
         ]),
         (inputnode, boldref_bold, [
             ('bold_minimal', 'in_file'),
@@ -1023,7 +1023,7 @@ def init_bold_session_wf(
             ]),
             (inputnode, fmap2session, [
                 ('orig2fmap_xfm', 'in1'),
-                ('orig2session_xfm', 'in2'),
+                ('run2boldref_xfm', 'in2'),
             ]),
             (inputnode, boldref_fmap, [
                 ('boldref_template', 'target_ref_file'),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -903,12 +903,12 @@ def init_bold_native_wf(
     return workflow
 
 
-def init_bold_session_wf(
+def init_bold_boldref_wf(
     *,
     bold_series: list[str],
     fieldmap_id: str | None = None,
     omp_nthreads: int = 1,
-    name: str = 'bold_session_wf',
+    name: str = 'bold_boldref_wf',
 ) -> pe.Workflow:
     r"""
     Resample BOLD series to session-level boldref space.
@@ -947,7 +947,7 @@ def init_bold_session_wf(
 
     Outputs
     -------
-    bold_session
+    bold_boldref
         BOLD series resampled into boldref template space with HMC and SDC applied.
 
     """
@@ -973,12 +973,12 @@ def init_bold_session_wf(
     )
 
     outputnode = pe.Node(
-        niu.IdentityInterface(fields=['bold_session']),
+        niu.IdentityInterface(fields=['bold_boldref']),
         name='outputnode',
     )
 
-    merge_bold2session = pe.Node(
-        niu.Merge(2), name='merge_bold2session', run_without_submitting=True
+    merge_bold2boldref = pe.Node(
+        niu.Merge(2), name='merge_bold2boldref', run_without_submitting=True
     )
 
     boldref_bold = pe.Node(
@@ -992,7 +992,7 @@ def init_bold_session_wf(
     )
 
     workflow.connect([
-        (inputnode, merge_bold2session, [
+        (inputnode, merge_bold2boldref, [
             ('motion_xfm', 'in1'),
             ('run2boldref_xfm', 'in2'),
         ]),
@@ -1000,8 +1000,8 @@ def init_bold_session_wf(
             ('bold_minimal', 'in_file'),
             ('boldref_template', 'ref_file'),
         ]),
-        (merge_bold2session, boldref_bold, [('out', 'transforms')]),
-        (boldref_bold, outputnode, [('out_file', 'bold_session')]),
+        (merge_bold2boldref, boldref_bold, [('out', 'transforms')]),
+        (boldref_bold, outputnode, [('out_file', 'bold_boldref')]),
     ])  # fmt:skip
 
     if fieldmap_id:
@@ -1010,7 +1010,7 @@ def init_bold_session_wf(
             name='distortion_params',
             run_without_submitting=True,
         )
-        fmap2session = pe.Node(niu.Merge(2), name='fmap2session', run_without_submitting=True)
+        fmap2boldref = pe.Node(niu.Merge(2), name='fmap2boldref', run_without_submitting=True)
         boldref_fmap = pe.Node(
             ReconstructFieldmap(inverse=[True, False]),
             name='boldref_fmap',
@@ -1021,7 +1021,7 @@ def init_bold_session_wf(
                 ('readout_time', 'ro_time'),
                 ('pe_direction', 'pe_dir'),
             ]),
-            (inputnode, fmap2session, [
+            (inputnode, fmap2boldref, [
                 ('orig2fmap_xfm', 'in1'),
                 ('run2boldref_xfm', 'in2'),
             ]),
@@ -1030,7 +1030,7 @@ def init_bold_session_wf(
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
             ]),
-            (fmap2session, boldref_fmap, [('out', 'transforms')]),
+            (fmap2boldref, boldref_fmap, [('out', 'transforms')]),
             (boldref_fmap, boldref_bold, [('out_file', 'fieldmap')]),
         ])  # fmt:skip
 

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -33,7 +33,6 @@ from niworkflows.interfaces.nitransforms import ConcatenateXFMs
 from sdcflows.workflows.apply.registration import init_coeff2epi_wf
 
 from nibabies import config
-from nibabies._types import Anatomical
 from nibabies.interfaces.resampling import (
     DistortionParameters,
     ReconstructFieldmap,
@@ -94,7 +93,6 @@ def get_sbrefs(
 def init_bold_fit_wf(
     *,
     bold_series: list[str],
-    reference_anat: Anatomical,
     precomputed: dict | None = None,
     fieldmap_id: str | None = None,
     jacobian: bool = False,
@@ -103,6 +101,7 @@ def init_bold_fit_wf(
 ) -> pe.Workflow:
     """
     This workflow controls the minimal estimation steps for functional preprocessing.
+    Note that this workflow does not perform bold to anatomical coregistration.
 
     Workflow Graph
         .. workflow::
@@ -115,7 +114,7 @@ def init_bold_fit_wf(
             with mock_config():
                 bold_file = config.execution.bids_dir / "sub-01" / "func" \
                     / "sub-01_task-mixedgamblestask_run-01_bold.nii.gz"
-                wf = init_bold_fit_wf(bold_series=[str(bold_file)], reference_anat='T1w')
+                wf = init_bold_fit_wf(bold_series=[str(bold_file)])
 
     Parameters
     ----------
@@ -131,21 +130,6 @@ def init_bold_fit_wf(
     ------
     bold_file
         BOLD series NIfTI file
-    anat_preproc
-        Bias-corrected structural template image
-    anat_mask
-        Mask of the skull-stripped template image
-    anat_dseg
-        Segmentation of preprocessed structural image, including
-        gray-matter (GM), white-matter (WM) and cerebrospinal fluid (CSF)
-    anat2std_xfm
-        List of transform files, collated with templates
-    subjects_dir
-        FreeSurfer SUBJECTS_DIR
-    subject_id
-        FreeSurfer subject ID
-    fsnative2t1w_xfm
-        LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
     fmap
         Fieldmap file
     fmap_ref
@@ -249,13 +233,6 @@ def init_bold_fit_wf(
                 'fmap_ref',
                 'fmap_coeff',
                 'fmap_mask',
-                # Anatomical coregistration
-                'anat_preproc',
-                'anat_mask',
-                'anat_dseg',
-                'subjects_dir',
-                'subject_id',
-                'fsnative2anat_xfm',
             ],
         ),
         name='inputnode',
@@ -433,6 +410,12 @@ def init_bold_fit_wf(
                 niu.Merge(2), name='fmapreg_source_files', run_without_submitting=True
             )
 
+            # TODO: the registration reference here is the run-level boldref
+            # (HMC target), so per the orig->run->boldref->anat space chain this
+            # should be source='run' (from-run_to-<fmap>) and the transform
+            # renamed orig2fmap_xfm -> run2fmap_xfm. Also update the io_spec key
+            # (boldref2fmap -> run2fmap) and docs/outputs.md. Changes the fmap
+            # registration derivative filename.
             ds_fmapreg_wf = init_ds_registration_wf(
                 source_file=bold_file,
                 output_dir=config.execution.nibabies_dir,

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -30,12 +30,10 @@ from nipype.pipeline import engine as pe
 from niworkflows.func.util import init_enhance_and_skullstrip_bold_wf, init_skullstrip_bold_wf
 from niworkflows.interfaces.header import ValidateImage
 from niworkflows.interfaces.nitransforms import ConcatenateXFMs
-from niworkflows.interfaces.utility import KeySelect
 from sdcflows.workflows.apply.registration import init_coeff2epi_wf
 
 from nibabies import config
 from nibabies._types import Anatomical
-from nibabies.interfaces.reports import FunctionalSummary
 from nibabies.interfaces.resampling import (
     DistortionParameters,
     ReconstructFieldmap,
@@ -54,7 +52,6 @@ from nibabies.workflows.bold.outputs import (
     init_ds_boldref_wf,
     init_ds_hmc_wf,
     init_ds_registration_wf,
-    init_func_fit_reports_wf,
 )
 from nibabies.workflows.bold.reference import init_raw_boldref_wf, init_validation_and_dummies_wf
 from nibabies.workflows.bold.registration import init_bold_reg_wf
@@ -102,6 +99,7 @@ def init_bold_fit_wf(
     precomputed: dict | None = None,
     fieldmap_id: str | None = None,
     jacobian: bool = False,
+    coreg_anat: bool = True,
     omp_nthreads: int = 1,
     name: str = 'bold_fit_wf',
 ) -> pe.Workflow:
@@ -150,18 +148,16 @@ def init_bold_fit_wf(
         FreeSurfer subject ID
     fsnative2t1w_xfm
         LTA-style affine matrix translating from FreeSurfer-conformed subject space to T1w
-    fmap_id
-        Unique identifiers to select fieldmap files
     fmap
-        List of estimated fieldmaps (collated with fmap_id)
+        Fieldmap file
     fmap_ref
-        List of fieldmap reference files (collated with fmap_id)
+        Fieldmap reference file
     fmap_coeff
-        List of lists of spline coefficient files (collated with fmap_id)
+        List of spline coefficient files
     fmap_mask
-        List of fieldmap masks (collated with fmap_id)
+        Fieldmap mask
     sdc_method
-        List of fieldmap correction method names (collated with fmap_id)
+        Fieldmap correction method name
 
     Outputs
     -------
@@ -180,7 +176,7 @@ def init_bold_fit_wf(
     boldref2anat_xfm
         Affine transform mapping from BOLD reference space to the anatomical
         space.
-    boldref2fmap_xfm
+    orig2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
     dummy_scans
@@ -232,11 +228,9 @@ def init_bold_fit_wf(
     config.loggers.workflow.info(sbref_msg)
 
     # Get metadata from BOLD file(s)
-    entities = extract_entities(bold_series)
     metadata = layout.get_metadata(bold_file)
-    orientation = ''.join(nb.aff2axcodes(nb.load(bold_file).affine))
 
-    bold_tlen, mem_gb = estimate_bold_mem_usage(bold_file)
+    _, mem_gb = estimate_bold_mem_usage(bold_file)
 
     # Boolean used to update workflow self-descriptions
     multiecho = len(bold_series) > 1
@@ -259,12 +253,9 @@ def init_bold_fit_wf(
             fields=[
                 'bold_file',
                 # Fieldmap registration
-                'fmap',
                 'fmap_ref',
                 'fmap_coeff',
                 'fmap_mask',
-                'fmap_id',
-                'sdc_method',
                 # Anatomical coregistration
                 'anat_preproc',
                 'anat_mask',
@@ -286,8 +277,15 @@ def init_bold_fit_wf(
                 'coreg_boldref',
                 'bold_mask',
                 'motion_xfm',
-                'boldref2anat_xfm',
-                'boldref2fmap_xfm',
+                'boldref2anat_xfm',  # Undefined if coreg_anat is False
+                'orig2fmap_xfm',
+                # summary (can be undefined)
+                'algo_dummy_scans',  # if hmc
+                'fallback',  # if run -> anat coregistration
+                # func fit reports wf
+                'validation_report',
+                'sdc_boldref',
+                'fieldmap',
             ],
         ),
         name='outputnode',
@@ -303,7 +301,7 @@ def init_bold_fit_wf(
     fmapref_buffer = pe.Node(niu.Function(function=_select_ref), name='fmapref_buffer')
     hmc_buffer = pe.Node(niu.IdentityInterface(fields=['hmc_xforms']), name='hmc_buffer')
     fmapreg_buffer = pe.Node(
-        niu.IdentityInterface(fields=['boldref2fmap_xfm']), name='fmapreg_buffer'
+        niu.IdentityInterface(fields=['orig2fmap_xfm']), name='fmapreg_buffer'
     )
     regref_buffer = pe.Node(
         niu.IdentityInterface(fields=['boldref', 'boldmask']), name='regref_buffer'
@@ -316,44 +314,12 @@ def init_bold_fit_wf(
         hmc_buffer.inputs.hmc_xforms = hmc_xforms
         config.loggers.workflow.debug(f'Reusing motion correction transforms: {hmc_xforms}')
     if boldref2fmap_xform:
-        fmapreg_buffer.inputs.boldref2fmap_xfm = boldref2fmap_xform
+        fmapreg_buffer.inputs.orig2fmap_xfm = boldref2fmap_xform
         config.loggers.workflow.debug(f'Reusing BOLD-to-fieldmap transform: {boldref2fmap_xform}')
     if coreg_boldref:
         regref_buffer.inputs.boldref = coreg_boldref
         config.loggers.workflow.debug(f'Reusing coregistration reference: {coreg_boldref}')
     fmapref_buffer.inputs.sbref_files = sbref_files
-
-    use_fs = config.workflow.surface_recon_method is not None
-    summary = pe.Node(
-        FunctionalSummary(
-            distortion_correction='None',  # Can override with connection
-            registration='FreeSurfer' if use_fs else 'FSL',
-            registration_dof=config.workflow.bold2anat_dof,
-            registration_init=config.workflow.bold2anat_init,
-            pe_direction=metadata.get('PhaseEncodingDirection'),
-            echo_idx=entities.get('echo', []),
-            tr=metadata['RepetitionTime'],
-            orientation=orientation,
-        ),
-        name='summary',
-        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        run_without_submitting=True,
-    )
-    summary.inputs.dummy_scans = config.workflow.dummy_scans
-    if config.workflow.level == 'full':
-        # Hack. More pain than it's worth to connect this up at a higher level.
-        # We can consider separating out fit and transform summaries,
-        # or connect a bunch a bunch of summary parameters to outputnodes
-        # to make available to the base workflow.
-        summary.inputs.slice_timing = (
-            bool(metadata.get('SliceTiming')) and 'slicetiming' not in config.workflow.ignore
-        )
-
-    func_fit_reports_wf = init_func_fit_reports_wf(
-        reference_anat=reference_anat,
-        sdc_correction=fieldmap_id is not None,
-        output_dir=config.execution.output_dir,
-    )
 
     workflow.connect([
         (hmcref_buffer, outputnode, [
@@ -365,23 +331,8 @@ def init_bold_fit_wf(
             ('boldref', 'coreg_boldref'),
             ('boldmask', 'bold_mask'),
         ]),
-        (fmapreg_buffer, outputnode, [('boldref2fmap_xfm', 'boldref2fmap_xfm')]),
+        (fmapreg_buffer, outputnode, [('orig2fmap_xfm', 'orig2fmap_xfm')]),
         (hmc_buffer, outputnode, [('hmc_xforms', 'motion_xfm')]),
-        (inputnode, func_fit_reports_wf, [
-            ('bold_file', 'inputnode.source_file'),
-            ('anat_preproc', 'inputnode.anat_preproc'),
-            # May not need all of these
-            ('anat_mask', 'inputnode.anat_mask'),
-            ('anat_dseg', 'inputnode.anat_dseg'),
-            ('subjects_dir', 'inputnode.subjects_dir'),
-            ('subject_id', 'inputnode.subject_id'),
-        ]),
-        (outputnode, func_fit_reports_wf, [
-            ('coreg_boldref', 'inputnode.coreg_boldref'),
-            ('bold_mask', 'inputnode.bold_mask'),
-            ('boldref2anat_xfm', 'inputnode.boldref2anat_xfm'),
-        ]),
-        (summary, func_fit_reports_wf, [('out_report', 'inputnode.summary_report')]),
     ])  # fmt:skip
 
     # Stage 1: Generate motion correction boldref
@@ -414,9 +365,9 @@ def init_bold_fit_wf(
                 ('outputnode.bold_file', 'bold_file'),
                 ('outputnode.skip_vols', 'dummy_scans'),
             ]),
-            (hmc_boldref_wf, summary, [('outputnode.algo_dummy_scans', 'algo_dummy_scans')]),
-            (hmc_boldref_wf, func_fit_reports_wf, [
-                ('outputnode.validation_report', 'inputnode.validation_report'),
+            (hmc_boldref_wf, outputnode, [
+                ('outputnode.algo_dummy_scans', 'algo_dummy_scans'),
+                ('outputnode.validation_report', 'validation_report'),
             ]),
             (ds_hmc_boldref_wf, hmc_boldref_source_buffer, [
                 ('outputnode.boldref', 'in_file'),
@@ -432,9 +383,7 @@ def init_bold_fit_wf(
                 ('outputnode.bold_file', 'bold_file'),
                 ('outputnode.skip_vols', 'dummy_scans'),
             ]),
-            (validation_and_dummies_wf, func_fit_reports_wf, [
-                ('outputnode.validation_report', 'inputnode.validation_report'),
-            ]),
+            (validation_and_dummies_wf, outputnode, [('outputnode.validation_report', 'validation_report')]),
             (hmcref_buffer, hmc_boldref_source_buffer, [('boldref', 'in_file')]),
         ])  # fmt:skip
 
@@ -465,38 +414,18 @@ def init_bold_fit_wf(
     # Stage 3: Register fieldmap to boldref and reconstruct in BOLD space
     if fieldmap_id:
         config.loggers.workflow.info('Stage 3: Adding fieldmap reconstruction workflow')
-        fmap_select = pe.Node(
-            KeySelect(
-                fields=['fmap_ref', 'fmap_coeff', 'fmap_mask', 'sdc_method'],
-                key=fieldmap_id,
-            ),
-            name='fmap_select',
-            run_without_submitting=True,
-        )
 
         boldref_fmap = pe.Node(ReconstructFieldmap(inverse=[True]), name='boldref_fmap', mem_gb=1)
 
         workflow.connect([
-            (inputnode, fmap_select, [
-                ('fmap_ref', 'fmap_ref'),
-                ('fmap_coeff', 'fmap_coeff'),
-                ('fmap_mask', 'fmap_mask'),
-                ('sdc_method', 'sdc_method'),
-                ('fmap_id', 'keys'),
-            ]),
             (fmapref_buffer, boldref_fmap, [('out', 'target_ref_file')]),
-            (fmapreg_buffer, boldref_fmap, [('boldref2fmap_xfm', 'transforms')]),
-            (fmap_select, boldref_fmap, [
+            (fmapreg_buffer, boldref_fmap, [('orig2fmap_xfm', 'transforms')]),
+            (inputnode, boldref_fmap, [
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
             ]),
-            (fmap_select, func_fit_reports_wf, [('fmap_ref', 'inputnode.fmap_ref')]),
-            (fmap_select, summary, [('sdc_method', 'distortion_correction')]),
-            (fmapref_buffer, func_fit_reports_wf, [('out', 'inputnode.sdc_boldref')]),
-            (fmapreg_buffer, func_fit_reports_wf, [
-                ('boldref2fmap_xfm', 'inputnode.boldref2fmap_xfm'),
-            ]),
-            (boldref_fmap, func_fit_reports_wf, [('out_file', 'inputnode.fieldmap')]),
+            (fmapref_buffer, outputnode, [('out', 'sdc_boldref')]),
+            (boldref_fmap, outputnode, [('out_file', 'fieldmap')]),
         ])  # fmt:skip
 
         if not boldref2fmap_xform:
@@ -523,18 +452,18 @@ def init_bold_fit_wf(
             )
 
             workflow.connect([
-                (fmap_select, fmapreg_wf, [
+                (inputnode, fmapreg_wf, [
                     ('fmap_ref', 'inputnode.fmap_ref'),
                     ('fmap_mask', 'inputnode.fmap_mask'),
                 ]),
                 (fmapref_buffer, fmapreg_source_files, [('out', 'in1')]),
-                (fmap_select, fmapreg_source_files, [
+                (inputnode, fmapreg_source_files, [
                     ('fmap_ref', 'in2'),
                 ]),
                 (fmapreg_wf, itk_mat2txt, [('outputnode.target2fmap_xfm', 'in_xfms')]),
                 (itk_mat2txt, ds_fmapreg_wf, [('out_xfm', 'inputnode.xform')]),
                 (fmapreg_source_files, ds_fmapreg_wf, [('out', 'inputnode.source_files')]),
-                (ds_fmapreg_wf, fmapreg_buffer, [('outputnode.xform', 'boldref2fmap_xfm')]),
+                (ds_fmapreg_wf, fmapreg_buffer, [('outputnode.xform', 'orig2fmap_xfm')]),
             ])  # fmt:skip
         else:
             config.loggers.workflow.info(
@@ -623,8 +552,8 @@ def init_bold_fit_wf(
                 (skullstrip_bold_wf, ds_boldmask_wf, [
                     ('outputnode.mask_file', 'inputnode.boldmask'),
                 ]),
-                (fmapreg_buffer, coreg_ref_source_files, [('boldref2fmap_xfm', 'in2')]),
-                (fmap_select, coreg_ref_source_files, [('fmap_coeff', 'in3')]),
+                (fmapreg_buffer, coreg_ref_source_files, [('orig2fmap_xfm', 'in2')]),
+                (inputnode, coreg_ref_source_files, [('fmap_coeff', 'in3')]),
             ])  # fmt:skip
 
             if not boldref2fmap_xform:
@@ -655,14 +584,14 @@ def init_bold_fit_wf(
             (skullstrip_precomp_ref_wf, regref_buffer, [('outputnode.mask_file', 'boldmask')])
         ])  # fmt:skip
 
-    if not boldref2anat_xform:
+    if coreg_anat and not boldref2anat_xform:
         config.loggers.workflow.info('Stage 5: Adding coregistration workflow')
         # calculate BOLD registration to T1w
         bold_reg_wf = init_bold_reg_wf(
             bold2anat_dof=config.workflow.bold2anat_dof,
             bold2anat_init=config.workflow.bold2anat_init,
             use_bbr=config.workflow.use_bbr,
-            freesurfer=use_fs,
+            freesurfer=config.workflow.surface_recon_method is not None,
             omp_nthreads=omp_nthreads,
             mem_gb=mem_gb['resampled'],
             sloppy=config.execution.sloppy,
@@ -695,7 +624,6 @@ def init_bold_fit_wf(
                 ('outputnode.metadata', 'inputnode.metadata'),
             ]),
             (ds_boldreg_wf, outputnode, [('outputnode.xform', 'boldref2anat_xfm')]),
-            (bold_reg_wf, summary, [('outputnode.fallback', 'fallback')]),
         ])  # fmt:skip
     else:
         config.loggers.workflow.info('Found coregistration transform - skipping Stage 5')
@@ -749,15 +677,15 @@ def init_bold_native_wf(
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
         as concatenated ITK affine transforms.
-    boldref2fmap_xfm
+    orig2fmap_xfm
         Affine transform mapping from BOLD reference space to the fieldmap
         space, if applicable.
-    fmap_id
-        Unique identifiers to select fieldmap files
+    orig2boldref_xfm
+        Transform mapping run-level BOLD reference with session space, if applicable.
     fmap_ref
-        List of fieldmap reference files (collated with fmap_id)
+        Fieldmap reference file
     fmap_coeff
-        List of lists of spline coefficient files (collated with fmap_id)
+        List of spline coefficient files
 
     Outputs
     -------
@@ -829,12 +757,12 @@ def init_bold_native_wf(
                 'boldref',
                 'bold_mask',
                 'motion_xfm',
-                'boldref2fmap_xfm',
+                'orig2boldref_xfm',
+                'orig2fmap_xfm',
                 'dummy_scans',
                 # Fieldmap fit
                 'fmap_ref',
                 'fmap_coeff',
-                'fmap_id',
             ],
         ),
         name='inputnode',
@@ -890,23 +818,12 @@ def init_bold_native_wf(
 
     # Prepare fieldmap metadata
     if fieldmap_id:
-        fmap_select = pe.Node(
-            KeySelect(fields=['fmap_ref', 'fmap_coeff'], key=fieldmap_id),
-            name='fmap_select',
-            run_without_submitting=True,
-        )
-
         distortion_params = pe.Node(
             DistortionParameters(metadata=metadata, in_file=bold_file),
             name='distortion_params',
             run_without_submitting=True,
         )
         workflow.connect([
-            (inputnode, fmap_select, [
-                ('fmap_ref', 'fmap_ref'),
-                ('fmap_coeff', 'fmap_coeff'),
-                ('fmap_id', 'keys'),
-            ]),
             (distortion_params, boldbuffer, [
                 ('readout_time', 'ro_time'),
                 ('pe_direction', 'pe_dir'),
@@ -924,10 +841,18 @@ def init_bold_native_wf(
         mem_gb=mem_gb['resampled'],
     )
 
+    merge_xfms = pe.Node(niu.Merge(2), name='merge_xfms', run_without_submitting=True)
+
     workflow.connect([
+        (inputnode, merge_xfms, [
+            ('motion_xfm', 'in1'),
+            ('orig2boldref_xfm', 'in2'),
+        ]),
+        (merge_xfms, boldref_bold, [
+            ('out', 'transforms'),
+        ]),
         (inputnode, boldref_bold, [
             ('boldref', 'ref_file'),
-            ('motion_xfm', 'transforms'),
         ]),
         (boldbuffer, boldref_bold, [
             ('bold_file', 'in_file'),
@@ -941,9 +866,7 @@ def init_bold_native_wf(
         workflow.connect([
             (inputnode, boldref_fmap, [
                 ('boldref', 'target_ref_file'),
-                ('boldref2fmap_xfm', 'transforms'),
-            ]),
-            (fmap_select, boldref_fmap, [
+                ('orig2fmap_xfm', 'transforms'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),
             ]),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -670,7 +670,7 @@ def init_bold_native_wf(
 
     Inputs
     ------
-    run_boldref
+    orig_boldref
         Per-run BOLD reference file (sbref or average volume from the run).
     bold_mask
         Mask of BOLD reference file
@@ -752,7 +752,7 @@ def init_bold_native_wf(
         niu.IdentityInterface(
             fields=[
                 # BOLD fit
-                'run_boldref',
+                'orig_boldref',
                 'bold_mask',
                 'motion_xfm',
                 'orig2fmap_xfm',
@@ -841,7 +841,7 @@ def init_bold_native_wf(
     workflow.connect([
         (inputnode, boldref_bold, [
             ('motion_xfm', 'transforms'),
-            ('run_boldref', 'ref_file'),
+            ('orig_boldref', 'ref_file'),
         ]),
         (boldbuffer, boldref_bold, [
             ('bold_file', 'in_file'),
@@ -854,7 +854,7 @@ def init_bold_native_wf(
         boldref_fmap = pe.Node(ReconstructFieldmap(inverse=[True]), name='boldref_fmap', mem_gb=1)
         workflow.connect([
             (inputnode, boldref_fmap, [
-                ('run_boldref', 'target_ref_file'),
+                ('orig_boldref', 'target_ref_file'),
                 ('orig2fmap_xfm', 'transforms'),
                 ('fmap_coeff', 'in_coeffs'),
                 ('fmap_ref', 'fmap_ref_file'),

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -746,13 +746,13 @@ def init_ds_bold_native_wf(
     return workflow
 
 
-def init_ds_bold_session_wf(
+def init_ds_bold_boldref_wf(
     *,
     bids_root: str,
     output_dir: str,
     multiecho: bool,
     all_metadata: list[dict],
-    name='ds_bold_session_wf',
+    name='ds_bold_boldref_wf',
 ) -> pe.Workflow:
     metadata = all_metadata[0]
     timing_parameters = prepare_timing_parameters(metadata)

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -185,7 +185,7 @@ def init_func_fit_reports_wf(
         BOLD reference to anatomical transform.
         run2boldref_xfm
         Original BOLD to BOLD reference transform
-    orig2fmap_xfm
+    run2fmap_xfm
         BOLD reference to fieldmap transform (optional)
     fieldmap
         Fieldmap image (optional)
@@ -206,7 +206,7 @@ def init_func_fit_reports_wf(
         'coreg_boldref',
         'bold_mask',
         'boldref2anat_xfm',
-        'orig2fmap_xfm',
+        'run2fmap_xfm',
         'run2boldref_xfm',
         'anat_preproc',
         'anat_mask',
@@ -394,7 +394,7 @@ def init_func_fit_reports_wf(
                 ('coreg_boldref', 'reference_image'),
             ]),
             (inputnode, to_fmap_xfm, [
-                ('orig2fmap_xfm', 'in1'),
+                ('run2fmap_xfm', 'in1'),
                 ('run2boldref_xfm', 'in2'),
             ]),
             (to_fmap_xfm, fmapref_boldref, [
@@ -626,7 +626,7 @@ def init_ds_bold_native_wf(
                 't2star',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
                 'run2boldref_xfm',
             ]
         ),
@@ -646,7 +646,7 @@ def init_ds_bold_native_wf(
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
             ('run2boldref_xfm', 'in3'),
-            ('orig2fmap_xfm', 'in4'),
+            ('run2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
 
@@ -766,7 +766,7 @@ def init_ds_bold_boldref_wf(
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
                 'run2boldref_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
             ]
         ),
         name='inputnode',
@@ -785,7 +785,7 @@ def init_ds_bold_boldref_wf(
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
             ('run2boldref_xfm', 'in3'),
-            ('orig2fmap_xfm', 'in4'),
+            ('run2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
 
@@ -846,7 +846,7 @@ def init_ds_volumes_wf(
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
                 'run2boldref_xfm',
-                'orig2fmap_xfm',
+                'run2fmap_xfm',
             ]
         ),
         name='inputnode',
@@ -881,7 +881,7 @@ def init_ds_volumes_wf(
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
             ('run2boldref_xfm', 'in3'),
-            ('orig2fmap_xfm', 'in4'),
+            ('run2fmap_xfm', 'in4'),
             ('boldref2anat_xfm', 'in5'),
             ('anat2std_xfm', 'in6'),
             ('template', 'in7'),

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -183,7 +183,7 @@ def init_func_fit_reports_wf(
         SDC-corrected BOLD reference image.
     boldref2anat_xfm
         BOLD reference to anatomical transform.
-        orig2session_xfm
+        run2boldref_xfm
         Original BOLD to BOLD reference transform
     orig2fmap_xfm
         BOLD reference to fieldmap transform (optional)
@@ -207,7 +207,7 @@ def init_func_fit_reports_wf(
         'bold_mask',
         'boldref2anat_xfm',
         'orig2fmap_xfm',
-        'orig2session_xfm',
+        'run2boldref_xfm',
         'anat_preproc',
         'anat_mask',
         'anat_dseg',
@@ -301,7 +301,7 @@ def init_func_fit_reports_wf(
         ]),
         (inputnode, to_anat_xfm, [
             ('boldref2anat_xfm', 'in1'),
-            ('orig2session_xfm', 'in2'),
+            ('run2boldref_xfm', 'in2'),
         ]),
         (to_anat_xfm, anat_boldref, [('out', 'transforms')]),
         (inputnode, anat_wm, [('anat_dseg', 'in_seg')]),
@@ -395,7 +395,7 @@ def init_func_fit_reports_wf(
             ]),
             (inputnode, to_fmap_xfm, [
                 ('orig2fmap_xfm', 'in1'),
-                ('orig2session_xfm', 'in2'),
+                ('run2boldref_xfm', 'in2'),
             ]),
             (to_fmap_xfm, fmapref_boldref, [
                 ('out', 'transforms'),
@@ -586,7 +586,7 @@ def init_ds_hmc_wf(
             extension='.txt',
             compress=True,
             dismiss_entities=DEFAULT_DISMISS_ENTITIES,
-            **{'from': 'orig', 'to': 'boldref'},
+            **{'from': 'orig', 'to': 'run'},
         ),
         name='ds_xforms',
         run_without_submitting=True,
@@ -627,7 +627,7 @@ def init_ds_bold_native_wf(
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
                 'orig2fmap_xfm',
-                'orig2session_xfm',
+                'run2boldref_xfm',
             ]
         ),
         name='inputnode',
@@ -645,7 +645,7 @@ def init_ds_bold_native_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('orig2session_xfm', 'in3'),
+            ('run2boldref_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
@@ -765,7 +765,7 @@ def init_ds_bold_session_wf(
                 'bold',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'orig2session_xfm',
+                'run2boldref_xfm',
                 'orig2fmap_xfm',
             ]
         ),
@@ -784,7 +784,7 @@ def init_ds_bold_session_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('orig2session_xfm', 'in3'),
+            ('run2boldref_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
@@ -792,7 +792,7 @@ def init_ds_bold_session_wf(
     ds_bold = pe.Node(
         DerivativesDataSink(
             base_directory=output_dir,
-            space='session',
+            space='boldref',
             desc='preproc',
             compress=True,
             SkullStripped=multiecho,
@@ -845,7 +845,7 @@ def init_ds_volumes_wf(
                 'resolution',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'orig2session_xfm',
+                'run2boldref_xfm',
                 'orig2fmap_xfm',
             ]
         ),
@@ -880,7 +880,7 @@ def init_ds_volumes_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('orig2session_xfm', 'in3'),
+            ('run2boldref_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
             ('boldref2anat_xfm', 'in5'),
             ('anat2std_xfm', 'in6'),

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -175,6 +175,23 @@ def init_func_fit_reports_wf(
         Segmentation in anatomical reference space
     anat_mask
         Brain (binary) mask estimated by brain extraction.
+    coreg_boldref
+        BOLD reference image.
+    bold_mask
+        Reference BOLD brain mask.
+    sdc_boldref
+        SDC-corrected BOLD reference image.
+    boldref2anat_xfm
+        BOLD reference to anatomical transform.
+        orig2boldref_xfm
+        Original BOLD to BOLD reference transform
+    orig2fmap_xfm
+        BOLD reference to fieldmap transform (optional)
+    fieldmap
+        Fieldmap image (optional)
+    fmap_ref
+        Fieldmap reference image (optional)
+
     """
     from nireports.interfaces.reporting.base import (
         SimpleBeforeAfterRPT as SimpleBeforeAfter,
@@ -189,7 +206,8 @@ def init_func_fit_reports_wf(
         'coreg_boldref',
         'bold_mask',
         'boldref2anat_xfm',
-        'boldref2fmap_xfm',
+        'orig2fmap_xfm',
+        'orig2boldref_xfm',
         'anat_preproc',
         'anat_mask',
         'anat_dseg',
@@ -228,13 +246,20 @@ def init_func_fit_reports_wf(
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
     )
 
+    to_anat_xfm = pe.Node(
+        niu.Merge(2),
+        name='to_anat_xfm',
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
     # Resample anatomical references into BOLD space for plotting
     anat_boldref = pe.Node(
         ApplyTransforms(
             dimension=3,
             default_value=0,
             float=True,
-            invert_transform_flags=[True],
+            invert_transform_flags=[True, False],
             interpolation='LanczosWindowedSinc',
         ),
         name='anat_boldref',
@@ -272,8 +297,13 @@ def init_func_fit_reports_wf(
         (inputnode, anat_boldref, [
             ('anat_preproc', 'input_image'),
             ('coreg_boldref', 'reference_image'),
-            ('boldref2anat_xfm', 'transforms'),
+            # ('boldref2anat_xfm', 'transforms'),
         ]),
+        (inputnode, to_anat_xfm, [
+            ('boldref2anat_xfm', 'in1'),
+            ('orig2boldref_xfm', 'in2'),
+        ]),
+        (to_anat_xfm, anat_boldref, [('out', 'transforms')]),
         (inputnode, anat_wm, [('anat_dseg', 'in_seg')]),
         (inputnode, boldref_wm, [
             ('coreg_boldref', 'reference_image'),
@@ -295,6 +325,13 @@ def init_func_fit_reports_wf(
     #       After: Resampled boldref with white matter mask
 
     if sdc_correction:
+        to_fmap_xfm = pe.Node(
+            niu.Merge(2),
+            name='to_fmap_xfm',
+            run_without_submitting=True,
+            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+        )
+
         fmapref_boldref = pe.Node(
             ApplyTransforms(
                 dimension=3,
@@ -355,7 +392,13 @@ def init_func_fit_reports_wf(
             (inputnode, fmapref_boldref, [
                 ('fmap_ref', 'input_image'),
                 ('coreg_boldref', 'reference_image'),
-                ('boldref2fmap_xfm', 'transforms'),
+            ]),
+            (inputnode, to_fmap_xfm, [
+                ('orig2fmap_xfm', 'in1'),
+                ('orig2boldref_xfm', 'in2'),
+            ]),
+            (to_fmap_xfm, fmapref_boldref, [
+                ('out', 'transforms'),
             ]),
             (inputnode, sdcreg_report, [
                 ('sdc_boldref', 'reference'),
@@ -583,7 +626,8 @@ def init_ds_bold_native_wf(
                 't2star',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'boldref2fmap_xfm',
+                'orig2fmap_xfm',
+                'orig2boldref_xfm',
             ]
         ),
         name='inputnode',
@@ -591,7 +635,7 @@ def init_ds_bold_native_wf(
 
     sources = pe.Node(
         BIDSURI(
-            numinputs=3,
+            numinputs=4,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.output_dir.absolute()),
         ),
@@ -601,7 +645,8 @@ def init_ds_bold_native_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('boldref2fmap_xfm', 'in3'),
+            ('orig2boldref_xfm', 'in3'),
+            ('orig2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
 
@@ -731,7 +776,8 @@ def init_ds_volumes_wf(
                 'resolution',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'boldref2fmap_xfm',
+                'orig2boldref_xfm',
+                'orig2fmap_xfm',
             ]
         ),
         name='inputnode',
@@ -739,7 +785,7 @@ def init_ds_volumes_wf(
 
     sources = pe.Node(
         BIDSURI(
-            numinputs=6,
+            numinputs=7,
             dataset_links=config.execution.dataset_links,
             out_dir=str(config.execution.output_dir.absolute()),
         ),
@@ -765,10 +811,11 @@ def init_ds_volumes_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('boldref2fmap_xfm', 'in3'),
-            ('boldref2anat_xfm', 'in4'),
-            ('anat2std_xfm', 'in5'),
-            ('template', 'in6'),
+            ('orig2boldref_xfm', 'in3'),
+            ('orig2fmap_xfm', 'in4'),
+            ('boldref2anat_xfm', 'in5'),
+            ('anat2std_xfm', 'in6'),
+            ('template', 'in7'),
         ]),
         (inputnode, boldref2target, [
             # Note that ANTs expects transforms in target-to-source order

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -763,7 +763,6 @@ def init_ds_bold_session_wf(
             fields=[
                 'source_files',
                 'bold',
-                'bold_mask',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
                 'orig2session_xfm',
@@ -788,27 +787,6 @@ def init_ds_bold_session_wf(
             ('orig2session_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
         ]),
-    ])  # fmt:skip
-
-    ds_bold_mask = pe.Node(
-        DerivativesDataSink(
-            base_directory=output_dir,
-            space='session',
-            desc='brain',
-            suffix='mask',
-            compress=True,
-            dismiss_entities=DEFAULT_DISMISS_ENTITIES,
-        ),
-        name='ds_bold_mask',
-        run_without_submitting=True,
-        mem_gb=DEFAULT_MEMORY_MIN_GB,
-    )
-    workflow.connect([
-        (inputnode, ds_bold_mask, [
-            ('source_files', 'source_file'),
-            ('bold_mask', 'in_file'),
-        ]),
-        (sources, ds_bold_mask, [('out', 'Sources')]),
     ])  # fmt:skip
 
     ds_bold = pe.Node(

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -896,7 +896,6 @@ def init_ds_volumes_wf(
             ('source_files', 'source_file'),
             ('bold', 'in_file'),
             ('space', 'space'),
-            ('cohort', 'cohort'),
             ('resolution', 'resolution'),
         ]),
         (sources, ds_bold, [('out', 'Sources')]),
@@ -987,7 +986,6 @@ def init_ds_volumes_wf(
             (inputnode, datasink, [
                 ('source_files', 'source_file'),
                 ('space', 'space'),
-                ('cohort', 'cohort'),
                 ('resolution', 'resolution'),
             ])
             for datasink in datasinks

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -183,7 +183,7 @@ def init_func_fit_reports_wf(
         SDC-corrected BOLD reference image.
     boldref2anat_xfm
         BOLD reference to anatomical transform.
-        orig2boldref_xfm
+        orig2session_xfm
         Original BOLD to BOLD reference transform
     orig2fmap_xfm
         BOLD reference to fieldmap transform (optional)
@@ -207,7 +207,7 @@ def init_func_fit_reports_wf(
         'bold_mask',
         'boldref2anat_xfm',
         'orig2fmap_xfm',
-        'orig2boldref_xfm',
+        'orig2session_xfm',
         'anat_preproc',
         'anat_mask',
         'anat_dseg',
@@ -301,7 +301,7 @@ def init_func_fit_reports_wf(
         ]),
         (inputnode, to_anat_xfm, [
             ('boldref2anat_xfm', 'in1'),
-            ('orig2boldref_xfm', 'in2'),
+            ('orig2session_xfm', 'in2'),
         ]),
         (to_anat_xfm, anat_boldref, [('out', 'transforms')]),
         (inputnode, anat_wm, [('anat_dseg', 'in_seg')]),
@@ -395,7 +395,7 @@ def init_func_fit_reports_wf(
             ]),
             (inputnode, to_fmap_xfm, [
                 ('orig2fmap_xfm', 'in1'),
-                ('orig2boldref_xfm', 'in2'),
+                ('orig2session_xfm', 'in2'),
             ]),
             (to_fmap_xfm, fmapref_boldref, [
                 ('out', 'transforms'),
@@ -627,7 +627,7 @@ def init_ds_bold_native_wf(
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
                 'orig2fmap_xfm',
-                'orig2boldref_xfm',
+                'orig2session_xfm',
             ]
         ),
         name='inputnode',
@@ -645,7 +645,7 @@ def init_ds_bold_native_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('orig2boldref_xfm', 'in3'),
+            ('orig2session_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
         ]),
     ])  # fmt:skip
@@ -776,7 +776,7 @@ def init_ds_volumes_wf(
                 'resolution',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
-                'orig2boldref_xfm',
+                'orig2session_xfm',
                 'orig2fmap_xfm',
             ]
         ),
@@ -811,7 +811,7 @@ def init_ds_volumes_wf(
         (inputnode, sources, [
             ('source_files', 'in1'),
             ('motion_xfm', 'in2'),
-            ('orig2boldref_xfm', 'in3'),
+            ('orig2session_xfm', 'in3'),
             ('orig2fmap_xfm', 'in4'),
             ('boldref2anat_xfm', 'in5'),
             ('anat2std_xfm', 'in6'),

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -841,6 +841,7 @@ def init_ds_volumes_wf(
                 'anat2std_xfm',
                 # Entities
                 'space',
+                'cohort',
                 'resolution',
                 # Transforms previously used to generate the outputs
                 'motion_xfm',
@@ -895,6 +896,7 @@ def init_ds_volumes_wf(
             ('source_files', 'source_file'),
             ('bold', 'in_file'),
             ('space', 'space'),
+            ('cohort', 'cohort'),
             ('resolution', 'resolution'),
         ]),
         (sources, ds_bold, [('out', 'Sources')]),
@@ -985,6 +987,7 @@ def init_ds_volumes_wf(
             (inputnode, datasink, [
                 ('source_files', 'source_file'),
                 ('space', 'space'),
+                ('cohort', 'cohort'),
                 ('resolution', 'resolution'),
             ])
             for datasink in datasinks

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -337,7 +337,7 @@ def init_func_fit_reports_wf(
                 dimension=3,
                 default_value=0,
                 float=True,
-                invert_transform_flags=[True],
+                invert_transform_flags=[True, False],
                 interpolation='LanczosWindowedSinc',
             ),
             name='fmapref_boldref',

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -746,6 +746,96 @@ def init_ds_bold_native_wf(
     return workflow
 
 
+def init_ds_bold_session_wf(
+    *,
+    bids_root: str,
+    output_dir: str,
+    multiecho: bool,
+    all_metadata: list[dict],
+    name='ds_bold_session_wf',
+) -> pe.Workflow:
+    metadata = all_metadata[0]
+    timing_parameters = prepare_timing_parameters(metadata)
+
+    workflow = pe.Workflow(name=name)
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                'source_files',
+                'bold',
+                'bold_mask',
+                # Transforms previously used to generate the outputs
+                'motion_xfm',
+                'orig2session_xfm',
+                'orig2fmap_xfm',
+            ]
+        ),
+        name='inputnode',
+    )
+
+    sources = pe.Node(
+        BIDSURI(
+            numinputs=4,
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.output_dir.absolute()),
+        ),
+        name='sources',
+    )
+    workflow.connect([
+        (inputnode, sources, [
+            ('source_files', 'in1'),
+            ('motion_xfm', 'in2'),
+            ('orig2session_xfm', 'in3'),
+            ('orig2fmap_xfm', 'in4'),
+        ]),
+    ])  # fmt:skip
+
+    ds_bold_mask = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            space='session',
+            desc='brain',
+            suffix='mask',
+            compress=True,
+            dismiss_entities=DEFAULT_DISMISS_ENTITIES,
+        ),
+        name='ds_bold_mask',
+        run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+    workflow.connect([
+        (inputnode, ds_bold_mask, [
+            ('source_files', 'source_file'),
+            ('bold_mask', 'in_file'),
+        ]),
+        (sources, ds_bold_mask, [('out', 'Sources')]),
+    ])  # fmt:skip
+
+    ds_bold = pe.Node(
+        DerivativesDataSink(
+            base_directory=output_dir,
+            space='session',
+            desc='preproc',
+            compress=True,
+            SkullStripped=multiecho,
+            TaskName=metadata.get('TaskName'),
+            dismiss_entities=DEFAULT_DISMISS_ENTITIES,
+            **timing_parameters,
+        ),
+        name='ds_bold',
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+    workflow.connect([
+        (inputnode, ds_bold, [
+            ('source_files', 'source_file'),
+            ('bold', 'in_file'),
+        ]),
+        (sources, ds_bold, [('out', 'Sources')]),
+    ])  # fmt:skip
+
+    return workflow
+
+
 def init_ds_volumes_wf(
     *,
     bids_root: str,

--- a/nibabies/workflows/bold/session.py
+++ b/nibabies/workflows/bold/session.py
@@ -1,0 +1,140 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Session-level BOLD workflows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: init_bold_coreg_runs_wf
+
+"""
+
+from nipype.interfaces import utility as niu
+from nipype.pipeline import engine as pe
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.func.util import init_skullstrip_bold_wf
+
+
+def init_coreg_session_bolds_wf(
+    *,
+    num_bold_runs: int,
+    unbiased: bool = False,
+    omp_nthreads: int = 1,
+    name: str = 'coreg_session_bolds_wf',
+) -> Workflow:
+    """
+    Register all BOLD runs of a session to a single session-reference.
+
+    Parameters
+    ----------
+    num_bolds : :obj:`int`
+        Number of BOLD runs
+    omp_nthreads : :obj:`int`
+        Number of threads.
+    unbiased : :obj:`bool`
+        Whether to use an unbiased registration strategy (default: False).
+
+    Inputs
+    ------
+    boldref_files
+        List of BOLD reference files to be coregistered.
+
+    Outputs
+    -------
+    boldref
+        The computed session-level BOLD reference.
+    bold_mask
+        Brain mask for the session-level BOLD reference.
+    boldref_files
+        List of BOLD reference files (same as input).
+    orig2boldref_xfms
+        Transforms from each run's original space to the session boldref
+
+    """
+    from niworkflows.interfaces.freesurfer import StructuralReference
+    from niworkflows.interfaces.nitransforms import ConvertAffine
+
+    workflow = Workflow(name=name)
+    workflow.__desc__ = 'All BOLD runs were coregistered to create a session-level BOLD reference.'
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(fields=['boldref_files']),
+        name='inputnode',
+    )
+
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=['boldref', 'bold_mask', 'orig2boldref_xfms', 'boldref_files']
+        ),
+        name='outputnode',
+    )
+
+    # TODO?: Do we want to denoise as well?
+    # https://neurostars.org/t/ants-denoiseimage-for-fmri-epis/3091/2
+
+    # if len(bold_runs) == 1:
+    #     from niworkflows.data import load as niw_load
+
+    #     identity_xfm = niw_load('identity_xfm')
+    #     outputnode.inputs.orig2boldref_xfms = [identity_xfm]
+    #     return workflow
+
+    boldref_template = pe.Node(
+        StructuralReference(
+            auto_detect_sensitivity=True,
+            initial_timepoint=1,
+            intensity_scaling=False,
+            subsample_threshold=200,
+            fixed_timepoint=not unbiased,
+            no_iteration=not unbiased,
+            transform_outputs=True,
+            out_file='boldref_template.nii.gz',
+        ),
+        mem_gb=2 * num_bold_runs - 1,
+        name='boldref_template',
+        n_procs=omp_nthreads,
+    )
+
+    to_itk = pe.MapNode(
+        ConvertAffine(in_fmt='fs', out_fmt='itk'),
+        iterfield=['in_xfm'],
+        name='to_itk',
+    )
+
+    skullstrip_boldref_wf = init_skullstrip_bold_wf(name='skullstrip_boldref_wf')
+
+    workflow.connect([
+        (inputnode, boldref_template, [
+            ('boldref_files', 'in_files'),
+        ]),
+        (boldref_template, outputnode, [
+            ('out_file', 'boldref'),
+        ]),
+        (boldref_template, to_itk, [
+            ('transform_outputs', 'in_xfm'),
+        ]),
+        (to_itk, outputnode, [
+            ('out_xfm', 'orig2boldref_xfms'),
+        ]),
+        (inputnode, outputnode, [
+            ('boldref_files', 'boldref_files'),
+        ]),
+        (boldref_template, skullstrip_boldref_wf, [('out_file', 'inputnode.in_file')]),
+        (skullstrip_boldref_wf, outputnode, [('outputnode.mask_file', 'bold_mask')]),
+    ])  # fmt:skip
+
+    return workflow

--- a/nibabies/workflows/bold/session.py
+++ b/nibabies/workflows/bold/session.py
@@ -61,7 +61,7 @@ def init_coreg_session_bolds_wf(
         Brain mask for the session-level BOLD reference.
     boldref_files
         List of BOLD reference files (same as input).
-    orig2boldref_xfms
+    orig2session_xfms
         Transforms from each run's original space to the session boldref
 
     """
@@ -78,7 +78,7 @@ def init_coreg_session_bolds_wf(
 
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['boldref', 'bold_mask', 'orig2boldref_xfms', 'boldref_files']
+            fields=['boldref', 'bold_mask', 'orig2session_xfms', 'boldref_files']
         ),
         name='outputnode',
     )
@@ -90,7 +90,7 @@ def init_coreg_session_bolds_wf(
     #     from niworkflows.data import load as niw_load
 
     #     identity_xfm = niw_load('identity_xfm')
-    #     outputnode.inputs.orig2boldref_xfms = [identity_xfm]
+    #     outputnode.inputs.orig2session_xfms = [identity_xfm]
     #     return workflow
 
     boldref_template = pe.Node(
@@ -128,7 +128,7 @@ def init_coreg_session_bolds_wf(
             ('transform_outputs', 'in_xfm'),
         ]),
         (to_itk, outputnode, [
-            ('out_xfm', 'orig2boldref_xfms'),
+            ('out_xfm', 'orig2session_xfms'),
         ]),
         (inputnode, outputnode, [
             ('boldref_files', 'boldref_files'),

--- a/nibabies/workflows/bold/template.py
+++ b/nibabies/workflows/bold/template.py
@@ -75,13 +75,11 @@ def init_bold_template_wf(
         unbiased = num_bold_runs >= 3
 
     workflow = Workflow(name=name)
+    workflow.__desc__ = f'All BOLD runs ({num_bold_runs}) were coregistered to '
     if unbiased:
-        workflow.__desc__ = (
-            'All BOLD runs were coregistered to an unbiased session-level BOLD reference '
-            'using an iterative template construction strategy.'
-        )
+        workflow.__desc__ += 'an unbiased session-level BOLD reference using an iterative template construction strategy.'
     else:
-        workflow.__desc__ = "All BOLD runs were coregistered to the first run's BOLD reference."
+        workflow.__desc__ = "the first run's BOLD reference."
 
     inputnode = pe.Node(
         niu.IdentityInterface(fields=['boldref_files']),
@@ -94,9 +92,6 @@ def init_bold_template_wf(
         ),
         name='outputnode',
     )
-
-    # TODO?: Do we want to denoise as well?
-    # https://neurostars.org/t/ants-denoiseimage-for-fmri-epis/3091/2
 
     boldref_template = pe.Node(
         StructuralReference(

--- a/nibabies/workflows/bold/template.py
+++ b/nibabies/workflows/bold/template.py
@@ -65,7 +65,7 @@ def init_bold_template_wf(
     boldref_files
         List of BOLD reference files (same as input).
     orig2session_xfms
-        Transforms from each run's original space to the session boldref
+        Transforms from each run's original space to the boldref template
 
     """
     from niworkflows.interfaces.freesurfer import StructuralReference

--- a/nibabies/workflows/bold/template.py
+++ b/nibabies/workflows/bold/template.py
@@ -64,7 +64,7 @@ def init_bold_template_wf(
         Brain mask for the session-level BOLD reference.
     boldref_files
         List of BOLD reference files (same as input).
-    orig2session_xfms
+    run2boldref_xfms
         Transforms from each run's original space to the boldref template
 
     """
@@ -90,7 +90,7 @@ def init_bold_template_wf(
 
     outputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['boldref', 'bold_mask', 'orig2session_xfms', 'boldref_files']
+            fields=['boldref', 'bold_mask', 'run2boldref_xfms', 'boldref_files']
         ),
         name='outputnode',
     )
@@ -133,7 +133,7 @@ def init_bold_template_wf(
             ('transform_outputs', 'in_xfm'),
         ]),
         (to_itk, outputnode, [
-            ('out_xfm', 'orig2session_xfms'),
+            ('out_xfm', 'run2boldref_xfms'),
         ]),
         (inputnode, outputnode, [
             ('boldref_files', 'boldref_files'),

--- a/nibabies/workflows/bold/template.py
+++ b/nibabies/workflows/bold/template.py
@@ -32,7 +32,7 @@ from niworkflows.func.util import init_skullstrip_bold_wf
 def init_bold_template_wf(
     *,
     num_bold_runs: int,
-    unbiased: bool = False,
+    unbiased: bool | None = None,
     omp_nthreads: int = 1,
     name: str = 'bold_template_wf',
 ) -> Workflow:
@@ -41,12 +41,15 @@ def init_bold_template_wf(
 
     Parameters
     ----------
-    num_bolds : :obj:`int`
-        Number of BOLD runs
+    num_bold_runs : :obj:`int`
+        Number of BOLD runs.
     omp_nthreads : :obj:`int`
         Number of threads.
-    unbiased : :obj:`bool`
-        Whether to use an unbiased registration strategy (default: False).
+    unbiased : :obj:`bool` or None
+        Whether to use an unbiased (iterative) registration strategy.
+        When ``None`` (default), the strategy is chosen automatically:
+        ``False`` (fixed first run as reference) for 2 runs, ``True``
+        (iterative mean-shape template) for 3 or more runs.
 
     Inputs
     ------
@@ -68,8 +71,17 @@ def init_bold_template_wf(
     from niworkflows.interfaces.freesurfer import StructuralReference
     from niworkflows.interfaces.nitransforms import ConvertAffine
 
+    if unbiased is None:
+        unbiased = num_bold_runs >= 3
+
     workflow = Workflow(name=name)
-    workflow.__desc__ = 'All BOLD runs were coregistered to create a session-level BOLD reference.'
+    if unbiased:
+        workflow.__desc__ = (
+            'All BOLD runs were coregistered to an unbiased session-level BOLD reference '
+            'using an iterative template construction strategy.'
+        )
+    else:
+        workflow.__desc__ = "All BOLD runs were coregistered to the first run's BOLD reference."
 
     inputnode = pe.Node(
         niu.IdentityInterface(fields=['boldref_files']),
@@ -85,13 +97,6 @@ def init_bold_template_wf(
 
     # TODO?: Do we want to denoise as well?
     # https://neurostars.org/t/ants-denoiseimage-for-fmri-epis/3091/2
-
-    # if len(bold_runs) == 1:
-    #     from niworkflows.data import load as niw_load
-
-    #     identity_xfm = niw_load('identity_xfm')
-    #     outputnode.inputs.orig2session_xfms = [identity_xfm]
-    #     return workflow
 
     boldref_template = pe.Node(
         StructuralReference(

--- a/nibabies/workflows/bold/template.py
+++ b/nibabies/workflows/bold/template.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 #
 """
-Session-level BOLD workflows
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+BOLD template creation workflow.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: init_bold_coreg_runs_wf
+.. autofunction:: init_bold_template_wf
 
 """
 
@@ -29,15 +29,15 @@ from niworkflows.engine.workflows import LiterateWorkflow as Workflow
 from niworkflows.func.util import init_skullstrip_bold_wf
 
 
-def init_coreg_session_bolds_wf(
+def init_bold_template_wf(
     *,
     num_bold_runs: int,
     unbiased: bool = False,
     omp_nthreads: int = 1,
-    name: str = 'coreg_session_bolds_wf',
+    name: str = 'bold_template_wf',
 ) -> Workflow:
     """
-    Register all BOLD runs of a session to a single session-reference.
+    Register all BOLD runs to a common template reference.
 
     Parameters
     ----------

--- a/nibabies/workflows/tests/test_base.py
+++ b/nibabies/workflows/tests/test_base.py
@@ -142,6 +142,7 @@ def _make_params(
     multi_step_reg: bool = True,
     hmc_bold_frame: int | str = 16,
     output_spaces: str | None = None,
+    bold_coreg_level: str = 'run',
 ):
     if ignore is None:
         ignore = []
@@ -166,6 +167,7 @@ def _make_params(
         multi_step_reg,
         hmc_bold_frame,
         output_spaces,
+        bold_coreg_level,
     )
 
 
@@ -197,6 +199,7 @@ def _patch_output_spaces(output_spaces: str | None):
         'multi_step_reg',
         'hmc_bold_frame',
         'output_spaces',
+        'bold_coreg_level',
     ),
     [
         _make_params(),
@@ -232,9 +235,9 @@ def _patch_output_spaces(output_spaces: str | None):
         # Regression test for gh-3154:
         _make_params(bids_filters={'sbref': {'suffix': 'sbref'}}),
         _make_params(norm_csf=True),
-        _make_params(multi_step_reg=True),
         _make_params(multi_step_reg=False),
         _make_params(hmc_bold_frame='auto'),
+        _make_params(bold_coreg_level='session'),
     ],
 )
 def test_init_nibabies_wf(
@@ -261,6 +264,7 @@ def test_init_nibabies_wf(
     multi_step_reg: bool,
     hmc_bold_frame: int | str,
     output_spaces: str | None,
+    bold_coreg_level: str,
 ):
     monkeypatch.setenv('SUBJECTS_DIR', '/opt/freesurfer/subjects')
     with mock_config(bids_dir=bids_root):
@@ -274,6 +278,7 @@ def test_init_nibabies_wf(
         config.workflow.project_goodvoxels = project_goodvoxels
         config.workflow.norm_csf = norm_csf
         config.workflow.multi_step_reg = multi_step_reg
+        config.workflow.bold_coreg_level = bold_coreg_level
         # config.workflow.run_msmsulc = run_msmsulc
         config.workflow.skull_strip_anat = skull_strip_anat
         config.workflow.cifti_output = cifti_output


### PR DESCRIPTION
Replaces #517 

Adds `--bold-coreg-level`, which allows setting the BOLD coregistration level as either: `run` (current behavior, a separate reference image is calculated and registered to the anatomical reference independently for each run) or `session` (all run-level BOLD references within a session are combined into a session template before registering to anatomical).