### PR TITLE
fix: additional bold reference clean up

### DIFF
--- a/nibabies/workflows/base.py
+++ b/nibabies/workflows/base.py
@@ -814,9 +814,6 @@ tasks and sessions), the following preprocessing was performed.
     merge_fit_boldrefs = pe.Node(
         niu.Merge(n_runs), name='merge_fit_boldrefs', run_without_submitting=True
     )
-    merge_fit_masks = pe.Node(
-        niu.Merge(n_runs), name='merge_fit_masks', run_without_submitting=True
-    )
 
     workflow.connect([
         (anat_fit_wf, bold_anat_coreg_wf, [
@@ -829,7 +826,6 @@ tasks and sessions), the following preprocessing was performed.
             ('outputnode.fsnative2anat_xfm', 'inputnode.fsnative2anat_xfm'),
         ]),
         (merge_fit_boldrefs, bold_anat_coreg_wf, [('out', 'inputnode.run_boldrefs')]),
-        (merge_fit_masks, bold_anat_coreg_wf, [('out', 'inputnode.run_masks')]),
     ])  # fmt:skip
 
     for i, bold_series in enumerate(bold_runs):
@@ -859,10 +855,9 @@ tasks and sessions), the following preprocessing was performed.
                     'bold_file',
                     'template2anat_xfm',
                     'run2template_xfm',
-                    'coreg_boldref',
-                    'bold_mask',
+                    'template_boldref',
                     'run_boldref',
-                    'orig_bold_mask',
+                    'run_mask',
                     'run2anat_xfm',
                     'boldref_template',
                 ],
@@ -919,8 +914,8 @@ tasks and sessions), the following preprocessing was performed.
             ]),
             (boldref_buffer, func_fit_reports_wf, [
                 ('bold_file', 'inputnode.source_file'),
-                ('coreg_boldref', 'inputnode.coreg_boldref'),
-                ('bold_mask', 'inputnode.bold_mask'),
+                ('run_boldref', 'inputnode.run_boldref'),
+                ('run_mask', 'inputnode.run_mask'),
                 ('run2template_xfm', 'inputnode.run2template_xfm'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
             ]),
@@ -961,13 +956,10 @@ tasks and sessions), the following preprocessing was performed.
 
         # Feed this run's fit reference/mask into the shared coregistration wf and
         # fan its matched per-run list outputs back into boldref_buffer.
-        select_coreg_boldref = pe.Node(
+        select_template_boldref = pe.Node(
             niu.Select(index=i),
-            name=f'select_coreg_boldref_{bold_id}',
+            name=f'select_template_boldref_{bold_id}',
             run_without_submitting=True,
-        )
-        select_bold_mask = pe.Node(
-            niu.Select(index=i), name=f'select_bold_mask_{bold_id}', run_without_submitting=True
         )
         select_run2template = pe.Node(
             niu.Select(index=i), name=f'select_run2template_{bold_id}', run_without_submitting=True
@@ -985,21 +977,18 @@ tasks and sessions), the following preprocessing was performed.
         )
 
         workflow.connect([
-            (bold_fit_wf, merge_fit_boldrefs, [('outputnode.coreg_boldref', f'in{i + 1}')]),
-            (bold_fit_wf, merge_fit_masks, [('outputnode.bold_mask', f'in{i + 1}')]),
-            # run_boldref/orig_bold_mask are the run's own fit outputs
+            (bold_fit_wf, merge_fit_boldrefs, [('outputnode.run_boldref', f'in{i + 1}')]),
+            # run_boldref/run_mask are the run's own fit outputs
             (bold_fit_wf, boldref_buffer, [
-                ('outputnode.coreg_boldref', 'run_boldref'),
-                ('outputnode.bold_mask', 'orig_bold_mask'),
+                ('outputnode.run_boldref', 'run_boldref'),
+                ('outputnode.run_mask', 'run_mask'),
             ]),
-            (bold_anat_coreg_wf, select_coreg_boldref, [('outputnode.coreg_boldrefs', 'inlist')]),
-            (bold_anat_coreg_wf, select_bold_mask, [('outputnode.bold_masks', 'inlist')]),
+            (bold_anat_coreg_wf, select_template_boldref, [('outputnode.template_boldrefs', 'inlist')]),
             (bold_anat_coreg_wf, select_run2template, [('outputnode.run2template_xfms', 'inlist')]),
             (bold_anat_coreg_wf, select_template2anat, [('outputnode.template2anat_xfms', 'inlist')]),
             (bold_anat_coreg_wf, select_run2anat, [('outputnode.run2anat_xfms', 'inlist')]),
             (bold_anat_coreg_wf, select_fallback, [('outputnode.fallbacks', 'inlist')]),
-            (select_coreg_boldref, boldref_buffer, [('out', 'coreg_boldref')]),
-            (select_bold_mask, boldref_buffer, [('out', 'bold_mask')]),
+            (select_template_boldref, boldref_buffer, [('out', 'template_boldref')]),
             (select_run2template, boldref_buffer, [('out', 'run2template_xfm')]),
             (select_template2anat, boldref_buffer, [('out', 'template2anat_xfm')]),
             (select_run2anat, boldref_buffer, [('out', 'run2anat_xfm')]),
@@ -1040,8 +1029,7 @@ tasks and sessions), the following preprocessing was performed.
                 (f'outputnode.{reg_sphere}', 'inputnode.sphere_reg_fsLR'),
             ]),
             (bold_fit_wf, bold_apply_wf, [
-                # ('outputnode.coreg_boldref', 'inputnode.coreg_boldref'),
-                # ('outputnode.bold_mask', 'inputnode.bold_mask'),
+                ('outputnode.hmc_boldref', 'inputnode.hmc_boldref'),
                 ('outputnode.motion_xfm', 'inputnode.motion_xfm'),
                 ('outputnode.run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('outputnode.dummy_scans', 'inputnode.dummy_scans'),
@@ -1049,10 +1037,9 @@ tasks and sessions), the following preprocessing was performed.
             (boldref_buffer, bold_apply_wf, [
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
                 ('run2template_xfm', 'inputnode.run2template_xfm'),
-                ('coreg_boldref', 'inputnode.coreg_boldref'),
-                ('bold_mask', 'inputnode.bold_mask'),
+                ('template_boldref', 'inputnode.template_boldref'),
                 ('run_boldref', 'inputnode.run_boldref'),
-                ('orig_bold_mask', 'inputnode.orig_bold_mask'),
+                ('run_mask', 'inputnode.run_mask'),
                 ('run2anat_xfm', 'inputnode.run2anat_xfm'),
                 ('boldref_template', 'inputnode.boldref_template'),
             ]),

--- a/nibabies/workflows/bold/apply.py
+++ b/nibabies/workflows/bold/apply.py
@@ -53,7 +53,7 @@ def init_bold_volumetric_resample_wf(
     ------
     bold_file
         BOLD series to resample.
-    bold_ref_file
+    run_boldref
         Reference image to which BOLD series is aligned.
     target_ref_file
         Reference image defining the target space.
@@ -61,16 +61,16 @@ def init_bold_volumetric_resample_wf(
         Brain mask corresponding to ``target_ref_file``.
         This is used to define the field of view for the resampled BOLD series.
     motion_xfm
-        List of affine transforms aligning each volume to ``bold_ref_file``.
+        List of affine transforms aligning each volume to ``run_boldref``.
         If undefined, no motion correction is performed.
     run2fmap_xfm
-        Affine transform from ``bold_ref_file`` to the fieldmap reference image.
+        Affine transform from ``run_boldref`` to the fieldmap reference image.
     fmap_ref
         Fieldmap reference image defining the valid field of view for the fieldmap.
     fmap_coeff
         B-Spline coefficients for the fieldmap.
     template2anat_xfm
-        Affine transform from ``bold_ref_file`` to the anatomical reference image.
+        Affine transform from template BOLD reference to the anatomical reference image.
     anat2std_xfm
         Affine transform from the anatomical reference image to standard space.
         Leave undefined to resample to anatomical reference space.
@@ -93,7 +93,7 @@ def init_bold_volumetric_resample_wf(
         niu.IdentityInterface(
             fields=[
                 'bold_file',
-                'bold_ref_file',
+                'run_boldref',
                 'target_ref_file',
                 'target_mask',
                 # HMC
@@ -133,7 +133,7 @@ def init_bold_volumetric_resample_wf(
 
     workflow.connect([
         (inputnode, gen_ref, [
-            ('bold_ref_file', 'moving_image'),
+            ('run_boldref', 'moving_image'),
             ('target_ref_file', 'fixed_image'),
             ('target_mask', 'fov_mask'),
             (('resolution', _is_native), 'keep_native'),

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -180,11 +180,11 @@ def init_bold_apply_wf(
         niu.IdentityInterface(
             fields=[
                 # Fit outputs
-                'coreg_boldref',
+                'template_boldref',
                 'boldref_template',
-                'bold_mask',
                 'run_boldref',
-                'orig_bold_mask',
+                'run_mask',
+                'hmc_boldref',
                 'run2anat_xfm',
                 'motion_xfm',
                 'run2fmap_xfm',
@@ -250,7 +250,7 @@ def init_bold_apply_wf(
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
             ('run_boldref', 'inputnode.run_boldref'),
-            ('bold_mask', 'inputnode.bold_mask'),
+            ('run_mask', 'inputnode.run_mask'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ('dummy_scans', 'inputnode.dummy_scans'),
@@ -279,7 +279,7 @@ def init_bold_apply_wf(
                 ('outputnode.t2star_map', 'inputnode.t2star'),
             ]),
             (inputnode, ds_bold_native_wf, [
-                ('orig_bold_mask', 'inputnode.bold_mask'),
+                ('run_mask', 'inputnode.bold_mask'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('run2template_xfm', 'inputnode.run2template_xfm'),
@@ -354,7 +354,7 @@ def init_bold_apply_wf(
             (inputnode, t2s_reporting_wf, [
                 ('anat_dseg', 'inputnode.label_file'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
-                ('coreg_boldref', 'inputnode.boldref'),
+                ('template_boldref', 'inputnode.boldref'),
             ]),
             (bold_native_wf, t2s_reporting_wf, [
                 ('outputnode.t2star_map', 'inputnode.t2star_file'),
@@ -388,7 +388,7 @@ def init_bold_apply_wf(
             ('anat_mask', 'inputnode.target_mask'),
             ('fmap_ref', 'inputnode.fmap_ref'),
             ('fmap_coeff', 'inputnode.fmap_coeff'),
-            ('coreg_boldref', 'inputnode.bold_ref_file'),
+            ('run_boldref', 'inputnode.run_boldref'),
             ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
             ('template2anat_xfm', 'inputnode.template2anat_xfm'),
             ('run2template_xfm', 'inputnode.run2template_xfm'),
@@ -413,8 +413,8 @@ def init_bold_apply_wf(
 
         workflow.connect([
             (inputnode, ds_bold_anat_wf, [
-                ('bold_mask', 'inputnode.bold_mask'),
-                ('coreg_boldref', 'inputnode.bold_ref'),
+                ('run_mask', 'inputnode.run_mask'),
+                ('run_boldref', 'inputnode.run_boldref'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
@@ -456,7 +456,7 @@ def init_bold_apply_wf(
                 ('std_resolution', 'inputnode.resolution'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
-                ('coreg_boldref', 'inputnode.bold_ref_file'),
+                ('run_boldref', 'inputnode.run_boldref'),
                 ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
                 ('run2template_xfm', 'inputnode.run2template_xfm'),
@@ -471,8 +471,8 @@ def init_bold_apply_wf(
                 ('std_space', 'inputnode.space'),
                 ('std_resolution', 'inputnode.resolution'),
                 ('std_cohort', 'inputnode.cohort'),
-                ('bold_mask', 'inputnode.bold_mask'),
-                ('coreg_boldref', 'inputnode.bold_ref'),
+                ('run_mask', 'inputnode.run_mask'),
+                ('run_boldref', 'inputnode.run_boldref'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
                 ('motion_xfm', 'inputnode.motion_xfm'),
                 ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
@@ -617,7 +617,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
                 ('anat2mniinfant_xfm', 'inputnode.anat2std_xfm'),
                 ('fmap_ref', 'inputnode.fmap_ref'),
                 ('fmap_coeff', 'inputnode.fmap_coeff'),
-                ('coreg_boldref', 'inputnode.bold_ref_file'),
+                ('run_boldref', 'inputnode.run_boldref'),
                 ('run2fmap_xfm', 'inputnode.run2fmap_xfm'),
                 ('template2anat_xfm', 'inputnode.template2anat_xfm'),
                 ('run2template_xfm', 'inputnode.run2template_xfm'),
@@ -718,8 +718,8 @@ excluding voxels whose time-series have a locally high coefficient of variation.
         (inputnode, bold_confounds_wf, [
             ('anat_tpms', 'inputnode.anat_tpms'),
             ('anat_mask', 'inputnode.anat_mask'),
-            ('orig_bold_mask', 'inputnode.bold_mask'),
-            ('run_boldref', 'inputnode.hmc_boldref'),
+            ('run_mask', 'inputnode.run_mask'),
+            ('hmc_boldref', 'inputnode.hmc_boldref'),
             ('motion_xfm', 'inputnode.motion_xfm'),
             ('run2anat_xfm', 'inputnode.template2anat_xfm'),
             ('dummy_scans', 'inputnode.skip_vols'),
@@ -751,7 +751,7 @@ excluding voxels whose time-series have a locally high coefficient of variation.
             ]),
             (inputnode, carpetplot_wf, [
                 ('dummy_scans', 'inputnode.dummy_scans'),
-                ('orig_bold_mask', 'inputnode.bold_mask'),
+                ('run_mask', 'inputnode.bold_mask'),
                 ('run2anat_xfm', 'inputnode.template2anat_xfm'),
             ]),
             (bold_native_wf, carpetplot_wf, [

--- a/nibabies/workflows/bold/confounds.py
+++ b/nibabies/workflows/bold/confounds.py
@@ -121,7 +121,7 @@ def init_bold_confs_wf(
     bold
         BOLD image, after the prescribed corrections (STC, HMC and SDC)
         when available.
-    bold_mask
+    run_mask
         BOLD series mask
     motion_xfm
         ITK-formatted head motion transforms
@@ -223,7 +223,7 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         niu.IdentityInterface(
             fields=[
                 'bold',
-                'bold_mask',
+                'run_mask',
                 'motion_xfm',
                 'hmc_boldref',
                 'skip_vols',
@@ -525,7 +525,7 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
     workflow.connect([
         # connect inputnode to each non-anatomical confound node
         (inputnode, dvars, [('bold', 'in_file'),
-                            ('bold_mask', 'in_mask')]),
+                            ('run_mask', 'in_mask')]),
         (inputnode, motion_params, [('motion_xfm', 'xfm_file'),
                                     ('hmc_boldref', 'boldref_file')]),
         (inputnode, rmsd, [('motion_xfm', 'xfm_file'),
@@ -533,9 +533,9 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         (motion_params, fdisp, [('out_file', 'in_file')]),
         # Brain mask
         (inputnode, anat_mask_tfm, [('anat_mask', 'input_image'),
-                                   ('bold_mask', 'reference_image'),
+                                   ('run_mask', 'reference_image'),
                                    ('template2anat_xfm', 'transforms')]),
-        (inputnode, union_mask, [('bold_mask', 'mask1')]),
+        (inputnode, union_mask, [('run_mask', 'mask1')]),
         (anat_mask_tfm, union_mask, [('output_image', 'mask2')]),
         (union_mask, dilated_mask, [('out', 'in_mask')]),
         (union_mask, subtract_mask, [('out', 'in_subtract')]),
@@ -547,8 +547,8 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         (inputnode, acc_masks, [('anat_tpms', 'in_vfs'),
                                 (('bold', _get_zooms), 'bold_zooms')]),
         (inputnode, acc_msk_tfm, [('template2anat_xfm', 'transforms'),
-                                  ('bold_mask', 'reference_image')]),
-        (inputnode, acc_msk_brain, [('bold_mask', 'in_mask')]),
+                                  ('run_mask', 'reference_image')]),
+        (inputnode, acc_msk_brain, [('run_mask', 'in_mask')]),
         (acc_masks, acc_msk_tfm, [('out_masks', 'input_image')]),
         (acc_msk_tfm, acc_msk_brain, [('output_image', 'in_file')]),
         (acc_msk_brain, acc_msk_bin, [('out_file', 'in_file')]),
@@ -564,10 +564,10 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         # tCompCor
         (inputnode, tcompcor, [('bold', 'realigned_file'),
                                ('skip_vols', 'ignore_initial_volumes'),
-                               ('bold_mask', 'mask_files')]),
+                               ('run_mask', 'mask_files')]),
         # Global signals extraction (constrained by anatomy)
         (inputnode, signals, [('bold', 'in_file')]),
-        (inputnode, merge_rois, [('bold_mask', 'in1')]),
+        (inputnode, merge_rois, [('run_mask', 'in1')]),
         (acc_msk_bin, merge_rois, [('out_file', 'in2')]),
         (tcompcor, merge_rois, [('high_variance_masks', 'in3')]),
         (merge_rois, signals, [('out', 'label_files')]),
@@ -607,7 +607,7 @@ the edge of the brain, as proposed by [@patriat_improved_2017].
         (tcompcor, outputnode, [('high_variance_masks', 'tcompcor_mask')]),
         (acc_msk_bin, outputnode, [('out_file', 'acompcor_masks')]),
         (inputnode, rois_plot, [('bold', 'in_file'),
-                                ('bold_mask', 'in_mask')]),
+                                ('run_mask', 'in_mask')]),
         (tcompcor, mrg_compcor, [('high_variance_masks', 'in1')]),
         (acc_msk_bin, mrg_compcor, [(('out_file', _last), 'in2')]),
         (subtract_mask, mrg_compcor, [('out_mask', 'in3')]),

--- a/nibabies/workflows/bold/coreg.py
+++ b/nibabies/workflows/bold/coreg.py
@@ -19,7 +19,6 @@ logger = logging.getLogger('nipype.workflow')
 
 INPUT_FIELDS = [
     'run_boldrefs',
-    'run_masks',
     'anat_preproc',
     'anat_mask',
     'anat_dseg',
@@ -31,8 +30,7 @@ INPUT_FIELDS = [
 # reference) consumed by the boldref-template resampling workflow. It is unset
 # at run level.
 OUTPUT_FIELDS = [
-    'coreg_boldrefs',
-    'bold_masks',
+    'template_boldrefs',
     'run2template_xfms',
     'template2anat_xfms',
     'run2anat_xfms',
@@ -81,10 +79,10 @@ def init_bold_anat_coreg_wf(
 
     Either way, per-run lists are returned so downstream workflows can be wired uniformly.
 
-    Writes coregistration derivatives (template boldref, template mask,
-    ``run2template_xfms`` and ``template2anat_xfm``). When a derivative is supplied
-    via ``precomputed``, the corresponding computation and datasink are skipped and
-    the precomputed path is reused.
+    Writes coregistration derivatives (template boldref, ``run2template_xfms``
+    and ``template2anat_xfm``). When a derivative is supplied via ``precomputed``,
+    the corresponding computation and datasink are skipped and the precomputed
+    path is reused.
 
     Parameters
     ----------
@@ -103,15 +101,12 @@ def init_bold_anat_coreg_wf(
         ``boldref_template``
             Session-level: the precomputed template reference. When supplied
             alongside a complete set of ``run2template_xfms``, it is reused directly
-            instead of reconstructing the reference from run 0. The template brain
-            mask is always derived from the run references.
+            instead of reconstructing the reference from run 0.
 
     Inputs
     ------
     run_boldrefs
         List of per-run SDC-corrected BOLD references.
-    run_masks
-        List of per-run brain masks.
     anat_preproc
         Bias-corrected anatomical image.
     anat_mask
@@ -127,11 +122,9 @@ def init_bold_anat_coreg_wf(
 
     Outputs
     -------
-    coreg_boldrefs
+    template_boldrefs
         Per-run boldref in coregistration target space: session template repeated
         n times (session-level) or each run's own boldref (run-level).
-    bold_masks
-        Per-run masks in coregistration target space.
     run2template_xfms
         Per-run transform from run space to the coregistration template.
         Identity transforms for run-level coregistration.
@@ -144,12 +137,8 @@ def init_bold_anat_coreg_wf(
     fallbacks
         Per-run fallback flags from registration.
     """
-    workflow = Workflow(name=name)
-    inputnode = pe.Node(niu.IdentityInterface(fields=INPUT_FIELDS), name='inputnode')
-    outputnode = pe.Node(niu.IdentityInterface(fields=OUTPUT_FIELDS), name='outputnode')
-
     init_coreg_wf = init_bold_run_coreg_wf if coreg_space == 'run' else init_bold_template_coreg_wf
-    coreg_wf = init_coreg_wf(
+    return init_coreg_wf(
         bold_files=bold_files,
         coreg_space=coreg_space,
         bold2anat_dof=bold2anat_dof,
@@ -162,14 +151,8 @@ def init_bold_anat_coreg_wf(
         output_dir=output_dir,
         reference_anat=reference_anat,
         precomputed=precomputed,
+        name=name,
     )
-
-    workflow.connect([
-        (inputnode, coreg_wf, [(field, f'inputnode.{field}') for field in INPUT_FIELDS]),
-        (coreg_wf, outputnode, [(f'outputnode.{field}', field) for field in OUTPUT_FIELDS]),
-    ])  # fmt:skip
-
-    return workflow
 
 
 def init_bold_run_coreg_wf(
@@ -265,8 +248,7 @@ def init_bold_run_coreg_wf(
 
     workflow.connect([
         (inputnode, outputnode, [
-            ('run_boldrefs', 'coreg_boldrefs'),
-            ('run_masks', 'bold_masks'),
+            ('run_boldrefs', 'template_boldrefs'),
         ]),
         (merge_template2anat, outputnode, [
             ('out', 'template2anat_xfms'),
@@ -299,7 +281,7 @@ def init_bold_template_coreg_wf(
     Shares the input/output signature of :func:`init_bold_anat_coreg_wf`. All run
     references are combined into a ``coreg_space`` (``session``) template, that
     template is registered to the anatomical, and per-run ``run->template->anat``
-    transforms are composed. The template boldref, mask and ``template->anat``
+    transforms are composed. The template boldref and ``template->anat``
     transform are each written once, dropping the run-varying entities (see
     :data:`~nibabies.utils.bids.GROUP_DISMISS_ENTITIES`).
     """
@@ -349,7 +331,7 @@ def init_bold_template_coreg_wf(
         )
 
     template_buffer = pe.Node(
-        niu.IdentityInterface(fields=['boldref', 'mask', 'run2template_xfms']),
+        niu.IdentityInterface(fields=['boldref', 'run2template_xfms']),
         name='template_buffer',
     )
     boldref_template = precomputed.get('boldref_template')
@@ -357,22 +339,6 @@ def init_bold_template_coreg_wf(
         from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
         template_buffer.inputs.run2template_xfms = list(run2template_xfms)
-
-        select_mask0 = pe.Node(
-            niu.Select(index=0), name='select_mask0', run_without_submitting=True
-        )
-        warp_template_mask = pe.Node(
-            ApplyTransforms(transforms=[run2template_xfms[0]], interpolation='MultiLabel'),
-            name='warp_template_mask',
-        )
-        workflow.connect([
-            (inputnode, select_mask0, [('run_masks', 'inlist')]),
-            (select_mask0, warp_template_mask, [
-                ('out', 'input_image'),
-                ('out', 'reference_image'),
-            ]),
-            (warp_template_mask, template_buffer, [('output_image', 'mask')]),
-        ])  # fmt:skip
 
         if boldref_template:
             logger.info('Reusing precomputed boldref template; skipping reconstruction.')
@@ -412,13 +378,12 @@ def init_bold_template_coreg_wf(
             (inputnode, bold_template_wf, [('run_boldrefs', 'inputnode.boldref_files')]),
             (bold_template_wf, template_buffer, [
                 ('outputnode.boldref', 'boldref'),
-                ('outputnode.bold_mask', 'mask'),
                 ('outputnode.run2template_xfms', 'run2template_xfms'),
             ]),
         ])  # fmt:skip
 
-        # Datasink the session template boldref + mask (written once, with
-        # run-varying entities dropped so a single file represents all runs)
+        # Datasink the session template boldref (written once, with run-varying
+        # entities dropped so a single file represents all runs)
         ds_boldref_template = pe.Node(
             DerivativesDataSink(
                 base_directory=output_dir,
@@ -429,19 +394,6 @@ def init_bold_template_coreg_wf(
                 dismiss_entities=_dismiss,
             ),
             name='ds_boldref_template',
-            run_without_submitting=True,
-        )
-        ds_boldref_mask = pe.Node(
-            DerivativesDataSink(
-                base_directory=output_dir,
-                source_file=bold_files[0],
-                space=coreg_space,
-                desc='brain',
-                suffix='mask',
-                compress=True,
-                dismiss_entities=_dismiss,
-            ),
-            name='ds_boldref_mask',
             run_without_submitting=True,
         )
         template_sources = pe.Node(
@@ -456,9 +408,7 @@ def init_bold_template_coreg_wf(
         workflow.connect([
             (inputnode, template_sources, [('run_boldrefs', 'in1')]),
             (template_buffer, ds_boldref_template, [('boldref', 'in_file')]),
-            (template_buffer, ds_boldref_mask, [('mask', 'in_file')]),
             (template_sources, ds_boldref_template, [('out', 'Sources')]),
-            (template_sources, ds_boldref_mask, [('out', 'Sources')]),
         ])  # fmt:skip
 
     reg_buffer = pe.Node(
@@ -555,21 +505,18 @@ def init_bold_template_coreg_wf(
             (concat, merge_run2anat_xfms, [('out_xfm', f'in{i + 1}')]),
         ])  # fmt:skip
 
-    # Broadcast the session template image/mask/fallback into per-run lists
+    # Broadcast the session template image/fallback into per-run lists
     expand_boldref = pe.Node(niu.Function(function=_expand), name='expand_boldref')
-    expand_mask = pe.Node(niu.Function(function=_expand), name='expand_mask')
     expand_fallback = pe.Node(niu.Function(function=_expand), name='expand_fallback')
-    for node in (expand_boldref, expand_mask, expand_fallback):
+    for node in (expand_boldref, expand_fallback):
         node.inputs.n = n_runs
         node.run_without_submitting = True
 
     workflow.connect([
         (template_buffer, expand_boldref, [('boldref', 'value')]),
-        (template_buffer, expand_mask, [('mask', 'value')]),
         (reg_buffer, expand_fallback, [('fallback', 'value')]),
         (template_buffer, outputnode, [('boldref', 'boldref_template')]),
-        (expand_boldref, outputnode, [('out', 'coreg_boldrefs')]),
-        (expand_mask, outputnode, [('out', 'bold_masks')]),
+        (expand_boldref, outputnode, [('out', 'template_boldrefs')]),
         (expand_fallback, outputnode, [('out', 'fallbacks')]),
         (merge_run2template, outputnode, [('out', 'run2template_xfms')]),
         (merge_template2anat, outputnode, [('out', 'template2anat_xfms')]),

--- a/nibabies/workflows/bold/fit.py
+++ b/nibabies/workflows/bold/fit.py
@@ -146,12 +146,12 @@ def init_bold_fit_wf(
     hmc_boldref
         BOLD reference image used for head motion correction.
         Minimally processed to ensure consistent contrast with BOLD series.
-    coreg_boldref
+    run_boldref
         BOLD reference image used for coregistration. Contrast-enhanced
         and fieldmap-corrected for greater anatomical fidelity, and aligned
         with ``hmc_boldref``.
-    bold_mask
-        Mask of ``coreg_boldref``.
+    run_mask
+        Mask of ``run_boldref``.
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
         as concatenated ITK affine transforms.
@@ -214,7 +214,7 @@ def init_bold_fit_wf(
     multiecho = len(bold_series) > 1
 
     hmc_boldref = precomputed.get('hmc_boldref')
-    coreg_boldref = precomputed.get('coreg_boldref')
+    run_boldref = precomputed.get('run_boldref')
     # Can contain
     #  1) run2fmap
     #  2) template2anat
@@ -244,8 +244,8 @@ def init_bold_fit_wf(
             fields=[
                 'dummy_scans',
                 'hmc_boldref',
-                'coreg_boldref',
-                'bold_mask',
+                'run_boldref',
+                'run_mask',
                 'motion_xfm',
                 'run2fmap_xfm',
                 # summary (can be undefined)
@@ -282,9 +282,9 @@ def init_bold_fit_wf(
     if run2fmap_xform:
         fmapreg_buffer.inputs.run2fmap_xfm = run2fmap_xform
         config.loggers.workflow.debug(f'Reusing BOLD-to-fieldmap transform: {run2fmap_xform}')
-    if coreg_boldref:
-        regref_buffer.inputs.boldref = coreg_boldref
-        config.loggers.workflow.debug(f'Reusing coregistration reference: {coreg_boldref}')
+    if run_boldref:
+        regref_buffer.inputs.boldref = run_boldref
+        config.loggers.workflow.debug(f'Reusing coregistration reference: {run_boldref}')
     fmapref_buffer.inputs.sbref_files = sbref_files
 
     workflow.connect([
@@ -294,8 +294,8 @@ def init_bold_fit_wf(
         ]),
         (hmcref_buffer, fmapref_buffer, [('boldref', 'boldref_files')]),
         (regref_buffer, outputnode, [
-            ('boldref', 'coreg_boldref'),
-            ('boldmask', 'bold_mask'),
+            ('boldref', 'run_boldref'),
+            ('boldmask', 'run_mask'),
         ]),
         (fmapreg_buffer, outputnode, [('run2fmap_xfm', 'run2fmap_xfm')]),
         (hmc_buffer, outputnode, [('hmc_xforms', 'motion_xfm')]),
@@ -440,7 +440,7 @@ def init_bold_fit_wf(
         config.loggers.workflow.info('No fieldmap correction - skipping Stage 3')
 
     # Stage 4: Create coregistration reference
-    if not coreg_boldref:
+    if not run_boldref:
         config.loggers.workflow.info('Stage 4: Adding coregistration boldref workflow')
 
         # If sbref files are available, add them to the list of sources
@@ -547,7 +547,7 @@ def init_bold_fit_wf(
         # TODO: Allow precomputed bold masks to be passed
         # Also needs consideration for how it interacts above
         skullstrip_precomp_ref_wf = init_skullstrip_bold_wf(name='skullstrip_precomp_ref_wf')
-        skullstrip_precomp_ref_wf.inputs.inputnode.in_file = coreg_boldref
+        skullstrip_precomp_ref_wf.inputs.inputnode.in_file = run_boldref
         workflow.connect([
             (skullstrip_precomp_ref_wf, regref_buffer, [('outputnode.mask_file', 'boldmask')])
         ])  # fmt:skip
@@ -595,7 +595,7 @@ def init_bold_native_wf(
     ------
     run_boldref
         Per-run BOLD reference file (sbref or average volume from the run).
-    bold_mask
+    run_mask
         Mask of BOLD reference file
     motion_xfm
         Affine transforms from each BOLD volume to ``hmc_boldref``, written
@@ -676,7 +676,7 @@ def init_bold_native_wf(
             fields=[
                 # BOLD fit
                 'run_boldref',
-                'bold_mask',
+                'run_mask',
                 'motion_xfm',
                 'run2fmap_xfm',
                 'dummy_scans',
@@ -806,7 +806,7 @@ def init_bold_native_wf(
         # Do NOT set motion_xfm on outputnode
         # This prevents downstream resamplers from double-dipping
         workflow.connect([
-            (inputnode, bold_t2s_wf, [('bold_mask', 'inputnode.bold_mask')]),
+            (inputnode, bold_t2s_wf, [('run_mask', 'inputnode.bold_mask')]),
             (boldref_bold, join_echos, [('out_file', 'bold_files')]),
             (join_echos, bold_t2s_wf, [('bold_files', 'inputnode.bold_file')]),
             (join_echos, outputnode, [('bold_files', 'bold_echos')]),

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -861,7 +861,7 @@ def init_ds_volumes_wf(
         ),
         name='sources',
     )
-    boldref2target = pe.Node(niu.Merge(2), name='boldref2target')
+    run2target = pe.Node(niu.Merge(3), name='run2target')
 
     # BOLD is pre-resampled
     ds_bold = pe.Node(
@@ -887,11 +887,11 @@ def init_ds_volumes_wf(
             ('anat2std_xfm', 'in6'),
             ('template', 'in7'),
         ]),
-        (inputnode, boldref2target, [
+        (inputnode, run2target, [
             # Note that ANTs expects transforms in target-to-source order
-            # Reverse this for nitransforms-based resamplers
             ('anat2std_xfm', 'in1'),
             ('template2anat_xfm', 'in2'),
+            ('run2template_xfm', 'in3'),
         ]),
         (inputnode, ds_bold, [
             ('source_files', 'source_file'),
@@ -981,7 +981,7 @@ def init_ds_volumes_wf(
             (inputnode, resampler, [('ref_file', 'reference_image')])
             for resampler in resamplers
         ] + [
-            (boldref2target, resampler, [('out', 'transforms')])
+            (run2target, resampler, [('out', 'transforms')])
             for resampler in resamplers
         ] + [
             (inputnode, datasink, [

--- a/nibabies/workflows/bold/outputs.py
+++ b/nibabies/workflows/bold/outputs.py
@@ -139,8 +139,8 @@ def prepare_timing_parameters(metadata: dict):
     return timing_parameters
 
 
-def _first_transform_inverse(transforms):
-    return [True] + [False] * (len(transforms) - 1)
+def _invert_all_transforms(transforms):
+    return [True] * len(transforms)
 
 
 def init_func_fit_reports_wf(
@@ -179,10 +179,10 @@ def init_func_fit_reports_wf(
         Segmentation in anatomical reference space
     anat_mask
         Brain (binary) mask estimated by brain extraction.
-    coreg_boldref
-        BOLD reference image.
-    bold_mask
-        Reference BOLD brain mask.
+    run_boldref
+        BOLD reference image, in ``run`` space.
+    run_mask
+        Reference BOLD brain mask, in ``run`` space.
     sdc_boldref
         SDC-corrected BOLD reference image.
     template2anat_xfm
@@ -207,8 +207,8 @@ def init_func_fit_reports_wf(
     inputfields = [
         'source_file',
         'sdc_boldref',
-        'coreg_boldref',
-        'bold_mask',
+        'run_boldref',
+        'run_mask',
         'template2anat_xfm',
         'run2fmap_xfm',
         'run2template_xfm',
@@ -248,6 +248,15 @@ def init_func_fit_reports_wf(
         name='ds_report_validation',
         run_without_submitting=True,
         mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
+    anat2run_xfms = pe.Node(
+        niu.Merge(2), name='anat2run_xfms', run_without_submitting=True, mem_gb=1
+    )
+    anat2run_invert = pe.Node(
+        niu.Function(function=_invert_all_transforms),
+        name='anat2run_invert',
+        run_without_submitting=True,
     )
 
     # Resample anatomical references into BOLD space for plotting
@@ -293,15 +302,22 @@ def init_func_fit_reports_wf(
         ]),
         (inputnode, anat_boldref, [
             ('anat_preproc', 'input_image'),
-            ('coreg_boldref', 'reference_image'),
-            ('template2anat_xfm', 'transforms'),
+            ('run_boldref', 'reference_image'),
         ]),
         (inputnode, anat_wm, [('anat_dseg', 'in_seg')]),
         (inputnode, boldref_wm, [
-            ('coreg_boldref', 'reference_image'),
-            ('template2anat_xfm', 'transforms'),
+            ('run_boldref', 'reference_image'),
         ]),
         (anat_wm, boldref_wm, [('out', 'input_image')]),
+        (inputnode, anat2run_xfms, [
+            ('template2anat_xfm', 'in1'),
+            ('run2template_xfm', 'in2'),
+        ]),
+        (anat2run_xfms, anat2run_invert, [('out', 'transforms')]),
+        (anat2run_xfms, anat_boldref, [('out', 'transforms')]),
+        (anat2run_xfms, boldref_wm, [('out', 'transforms')]),
+        (anat2run_invert, anat_boldref, [('out', 'invert_transform_flags')]),
+        (anat2run_invert, boldref_wm, [('out', 'invert_transform_flags')]),
     ])  # fmt:skip
 
     # Reportlets follow the structure of init_bold_fit_wf stages
@@ -317,27 +333,16 @@ def init_func_fit_reports_wf(
     #       After: Resampled boldref with white matter mask
 
     if sdc_correction:
-        to_fmap_xfm = pe.Node(
-            niu.Merge(2),
-            name='to_fmap_xfm',
-            run_without_submitting=True,
-            mem_gb=config.DEFAULT_MEMORY_MIN_GB,
-        )
-
         fmapref_boldref = pe.Node(
             ApplyTransforms(
                 dimension=3,
                 default_value=0,
                 float=True,
                 interpolation='LanczosWindowedSinc',
+                invert_transform_flags=[True],
             ),
             name='fmapref_boldref',
             mem_gb=1,
-        )
-        fmap_inverts = pe.Node(
-            niu.Function(function=_first_transform_inverse),
-            name='fmap_inverts',
-            run_without_submitting=True,
         )
 
         # SDC1
@@ -387,26 +392,20 @@ def init_func_fit_reports_wf(
         workflow.connect([
             (inputnode, fmapref_boldref, [
                 ('fmap_ref', 'input_image'),
-                ('coreg_boldref', 'reference_image'),
+                ('run_boldref', 'reference_image'),
+                ('run2fmap_xfm', 'transforms'),
             ]),
-            (inputnode, to_fmap_xfm, [
-                ('run2fmap_xfm', 'in1'),
-                ('run2template_xfm', 'in2'),
-            ]),
-            (to_fmap_xfm, fmap_inverts, [('out', 'transforms')]),
-            (to_fmap_xfm, fmapref_boldref, [('out', 'transforms')]),
-            (fmap_inverts, fmapref_boldref, [('out', 'invert_transform_flags')]),
             (inputnode, sdcreg_report, [
                 ('sdc_boldref', 'reference'),
                 ('fieldmap', 'fieldmap'),
-                ('bold_mask', 'mask'),
+                ('run_mask', 'mask'),
             ]),
             (fmapref_boldref, sdcreg_report, [('output_image', 'moving')]),
             (inputnode, ds_sdcreg_report, [('source_file', 'source_file')]),
             (sdcreg_report, ds_sdcreg_report, [('out_report', 'in_file')]),
             (inputnode, sdc_report, [
                 ('sdc_boldref', 'before'),
-                ('coreg_boldref', 'after'),
+                ('run_boldref', 'after'),
             ]),
             (boldref_wm, sdc_report, [('output_image', 'wm_seg')]),
             (inputnode, ds_sdc_report, [('source_file', 'source_file')]),
@@ -438,7 +437,7 @@ def init_func_fit_reports_wf(
     )
 
     workflow.connect([
-        (inputnode, epi_anat_report, [('coreg_boldref', 'after')]),
+        (inputnode, epi_anat_report, [('run_boldref', 'after')]),
         (anat_boldref, epi_anat_report, [('output_image', 'before')]),
         (boldref_wm, epi_anat_report, [('output_image', 'wm_seg')]),
         (inputnode, ds_epi_anat_report, [('source_file', 'source_file')]),
@@ -833,8 +832,8 @@ def init_ds_volumes_wf(
                 'source_files',
                 'ref_file',
                 'bold',  # Resampled into target space
-                'bold_mask',  # boldref space
-                'bold_ref',  # boldref space
+                'run_mask',  # boldref space
+                'run_boldref',  # boldref space
                 't2star',  # boldref space
                 'template',  # target reference image from original transform
                 # Anatomical
@@ -916,8 +915,8 @@ def init_ds_volumes_wf(
     resamplers = [resample_ref, resample_mask]
 
     workflow.connect([
-        (inputnode, resample_ref, [('bold_ref', 'input_image')]),
-        (inputnode, resample_mask, [('bold_mask', 'input_image')]),
+        (inputnode, resample_ref, [('run_boldref', 'input_image')]),
+        (inputnode, resample_mask, [('run_mask', 'input_image')]),
     ])  # fmt:skip
 
     ds_ref = pe.Node(


### PR DESCRIPTION
- consistent naming of internal fields
- drops template mask output
- adds missed run2template_xfm when sampling to target