### PR TITLE
Clarify help text for memory limit argument

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -311,7 +311,7 @@ NiBabies: Preprocessing workflows for infants v{config.environment.version}"""
         dest='memory_gb',
         action='store',
         type=_to_gb,
-        help='upper bound memory limit for NiBabies processes',
+        help='upper bound memory limit for NiBabies processes, in megabytes',
     )
     g_perfm.add_argument(
         '--low-mem',


### PR DESCRIPTION
this always caused a bit of confusion for me so I just added an explicit statement saying this should be MB