### PR TITLE
ENH: Add toggle for SVG compression

### DIFF
--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -370,6 +370,13 @@ NiBabies: Preprocessing workflows for infants v{config.environment.version}"""
         help='treat dataset as longitudinal - may increase runtime',
     )
     g_conf.add_argument(
+        '--compress-svgs',
+        action=BooleanOptionalAction,
+        default=True,
+        help='Compress reportlet SVGs to reduce report size (only viewable in a browser). '
+        'Use --no-compress-svgs to keep SVGs universally viewable.',
+    )
+    g_conf.add_argument(
         '--output-spaces',
         nargs='*',
         action=OutputReferencesAction,

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -367,6 +367,8 @@ class execution(_Config):
     """A dictionary of BIDS selection filters."""
     boilerplate_only = False
     """Only generate a boilerplate."""
+    compress_svgs = True
+    """Compress reportlet SVGs to reduce report size (only viewable in a browser)."""
     copy_derivatives = False
     """Copy any found derivatives into the output directory."""
     sloppy = False

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -609,7 +609,7 @@ It is released under the [CC0]\
             ])  # fmt:skip
 
     if config.workflow.anat_only:
-        return clean_datasinks(workflow)
+        return configure_workflow(workflow)
 
     fmap_estimators, estimator_map = map_fieldmap_estimation(
         layout=config.execution.layout,
@@ -1100,7 +1100,7 @@ tasks and sessions), the following preprocessing was performed.
                     ]),
                 ])  # fmt:skip
 
-    return clean_datasinks(workflow)
+    return configure_workflow(workflow)
 
 
 def _subject_session_id(subject_id: str, session_id: str | None) -> str:
@@ -1121,15 +1121,28 @@ def _subject_session_id(subject_id: str, session_id: str | None) -> str:
     return '_'.join(entities)
 
 
-def clean_datasinks(workflow: pe.Workflow) -> pe.Workflow:
-    # Overwrite ``out_path_base`` of smriprep's DataSinks
-    for node in workflow.list_node_names():
-        if node.split('.')[-1].startswith('ds_'):
-            workflow.get_node(node).interface.out_path_base = ''
-            workflow.get_node(node).interface.inputs.base_directory = config.execution.nibabies_dir
+def configure_workflow(workflow: pe.Workflow) -> pe.Workflow:
+    """
+    Per-node configuration of a workflow once constructed.
+
+    Specifically:
+    - Alters DataSink nodes to write to output directory
+    - Adds config hash to DataSink nodes if multiverse layout is requested
+    - Compress SVG reportlets if requested and supported
+    """
+    compress = 'auto' if config.execution.compress_svgs else False
+    for node in workflow._get_all_nodes():
+        # Overwrite ``out_path_base`` of smriprep's DataSinks
+        if node.name.startswith('ds_'):
+            node.interface.out_path_base = ''
+            node.interface.inputs.base_directory = config.execution.nibabies_dir
 
             if config.execution.output_layout == 'multiverse':
-                workflow.get_node(node).interface.inputs.hash = config.execution.parameters_hash
+                node.interface.inputs.hash = config.execution.parameters_hash
+
+        # Reportlet-generating nodes expose ``compress_report`` regardless of node name
+        if 'compress_report' in node.interface.inputs.traits():
+            node.interface.inputs.compress_report = compress
     return workflow
 
 

--- a/nibabies/workflows/tests/test_base.py
+++ b/nibabies/workflows/tests/test_base.py
@@ -388,3 +388,31 @@ def test_get_estimator_multiple_b0fields(tmp_path):
     # Always get an iterable; don't care if it's a list or tuple
     assert get_estimator(layout, bold_files[0]) == ['epi', 'phasediff']
     assert get_estimator(layout, bold_files[1]) == ('epi',)
+
+
+@pytest.mark.parametrize(
+    ('compress_svgs', 'expected'),
+    [(True, 'auto'), (False, False)],
+)
+def test_configure_workflow_compress_svgs(compress_svgs, expected):
+    """``configure_workflow`` propagates the compress-svgs switch to reportlet nodes."""
+    import nipype.pipeline.engine as pe
+    from nipype.interfaces import utility as niu
+    from nireports.interfaces.reporting.base import SimpleBeforeAfterRPT
+
+    from ..base import configure_workflow
+
+    wf = pe.Workflow(name='test_compress_svgs')
+    wf.add_nodes(
+        [
+            pe.Node(SimpleBeforeAfterRPT(), name='rpt'),
+            pe.Node(niu.IdentityInterface(fields=['x']), name='plain'),
+        ]
+    )
+
+    with patch.object(config.execution, 'compress_svgs', compress_svgs):
+        configure_workflow(wf)
+
+    assert wf.get_node('rpt').interface.inputs.compress_report == expected
+    # Nodes without the trait are left untouched
+    assert 'compress_report' not in wf.get_node('plain').interface.inputs.traits()


### PR DESCRIPTION
Raised in https://github.com/nipreps/nibabies/discussions/504

This adds a new flag `--[no-]compress-svgs` that [dis/en]ables SVG compression (and png -> webp conversion). Disable to make reports universally viewable.