### PR TITLE
fix: always populate workflow postdesc

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -61,8 +61,8 @@ _apt_mirror_fallback: &apt_mirror_fallback
   name: Configure apt mirror fallback
   command: |
     printf '%s\n' \
-      'http://us-east-1.ec2.archive.ubuntu.com/ubuntu/	priority:1' \
-      'http://archive.ubuntu.com/ubuntu/	priority:2' \
+      'http://archive.ubuntu.com/ubuntu/	priority:1' \
+      'http://us-east-1.ec2.archive.ubuntu.com/ubuntu/	priority:2' \
       | sudo tee /etc/apt/mirrors.txt
     sudo sed -i -E 's#https?://[a-z0-9.-]*ec2\.archive\.ubuntu\.com/ubuntu/?#mirror+file:/etc/apt/mirrors.txt#g' /etc/apt/sources.list
 

--- a/nibabies/workflows/bold/base.py
+++ b/nibabies/workflows/bold/base.py
@@ -175,6 +175,14 @@ def init_bold_apply_wf(
     _, mem_gb = estimate_bold_mem_usage(bold_file)
 
     workflow = Workflow(name=name)
+    workflow.__postdesc__ = """\
+All resamplings can be performed with *a single interpolation
+step* by composing all the pertinent transformations (i.e. head-motion
+transform matrices, susceptibility distortion correction when available,
+and co-registrations to anatomical and output spaces).
+Gridded (volumetric) resamplings were performed using `nitransforms`,
+configured with cubic B-spline interpolation.
+"""
 
     inputnode = pe.Node(
         niu.IdentityInterface(

--- a/nibabies/workflows/tests/test_base.py
+++ b/nibabies/workflows/tests/test_base.py
@@ -228,6 +228,7 @@ def _patch_output_spaces(output_spaces: str | None):
         # _make_params(surface_recon_method='mcribs'),  # Requires precomputed segmentation
         _make_params(surface_recon_method='infantfs'),
         _make_params(surface_recon_method='freesurfer'),
+        _make_params(surface_recon_method='freesurfer', output_spaces='fsaverage'),
         # Currently unsupported:
         # _make_params(freesurfer=False, bold2anat_init="header"),
         # _make_params(freesurfer=False, bold2anat_init="header", use_bbr=True),


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/app/.pixi/envs/nibabies/bin/nibabies", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/app/.pixi/envs/nibabies/lib/python3.12/site-packages/nibabies/cli/run.py", line 62, in main
    retval = build_workflow(config_file)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.pixi/envs/nibabies/lib/python3.12/site-packages/nibabies/cli/workflow.py", line 76, in build_workflow
    retval['workflow'] = init_nibabies_wf(config.execution.unique_labels)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.pixi/envs/nibabies/lib/python3.12/site-packages/nibabies/workflows/base.py", line 177, in init_nibabies_wf
    single_subject_wf = init_single_subject_wf(
                        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.pixi/envs/nibabies/lib/python3.12/site-packages/nibabies/workflows/base.py", line 1007, in init_single_subject_wf
    bold_apply_wf = init_bold_apply_wf(
                    ^^^^^^^^^^^^^^^^^^^
  File "/app/.pixi/envs/nibabies/lib/python3.12/site-packages/nibabies/workflows/bold/base.py", line 489, in init_bold_apply_wf
    workflow.__postdesc__ += """\
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

would occur if running with a `surface_recon_method` and any FS output space.