### PR TITLE
enh: add msm sulc workflow

### DIFF
--- a/.circleci/bcp_anat_outputs.txt
+++ b/.circleci/bcp_anat_outputs.txt
@@ -26,6 +26,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_desc-cortex_mask.label.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_inflated.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_pial.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_sphere.surf.gii
@@ -38,6 +39,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_desc-cortex_mask.label.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_inflated.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_pial.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_sphere.surf.gii

--- a/.circleci/bcp_anat_t2only_outputs.txt
+++ b/.circleci/bcp_anat_t2only_outputs.txt
@@ -27,6 +27,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_pial.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_den-32k_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_den-32k_pial.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_den-32k_white.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_sphere.surf.gii
@@ -42,6 +43,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_pial.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_den-32k_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_den-32k_pial.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_den-32k_white.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_sphere.surf.gii

--- a/.circleci/bcp_full_outputs.txt
+++ b/.circleci/bcp_full_outputs.txt
@@ -26,6 +26,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_desc-cortex_mask.label.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_inflated.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_pial.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-L_sphere.surf.gii
@@ -38,6 +39,7 @@ sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_desc-cortex_mask.label.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_inflated.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_midthickness.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_pial.surf.gii
+sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-msmsulc_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsLR_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_space-fsaverage_desc-reg_sphere.surf.gii
 sub-01/ses-1mo/anat/sub-01_ses-1mo_run-001_hemi-R_sphere.surf.gii

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,11 @@ RUN mkdir -p /opt/afni-latest \
         -name "3dAutomask" -or \
         -name "3dvolreg" \) -delete
 
+# MSM HOCR (Nov 19, 2019 release)
+FROM downloader AS msm
+RUN curl -L -H "Accept: application/octet-stream" https://api.github.com/repos/ecr05/MSM_HOCR/releases/assets/16253707 -o /usr/local/bin/msm \
+    && chmod +x /usr/local/bin/msm
+
 # Main container
 FROM ${BASE_IMAGE} AS nibabies
 ENV DEBIAN_FRONTEND="noninteractive" \
@@ -168,6 +173,9 @@ RUN apt-get update -qq \
     && ldconfig
 
 COPY --from=afni /opt/afni-latest /opt/afni-latest
+
+# MSM HOCR
+COPY --from=msm /usr/local/bin/msm /usr/local/bin/msm
 
 # AFNI config
 ENV PATH="/opt/afni-latest:$PATH" \

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -148,13 +148,15 @@ sub-<subject_label>/[ses-<session_label>/]
     sub-<subject_label>_hemi-[LR]_pial.surf.gii
     sub-<subject_label>_hemi-[LR]_desc-reg_sphere.surf.gii
     sub-<subject_label>_hemi-[LR]_space-fsLR_desc-reg_sphere.surf.gii
+    sub-<subject_label>_hemi-[LR]_space-fsLR_desc-msmsulc_sphere.surf.gii
 ```
 
 The registration spheres target `fsaverage` and `fsLR` spaces.
 
-:::{warning}
-Unlike fMRIPrep, MSMSulc support is not available at the moment.
-:::
+When MSM-sulc registration is enabled (default, disable with `--no-msm`), an
+additional `desc-msmsulc` sphere is generated that refines the `fsLR` registration
+by driving the subject's sulcal depth onto the `fsLR` reference. It is used as the
+registration sphere for all downstream `fsLR` resampling.
 
 And the affine translation (and inverse) between the anatomical reference sampling and
 FreeSurfer's conformed space for surface reconstruction (`fsnative`) is stored in::

--- a/nibabies/cli/parser.py
+++ b/nibabies/cli/parser.py
@@ -612,6 +612,13 @@ Useful for further Tedana processing post-NiBabies.""",
         dest='hires',
         help='disable sub-millimeter (hires) reconstruction',
     )
+    g_surfs.add_argument(
+        '--msm',
+        action=BooleanOptionalAction,
+        default=True,
+        dest='msm_sulc',
+        help='Enable MSM-sulc surface registration to fsLR (default: enabled)',
+    )
     g_surfs_xor = g_surfs.add_mutually_exclusive_group()
     g_surfs_xor.add_argument(
         '--cifti-output',

--- a/nibabies/config.py
+++ b/nibabies/config.py
@@ -588,6 +588,8 @@ class workflow(_Config):
     """Run FreeSurfer ``recon-all`` with the ``-logitudinal`` flag."""
     medial_surface_nan = None
     """Fill medial surface with :abbr:`NaNs (not-a-number)` when sampling."""
+    msm_sulc = True
+    """Run Multimodal Surface Matching registration of the sulcal depth to fsLR."""
     multi_step_reg = True
     """Perform multiple registrations (native -> MNIInfant -> template) and concatenate into a
     single transform"""
@@ -837,6 +839,7 @@ DEFAULT_CONFIG_HASH_FIELDS = {
         'hmc_bold_frame',
         'longitudinal',
         'medial_surface_nan',
+        'msm_sulc',
         'multi_step_reg',
         'norm_csf',
         'project_goodvoxels',

--- a/nibabies/tests/test_config.py
+++ b/nibabies/tests/test_config.py
@@ -150,7 +150,7 @@ def _load_spaces(age):
 
 def test_hash_config():
     # This may change with changes to config defaults / new attributes!
-    expected = '84226605'
+    expected = '09e9058e'
     assert config.hash_config(config.get()) == expected
     _reset_config()
 

--- a/nibabies/workflows/anatomical/fit.py
+++ b/nibabies/workflows/anatomical/fit.py
@@ -33,6 +33,7 @@ from smriprep.workflows.surfaces import (
     init_fsLR_reg_wf,
     init_gifti_morphometrics_wf,
     init_gifti_surfaces_wf,
+    init_msm_sulc_wf,
     init_refinement_wf,
 )
 
@@ -1392,6 +1393,34 @@ def init_infant_anat_fit_wf(
         LOGGER.info('ANAT Stage 9: Found pre-computed fsLR registration sphere')
         fsLR_buffer.inputs.sphere_reg_fsLR = sorted(precomputed['sphere_reg_fsLR'])
 
+    # Stage 9b: MSMSulc refinement of the fsLR registration sphere
+    if msm_sulc and len(precomputed.get('sphere_reg_msm', [])) < 2:
+        LOGGER.info('ANAT Stage 9b: Running MSMSulc registration')
+        msm_sulc_wf = init_msm_sulc_wf(sloppy=config.execution.sloppy)
+        ds_msmsulc_wf = init_ds_surfaces_wf(
+            output_dir=output_dir,
+            surfaces=['sphere_reg_msm'],
+            name='ds_msmsulc_wf',
+        )
+
+        workflow.connect([
+            (surfaces_buffer, msm_sulc_wf, [
+                ('sphere', 'inputnode.sphere'),
+                ('sulc', 'inputnode.sulc'),
+            ]),
+            (fsLR_buffer, msm_sulc_wf, [('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR')]),
+            (sourcefile_buffer, ds_msmsulc_wf, [('anat_source_files', 'inputnode.source_files')]),
+            (msm_sulc_wf, ds_msmsulc_wf, [
+                ('outputnode.sphere_reg_fsLR', 'inputnode.sphere_reg_msm')
+            ]),
+            (ds_msmsulc_wf, msm_buffer, [('outputnode.sphere_reg_msm', 'sphere_reg_msm')]),
+        ])  # fmt:skip
+    elif msm_sulc:
+        LOGGER.info('ANAT Stage 9b: Found pre-computed MSMSulc registration sphere')
+        msm_buffer.inputs.sphere_reg_msm = sorted(precomputed['sphere_reg_msm'])
+    else:
+        LOGGER.info('ANAT Stage 9b: MSMSulc disabled')
+
     # Stage 10: Cortical surface mask
     if len(precomputed.get('cortex_mask', [])) < 2:
         LOGGER.info('ANAT Stage 11: Creating cortical surface mask')
@@ -2324,6 +2353,34 @@ def init_infant_single_anat_fit_wf(
     else:
         LOGGER.info('ANAT Stage 9: Found pre-computed fsLR registration sphere')
         fsLR_buffer.inputs.sphere_reg_fsLR = sorted(precomputed['sphere_reg_fsLR'])
+
+    # Stage 9b: MSMSulc refinement of the fsLR registration sphere
+    if msm_sulc and len(precomputed.get('sphere_reg_msm', [])) < 2:
+        LOGGER.info('ANAT Stage 9b: Running MSMSulc registration')
+        msm_sulc_wf = init_msm_sulc_wf(sloppy=config.execution.sloppy)
+        ds_msmsulc_wf = init_ds_surfaces_wf(
+            output_dir=output_dir,
+            surfaces=['sphere_reg_msm'],
+            name='ds_msmsulc_wf',
+        )
+
+        workflow.connect([
+            (surfaces_buffer, msm_sulc_wf, [
+                ('sphere', 'inputnode.sphere'),
+                ('sulc', 'inputnode.sulc'),
+            ]),
+            (fsLR_buffer, msm_sulc_wf, [('sphere_reg_fsLR', 'inputnode.sphere_reg_fsLR')]),
+            (sourcefile_buffer, ds_msmsulc_wf, [('anat_source_files', 'inputnode.source_files')]),
+            (msm_sulc_wf, ds_msmsulc_wf, [
+                ('outputnode.sphere_reg_fsLR', 'inputnode.sphere_reg_msm')
+            ]),
+            (ds_msmsulc_wf, msm_buffer, [('outputnode.sphere_reg_msm', 'sphere_reg_msm')]),
+        ])  # fmt:skip
+    elif msm_sulc:
+        LOGGER.info('ANAT Stage 9b: Found pre-computed MSMSulc registration sphere')
+        msm_buffer.inputs.sphere_reg_msm = sorted(precomputed['sphere_reg_msm'])
+    else:
+        LOGGER.info('ANAT Stage 9b: MSMSulc disabled')
 
     # Stage 10: Cortical surface mask
     if len(precomputed.get('cortex_mask', [])) < 2:

--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -326,7 +326,7 @@ It is released under the [CC0]\
         )
 
     recon_method = config.workflow.surface_recon_method
-    msm_sulc = False
+    msm_sulc = config.workflow.msm_sulc
 
     anatomical_cache = {}
     if config.execution.derivatives:


### PR DESCRIPTION
Reimplementation of #313

After #557, all reconstruction methods register to fsLR, making this theoretically universal